### PR TITLE
Allow restarting Peacock while the game is active

### DIFF
--- a/components/databaseHandler.ts
+++ b/components/databaseHandler.ts
@@ -108,6 +108,33 @@ export function getUserData(
 }
 
 /**
+ * Only attempt to load a user's profile if it hasn't been loaded yet
+ *
+ * @param userId The user's ID.
+ * @param gameVersion The game's version.
+ */
+export async function cheapLoadUserData(
+    userId: string,
+    gameVersion: GameVersion,
+): Promise<void> {
+    if (!userId || !gameVersion) {
+        return
+    }
+
+    const userProfile = asyncGuard.getProfile(`${userId}.${gameVersion}`)
+
+    if (userProfile) {
+        return
+    }
+
+    try {
+        await loadUserData(userId, gameVersion)
+    } catch (e) {
+        log(LogLevel.DEBUG, "Unable to load profile information.")
+    }
+}
+
+/**
  * Loads a user's profile data.
  *
  * @param userId The user's ID.

--- a/components/eventHandler.ts
+++ b/components/eventHandler.ts
@@ -30,7 +30,7 @@ import {
     Seconds,
     ServerToClientEvent,
 } from "./types/types"
-import { extractToken, ServerVer } from "./utils"
+import { extractToken, gameDifficulty, ServerVer } from "./utils"
 import { json as jsonMiddleware } from "body-parser"
 import { log, LogLevel } from "./loggingInterop"
 import { getUserData, writeUserData } from "./databaseHandler"
@@ -461,7 +461,25 @@ function saveEvents(
     const processed: string[] = []
     const userData = getUserData(req.jwt.unique_name, req.gameVersion)
     events.forEach((event) => {
-        const session = contractSessions.get(event.ContractSessionId)
+        let session = contractSessions.get(event.ContractSessionId)
+
+        if (!session) {
+            log(
+                LogLevel.WARN,
+                "Creating a fake session to avoid problems... scoring will not work!",
+            )
+
+            newSession(
+                event.ContractSessionId,
+                event.ContractId,
+                req.jwt.unique_name,
+                gameDifficulty.normal,
+                req.gameVersion,
+                false,
+            )
+
+            session = contractSessions.get(event.ContractSessionId)
+        }
 
         if (
             !session ||

--- a/components/index.ts
+++ b/components/index.ts
@@ -80,6 +80,7 @@ import { multiplayerRouter } from "./multiplayer/multiplayerService"
 import { multiplayerMenuDataRouter } from "./multiplayer/multiplayerMenuData"
 import { pack, unpack } from "msgpackr"
 import { liveSplitManager } from "./livesplit/liveSplitManager"
+import { cheapLoadUserData } from "./databaseHandler"
 
 // welcome to the bleeding edge
 setFlagsFromString("--harmony")
@@ -356,7 +357,18 @@ app.use(
 
             next()
         }),
-)
+).use(async (req: RequestWithJwt, _res, next): Promise<void> => {
+    if (!req.jwt) {
+        next()
+
+        return
+    }
+
+    // make sure the userdata is always loaded if a proper jwt token is available
+    await cheapLoadUserData(req.jwt.unique_name, req.gameVersion)
+
+    next()
+})
 
 function generateBlobConfig(req: RequestWithJwt) {
     return {


### PR DESCRIPTION
Currently if you restart Peacock, you will lose the in-memory UserProfile that got created during the `/oauth/token`-call, causing pretty much everything to topple over and requiring the user to go offline-mode first. On top of that, you will also lose any active contractSession, because they are only ever persisted if you make a save.

This PR fixes the first issue by checking if the unique_name in the JWT token is already loaded into memory on every request. It does this using a cheap check, so it's only a very minor overhead on each request.

The contractSession issue is not really fixed with this PR, but silently averted by creating a newSession on the fly. It's not a pretty solution, but it works.

All in all, this PR allows developers to make changes to Peacock and restart the server without being forced to go to offline-mode, saving valuable development time. For normal end-users, it's not really useful in a local server situation.

That said, while outside the scope of this PR, we should probably consider using a different mechanism to store volatile data, eg. by storing them in a fast NoSQL-like database (Eg. AceBase: https://github.com/appy-one/acebase)