### PR TITLE
Added hot reload functionality for plugins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,8 @@ module.exports = {
         project: [
             // server full
             "./tsconfig.json",
+            // plugins
+            "./plugins/tsconfig.json",
             // web UI
             "./webui/tsconfig.json",
         ],

--- a/components/flags.ts
+++ b/components/flags.ts
@@ -93,6 +93,10 @@ const defaultFlags: Flags = {
         desc: "When set to true, the official servers will be used for contract downloading in H3, which only works for the platform you are playing on. When false, the HITMAPS servers will be used instead. Note that this option only pertains to H3. Official servers will be used for H1 and H2 regardless of the value of this option.",
         default: false,
     },
+    developmentTestMode: {
+        desc: "[Development] Toggle running of test code to verify functionality during runtime",
+        default: false,
+    },
 }
 
 const OLD_FLAGS_FILE = "flags.json5"

--- a/components/hooksImpl.ts
+++ b/components/hooksImpl.ts
@@ -123,6 +123,24 @@ export abstract class BaseImpl<Params, Return = void> {
     }
 
     /**
+     * Remove an interceptor.
+     *
+     * @param name A string containing the interceptor's name.
+     * @returns True if the removal was successful
+     */
+    public removeInterceptor(name: string): boolean {
+        const index = this._intercepts.findIndex((e) => e.name === name)
+
+        if (index < 0) {
+            return false
+        }
+
+        this._intercepts.splice(index, 1)
+
+        return true
+    }
+
+    /**
      * Tap the hook.
      *
      * @param nameOrOptions A string containing the tap's name, or an object containing the tap's details.
@@ -151,6 +169,29 @@ export abstract class BaseImpl<Params, Return = void> {
             func: consumer,
             enableContext,
         })
+    }
+
+    /**
+     * Untap the hook.
+     *
+     * @param nameOrOptions A string containing the tap's name, or an object containing the tap's details.
+     * @returns True if the untap was successful
+     */
+    public untap(nameOrOptions: TapOptions): boolean {
+        const name =
+            typeof nameOrOptions === "string"
+                ? nameOrOptions
+                : nameOrOptions.name
+
+        const index = this._taps.findIndex((e) => e.name === name)
+
+        if (index < 0) {
+            return false
+        }
+
+        this._taps.splice(index, 1)
+
+        return true
     }
 }
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -459,6 +459,12 @@ app.use(
         .use(primaryRouter),
 )
 
+app.get("/reloadplugin/:name", (req: Request, res) => {
+    const result = controller.reloadPlugin(req.params.name)
+
+    res.status(result ? 200 : 400).send()
+})
+
 app.all("*", (req, res) => {
     log(LogLevel.WARN, `Unhandled URL: ${req.url}`)
     res.status(404).send("Not found!")
@@ -520,6 +526,7 @@ function startServer(options: { hmr: boolean; pluginDevHost: boolean }): void {
         "plugins",
         "userdata",
         "contracts",
+        "plugins",
         join("userdata", "epicids"),
         join("userdata", "steamids"),
         join("userdata", "users"),

--- a/plugins/TestHotReload.plugin.ts
+++ b/plugins/TestHotReload.plugin.ts
@@ -1,0 +1,68 @@
+import { log, LogLevel } from "../components/loggingInterop"
+import { Controller, IPlugin } from "../components/controller"
+import { Intercept } from "../components/hooksImpl"
+
+class TestHotReloadPlugin implements IPlugin {
+    private controller: Controller
+
+    public get name() {
+        return "TestHotReloadPlugin"
+    }
+
+    constructor(controller: Controller) {
+        this.controller = controller
+
+        this.init()
+    }
+
+    private init(): void {
+        log(LogLevel.DEBUG, `[${this.name}] Loading...`)
+
+        const interceptor: Intercept<[], void> = {
+            name: `${this.name}_ServerStart_Interceptor`,
+            call: () => {
+                log(LogLevel.DEBUG, `[${this.name}] interceptor called!`)
+            },
+            tap: () => {
+                log(LogLevel.DEBUG, `[${this.name}] interceptor tapped!`)
+            },
+        }
+        this.controller.hooks.serverStart.intercept(interceptor)
+
+        this.controller.hooks.serverStart.tap(
+            `${this.name}_ServerStart_Tap`,
+            () => {
+                log(LogLevel.DEBUG, `[${this.name}] hook called!`)
+            },
+        )
+
+        this.controller.hooks.serverStart.call()
+
+        log(LogLevel.INFO, `[${this.name}] Loaded!`)
+    }
+
+    public unload(): boolean {
+        log(LogLevel.DEBUG, `[${this.name}] Unloading...`)
+
+        let result = this.controller.hooks.serverStart.removeInterceptor(
+            `${this.name}_ServerStart_Interceptor`,
+        )
+        result &&= this.controller.hooks.serverStart.untap(
+            `${this.name}_ServerStart_Tap`,
+        )
+
+        log(LogLevel.INFO, `[${this.name}] Unloaded!`)
+
+        return result
+    }
+}
+
+function initPlugin(controller: Controller): void | IPlugin {
+    if (!controller.runningInTestMode()) {
+        return
+    }
+
+    return new TestHotReloadPlugin(controller)
+}
+
+module.exports = initPlugin

--- a/plugins/TestNormal.plugin.ts
+++ b/plugins/TestNormal.plugin.ts
@@ -1,0 +1,26 @@
+import { log, LogLevel } from "../components/loggingInterop"
+import { Controller, IPlugin } from "../components/controller"
+
+class TestNormalPlugin {
+    private name = "TestNormalPlugin"
+
+    constructor() {
+        this.init()
+    }
+
+    private init(): void {
+        log(LogLevel.DEBUG, `[${this.name}] Loading...`)
+
+        log(LogLevel.INFO, `[${this.name}] Loaded!`)
+    }
+}
+
+function initPlugin(controller: Controller): void | IPlugin {
+    if (!controller.runningInTestMode()) {
+        return
+    }
+
+    new TestNormalPlugin()
+}
+
+module.exports = initPlugin

--- a/plugins/tsconfig.json
+++ b/plugins/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "node"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
         "stripInternal": true
     },
     "include": ["components"],
-    "exclude": ["packaging", "chunk0.js", "webui"]
+    "exclude": ["packaging", "chunk0.js", "webui", "plugins"]
 }


### PR DESCRIPTION
Implementation of my hot reload system for plugins:
- Is backwards compatible with existing plugins
- Contains two test-plugins to show an old situation and a new situation, will only run when test-mode is enabled.

The following changes have been made:
- Exposes an IPlugin interface plugins can implement, this will require a name for the plugin and optional an "unload" method.
- The "unload" method should undo any interceptors or taps that have been applied, it's the plugins responsibility to keep track of that.
- Added "untap" and "removeInterceptor" to hooks to make unloading possible
- Added an API endpoint to reload a plugin based on its name: `/reloadplugin/<pluginname>`
- Added configuration for plugins to lint properly
- Added convenience functions for plugins to check for Development and test-mode

How to test:
- Default committed plugins will just load and do their thing once on startup.
- `/reloadplugin/TestNormalPlugin` will give a 400 response
- `/reloadplugin/TestHotReloadPlugin` will give a 200 response
- Every time you reload the TestHotReloadPlugin, it will always output the following:
```
[Info] GET /reloadplugin/TestHotReloadPlugin
[Debug] [TestHotReloadPlugin] Unloading...
[Info] [TestHotReloadPlugin] Unloaded!
[Info] Plugin 'TestHotReloadPlugin' has been unloaded!
[Info] Plugin 'TestHotReloadPlugin' has been loaded!
[Debug] [TestHotReloadPlugin] Loading...
[Debug] [TestHotReloadPlugin] interceptor tapped!
[Debug] [TestHotReloadPlugin] interceptor called!
[Debug] [TestHotReloadPlugin] hook called!
[Info] [TestHotReloadPlugin] Loaded!
[Debug] Plugin 'TestHotReloadPlugin' potentially supports hot reloading
```
- If you intentionally break the plugin during a hot reload by wiping the "unload" function and immediately returning true, and then reload a few times, the interceptors/taps of previously loaded plugins will also still be called.
- If you change the "return true" into a "return false" and then reload, the unloading will fail and the user is requested to restart the server instead.

Possible extensions/future:
- Create a "scoped" plugin host that can be disposed and undoes all changes it made. However, the current implementation explicitly asks the developer if hot-reloading is supported AND any hacks that were applied outside of the hook system (eg. trampolines on functions) can also be undone.
- Add a route in the web-ui to reload plugins with the press of a button
- Add support for undoing addMission/addEscalation