### PR TITLE
Fixed flags from being loaded rather late in the startup phase

### DIFF
--- a/components/flags.ts
+++ b/components/flags.ts
@@ -37,6 +37,10 @@ const defaultFlags: Flags = {
         desc: "Use official servers for contract downloading",
         default: true,
     },
+    liveSplit: {
+        desc: "Toggle LiveSplit support on or off",
+        default: false,
+    },
     autoSplitterCampaign: {
         desc: "Which (main) campaign to use for the AutoSplitter. Can be set to 1, 2, 3, or 'trilogy'.",
         default: "trilogy",

--- a/components/index.ts
+++ b/components/index.ts
@@ -19,6 +19,10 @@
 /* eslint-disable no-inner-declarations */
 // noinspection RequiredAttributes
 
+// load flags as soon as possible
+import { getFlag, loadFlags } from "./flags"
+loadFlags()
+
 import { setFlagsFromString } from "v8"
 import { program } from "commander"
 import express, { Request, Router } from "express"
@@ -60,7 +64,6 @@ import {
 import { legacyProfileRouter } from "./2016/legacyProfileRouter"
 import { legacyMenuDataRouter } from "./2016/legacyMenuData"
 import { legacyContractRouter } from "./2016/legacyContractHandler"
-import { getFlag, loadFlags } from "./flags"
 import { initRp } from "./discordRp"
 import random from "random"
 import { generateUserCentric } from "./contracts/dataGen"
@@ -114,8 +117,6 @@ function uncaught(error: Error): void {
 }
 
 process.on("uncaughtException", uncaught)
-
-loadFlags()
 
 const app = express()
 

--- a/components/livesplit/liveSplitManager.ts
+++ b/components/livesplit/liveSplitManager.ts
@@ -38,6 +38,14 @@ export class LiveSplitManager {
     private _raceMode: boolean | undefined // gets late-initialized, use _isRaceMode to access
 
     constructor() {
+        // don't finish initializing if livesplit is disabled
+        if (!getFlag("liveSplit")) {
+            this._initialized = false
+            this._initializationAttempted = true
+
+            return
+        }
+
         this._initialized = false
         this._initializationAttempted = false
         this._resetMinimum = 1


### PR DESCRIPTION
Because imports can also use flags, and there are a lot of imports before the server even starts, it makes sense to load those as soon as possible to prevent undefined errors.

In this PR, that is fixed as well as adding a toggle for LiveSplit (which is secretly instanced and tried during the startup phase), so it won't try to make the connection at all (and thus error out if it's not available).