### PR TITLE
Setup eslint to run prettier as part of lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,11 +21,11 @@ module.exports = {
         node: true,
         es2021: true,
     },
-    plugins: ["@typescript-eslint", "promise", "react-hooks"],
+    plugins: ["@typescript-eslint", "promise", "react-hooks", "prettier"],
     extends: [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
-        "prettier",
+        "plugin:prettier/recommended",
     ],
     parser: "@typescript-eslint/parser",
     parserOptions: {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "eslint.runtime": "nodedist\\node.exe",
     "editor.codeActionsOnSave": {
         "source.organizeImports": false
     },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "eslint": "^8.24.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-formatter-pretty": "^4.1.0",
+        "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.0.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "json-keys-sort": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,6 +291,7 @@ __metadata:
     eslint: ^8.24.0
     eslint-config-prettier: ^8.5.0
     eslint-formatter-pretty: ^4.1.0
+    eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.0.1
     eslint-plugin-react-hooks: ^4.6.0
     express: 4.18.1
@@ -1677,6 +1678,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prettier@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-plugin-prettier@npm:4.2.1"
+  dependencies:
+    prettier-linter-helpers: ^1.0.0
+  peerDependencies:
+    eslint: ">=7.28.0"
+    prettier: ">=2.0.0"
+  peerDependenciesMeta:
+    eslint-config-prettier:
+      optional: true
+  checksum: b9e839d2334ad8ec7a5589c5cb0f219bded260839a857d7a486997f9870e95106aa59b8756ff3f37202085ebab658de382b0267cae44c3a7f0eb0bcc03a4f6d6
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-promise@npm:^6.0.1":
   version: 6.0.1
   resolution: "eslint-plugin-promise@npm:6.0.1"
@@ -1941,6 +1957,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:^1.1.2":
+  version: 1.2.0
+  resolution: "fast-diff@npm:1.2.0"
+  checksum: 1b5306eaa9e826564d9e5ffcd6ebd881eb5f770b3f977fcbf38f05c824e42172b53c79920e8429c54eb742ce15a0caf268b0fdd5b38f6de52234c4a8368131ae
   languageName: node
   linkType: hard
 
@@ -3402,6 +3425,15 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: cd192ec0d0a8e4c6da3bb80e4f62afe336df3f76271ac6deb0e6a36187133b6073a19e9727a1ff108cd8b9982e4768850d413baa71214dd80c7979617dca827a
+  languageName: node
+  linkType: hard
+
+"prettier-linter-helpers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "prettier-linter-helpers@npm:1.0.0"
+  dependencies:
+    fast-diff: ^1.1.2
+  checksum: 00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This should make so code formatting is respected without manual intervention.