### PR TITLE
Prevent _checkInit debug message when LiveSplit is disabled

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -553,10 +553,8 @@ function startServer(options: { hmr: boolean; pluginDevHost: boolean }): void {
         initRp()
     }
 
-    if (getFlag("liveSplit") === true) {
-        // initialize livesplit
-        liveSplitManager.init()
-    }
+    // initialize livesplit
+    liveSplitManager.init()
 }
 
 program.option(

--- a/components/livesplit/liveSplitManager.ts
+++ b/components/livesplit/liveSplitManager.ts
@@ -230,6 +230,12 @@ export class LiveSplitManager {
      */
 
     async init() {
+        if (!getFlag("liveSplit")) {
+            this._initializationAttempted = true
+
+            return
+        }
+
         try {
             logLiveSplitError(await this._liveSplitClient.connect(), "connect")
             logLiveSplitError(
@@ -247,7 +253,6 @@ export class LiveSplitManager {
         } catch (e) {
             log(LogLevel.DEBUG, "Failed to initialize LiveSplit: ")
             log(LogLevel.DEBUG, e)
-            this._initializationAttempted = true
         }
     }
 


### PR DESCRIPTION
The fixes done to LiveSplit to properly disable it now cause the _checkInit to always log a debug message. This PR fixes that.