### PR TITLE
Added hook for the MissionEnd response

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -77,6 +77,8 @@ import { ChallengePackage } from "./types/challenges"
 import { promisify } from "util"
 import { brotliDecompress } from "zlib"
 import assert from "assert"
+import { Response } from "express"
+import { MissionEndRequestQuery } from "./types/gameSchemas"
 
 /**
  * An array of string arrays that contains the IDs of the featured contracts.
@@ -362,6 +364,13 @@ export class Controller {
             ],
             PlayNextGetCampaignsHookReturn | undefined
         >
+        getMissionEnd: SyncBailHook<
+            [
+                /** req */ RequestWithJwt<MissionEndRequestQuery>,
+                /** res */ Response,
+            ],
+            boolean
+        >
     }
     public escalationMappings = escalationMappings
     public configManager: typeof configManagerType = {
@@ -399,6 +408,7 @@ export class Controller {
             contributeCampaigns: new SyncHook(),
             getSearchResults: new AsyncSeriesHook(),
             getNextCampaignMission: new SyncBailHook(),
+            getMissionEnd: new SyncBailHook(),
         }
 
         if (modFrameworkDataPath && existsSync(modFrameworkDataPath)) {

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -560,7 +560,7 @@ menuDataRouter.get(
             })
         }
 
-        await missionEnd(req, res)
+        await innerMissionEnd(req, res)
     },
 )
 
@@ -778,9 +778,22 @@ menuDataRouter.get("/missionendready", async (req, res) => {
     }
 })
 
-menuDataRouter.get("/missionend", missionEnd)
+menuDataRouter.get("/missionend", innerMissionEnd)
 
-menuDataRouter.get("/scoreoverviewandunlocks", missionEnd)
+menuDataRouter.get("/scoreoverviewandunlocks", innerMissionEnd)
+
+async function innerMissionEnd(
+    req: RequestWithJwt<MissionEndRequestQuery>,
+    res: Response,
+): Promise<void> {
+    const result = controller.hooks.getMissionEnd.call(req, res)
+
+    if (result) {
+        return
+    }
+
+    await missionEnd(req, res)
+}
 
 menuDataRouter.get(
     "/Destination",


### PR DESCRIPTION
This allows plugins to override the response for the /MissionEnd-call. Returning false will give other plugins a chance, otherwise fallback to the default implementation.

Use-case is implementation a custom scoring and end-screen in a plugin, which is useful to test things before they might be merged into the core files.