### PR TITLE
Fixed issue where loading a save would kick you offline in-game

### DIFF
--- a/components/profileHandler.ts
+++ b/components/profileHandler.ts
@@ -22,6 +22,7 @@ import { castUserProfile, nilUuid, uuidRegex } from "./utils"
 import { json as jsonMiddleware } from "body-parser"
 import { getPlatformEntitlements } from "./platformEntitlements"
 import {
+    contractSessions,
     getActiveSessionIdForUser,
     loadSession,
     newSession,
@@ -674,6 +675,12 @@ profileRouter.post(
 
         try {
             await loadSession(req.body.contractSessionId, req.body.saveToken)
+
+            controller.challengeService.startContract(
+                req.jwt.unique_name,
+                req.body.contractSessionId,
+                contractSessions.get(req.body.contractSessionId)!,
+            )
         } catch (e) {
             if (
                 getActiveSessionIdForUser(req.jwt.unique_name) ===


### PR DESCRIPTION
Loading a save after restarting the game/server would fail because the startContract of the profileService was not called. Usually newSession does this for you, but since we are loading an existing session...