### PR TITLE
Added flags for easily enabling program options

### DIFF
--- a/components/flags.ts
+++ b/components/flags.ts
@@ -85,6 +85,14 @@ const defaultFlags: Flags = {
         desc: "Forcibly disable installed mod checks",
         default: false,
     },
+    experimentalHMR: {
+        desc: "[Experimental] Toggle hot reloading of contracts",
+        default: false,
+    },
+    developmentPluginDevHost: {
+        desc: "[Development - Workspace required] Toggle loading of plugins with a .ts/.cts extension inside the /plugins folder",
+        default: false,
+    },
 }
 
 const OLD_FLAGS_FILE = "flags.json5"

--- a/components/index.ts
+++ b/components/index.ts
@@ -553,10 +553,15 @@ function startServer(options: { hmr: boolean; pluginDevHost: boolean }): void {
     }
 }
 
-program.option("--hmr", "enable experimental hot reloading of contracts")
+program.option(
+    "--hmr",
+    "enable experimental hot reloading of contracts",
+    getFlag("experimentalHMR") as boolean,
+)
 program.option(
     "--plugin-dev-host",
     "activate plugin development features - requires plugin dev workspace setup",
+    getFlag("developmentPluginDevHost") as boolean,
 )
 program.action(startServer)
 


### PR DESCRIPTION
This allows users to enable --hmr and --plugin-dev-host from the options.ini.

For developers, this makes things a lot easier as we can just `run-dev` with no additional trickery.
For normal users, this would mean they don't have to mess around with startup arguments.

Tried to set a "standard" for the flag names:
- "development"-prefix if it's only useful during development (eg. it needs dev dependencies)
- "experimental"-prefix meaning it can be removed, is unstable or will change in the future.