### PR TITLE
Fixed issue where folders for cached images weren't properly created

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -514,6 +514,7 @@ function startServer(options: { hmr: boolean; pluginDevHost: boolean }): void {
         join("userdata", "scpc", "steamids"),
         join("images", "actors"),
         join("images", "contracts"),
+        join("images", "contracts", "elusive"),
         join("images", "contracts", "escalation"),
         join("images", "contracts", "featured"),
         join("images", "unlockables_override"),

--- a/components/menus/imageHandler.ts
+++ b/components/menus/imageHandler.ts
@@ -70,6 +70,14 @@ export async function imageFetchingMiddleware(
         if (getFlag("imageLoading") === "SAVEASREQUESTED") {
             log(LogLevel.DEBUG, `Saving image ${path} to disk.`)
 
+            const dir = ppath.dirname(path as Filename)
+
+            if (!imageJailFs.existsSync(dir)) {
+                log(LogLevel.DEBUG, `Creating missing directory ${dir}`)
+
+                imageJailFs.mkdirSync(dir, { recursive: true })
+            }
+
             const writeStream = imageJailFs.createWriteStream(
                 ppath.resolve(path as Filename),
             )


### PR DESCRIPTION
I noticed that saving images of Elusive Targets were always failing. This fixes that issue.

Elusive Targets have images in subfolders, whereas the general logic expects a flat file structure.