### PR TITLE
Fixed issue where the newEvent-hook is called twice

### DIFF
--- a/components/eventHandler.ts
+++ b/components/eventHandler.ts
@@ -545,9 +545,6 @@ function saveEvents(
             return
         }
 
-        // @ts-expect-error Tapable types not sufficient
-        controller.hooks.newEvent.call(event, req)
-
         const contract = controller.resolveContract(session.contractId)
         const contractType = contract?.Metadata?.Type?.toLowerCase()
 


### PR DESCRIPTION
Currently, the newEvent-hook is called twice. This PR fixes that issue by removing the second instance. Reason being the first instance is very early in the process of handling an event, giving plugins a chance to do something with it, before Peacock returns (eg. additional messages that may arrive after the timer ended, but aren't in the curated list of allowed events).