### PR TITLE
Added additional reason to detect IIS as being the issue

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -85,6 +85,7 @@ const port = process.env.PORT || 80
 function uncaught(error: Error): void {
     if (
         (error.message || "").includes("EADDRINUSE") ||
+        (error.message || "").includes("EACCES") ||
         (error.stack || "").includes("EADDRINUSE")
     ) {
         log(LogLevel.ERROR, `Failed to use the server on ${host}:${port}!`)


### PR DESCRIPTION
Gracefully handle an additional situation where IIS is actually the root cause of not being able to boot, since we've already gone out of our way to tell the user nicely anyway.