### PR TITLE
Added vitest and configuration to support unit tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,13 @@ module.exports = {
         node: true,
         es2021: true,
     },
-    plugins: ["@typescript-eslint", "promise", "react-hooks", "prettier"],
+    plugins: [
+        "@typescript-eslint",
+        "promise",
+        "react-hooks",
+        "prettier",
+        "custom-rules",
+    ],
     extends: [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
@@ -62,5 +68,6 @@ module.exports = {
         "promise/valid-params": "warn",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
+        "custom-rules/import-components": "error"
     },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,8 @@ module.exports = {
             "./tsconfig.json",
             // web UI
             "./webui/tsconfig.json",
+            // tests
+            "./tests/tsconfig.json",
         ],
     },
     rules: {

--- a/components/candle/challengeHelpers.ts
+++ b/components/candle/challengeHelpers.ts
@@ -25,8 +25,8 @@ import {
     RegistryChallenge,
 } from "../types/types"
 import assert from "assert"
-import { SavedChallengeGroup } from "components/types/challenges"
-import { controller } from "components/controller"
+import { SavedChallengeGroup } from "../types/challenges"
+import { controller } from "../controller"
 
 export function compileScoringChallenge(
     challenge: RegistryChallenge,

--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -16,8 +16,8 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { getSubLocationByName } from "components/contracts/dataGen"
-import { log, LogLevel } from "components/loggingInterop"
+import { getSubLocationByName } from "../contracts/dataGen"
+import { log, LogLevel } from "../loggingInterop"
 import { getConfig, getVersionedConfig } from "../configSwizzleManager"
 import { getUserData } from "../databaseHandler"
 import {

--- a/components/contracts/contractRouting.ts
+++ b/components/contracts/contractRouting.ts
@@ -54,7 +54,7 @@ import {
 import { createSniperLoadouts } from "../menus/sniper"
 import { GetForPlay2Body } from "../types/gameSchemas"
 import assert from "assert"
-import { getUserData } from "components/databaseHandler"
+import { getUserData } from "../databaseHandler"
 import { getCpd } from "../evergreen"
 
 const contractRoutingRouter = Router()

--- a/components/menus/destinations.ts
+++ b/components/menus/destinations.ts
@@ -28,8 +28,8 @@ import type {
 } from "../types/types"
 import { controller } from "../controller"
 import { generateCompletionData } from "../contracts/dataGen"
-import { getUserData } from "components/databaseHandler"
-import { ChallengeFilterType } from "components/candle/challengeHelpers"
+import { getUserData } from "../databaseHandler"
+import { ChallengeFilterType } from "../candle/challengeHelpers"
 
 type GameFacingDestination = {
     ChallengeCompletion: {

--- a/components/multiplayer/multiplayerMenuData.ts
+++ b/components/multiplayer/multiplayerMenuData.ts
@@ -27,7 +27,7 @@ import {
 import { Router } from "express"
 import { getConfig } from "../configSwizzleManager"
 import { MultiplayerPreset } from "./multiplayerService"
-import { generateUserCentric } from "components/contracts/dataGen"
+import { generateUserCentric } from "../contracts/dataGen"
 import { controller } from "../controller"
 import {
     MissionEndRequestQuery,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
         "webui": "yarn workspace @peacockproject/web-ui",
         "typedefs": "yarn workspace @peacockproject/core",
         "run-dev": "node packaging/devLoader.mjs",
-        "extract-challenge-data": "node packaging/extractChallengeData.mjs"
+        "extract-challenge-data": "node packaging/extractChallengeData.mjs",
+        "test": "vitest --run --config tests/vitest.config.ts",
+        "test-ui": "vitest --config tests/vitest.config.ts --ui"
     },
     "prettier": {
         "semi": false,
@@ -71,6 +73,7 @@
         "@types/send": "^0.17.1",
         "@typescript-eslint/eslint-plugin": "^5.55.0",
         "@typescript-eslint/parser": "^5.55.0",
+        "@vitest/ui": "0.29.6",
         "esbuild": "^0.17.12",
         "esbuild-register": "^3.4.2",
         "eslint": "^8.36.0",
@@ -85,7 +88,8 @@
         "prettier": "^2.8.4",
         "rimraf": "^4.4.0",
         "terser": "^5.16.6",
-        "typescript": "4.9.5"
+        "typescript": "4.9.5",
+        "vitest": "0.29.6"
     },
     "engines": {
         "node": "18.x || 19.x",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "eslint": "^8.36.0",
         "eslint-config-prettier": "^8.7.0",
         "eslint-formatter-pretty": "^4.1.0",
+        "eslint-plugin-custom-rules": "link:./packaging/eslint",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react-hooks": "^4.6.0",

--- a/packaging/eslint/import-components.js
+++ b/packaging/eslint/import-components.js
@@ -1,0 +1,17 @@
+// @ts-check
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+    create(context) {
+        return {
+            ImportDeclaration: function (node) {
+                if (node.source.value?.toString().startsWith("components")) {
+                    context.report({
+                        node,
+                        message:
+                            "Module paths can't start with 'components', use '../' instead.",
+                    })
+                }
+            },
+        }
+    },
+}

--- a/packaging/eslint/index.js
+++ b/packaging/eslint/index.js
@@ -1,0 +1,12 @@
+const fs = require("fs")
+const path = require("path")
+
+const ruleFiles = fs
+    .readdirSync(__dirname)
+    .filter((file) => file !== "index.js" && !file.endsWith("test.js"))
+
+const rules = Object.fromEntries(
+    ruleFiles.map((file) => [path.basename(file, ".js"), require("./" + file)]),
+)
+
+module.exports = { rules }

--- a/tests/helpers/testHelpers.ts
+++ b/tests/helpers/testHelpers.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type * as core from "express-serve-static-core"
+import { RequestWithJwt } from "../../components/types/types"
+import { Mock } from "vitest"
+
+export function asMock<T>(value: T): Mock {
+    return value as Mock
+}
+
+export function mockRequestWithJwt(): RequestWithJwt<core.Query, any> {
+    return <RequestWithJwt<core.Query, any>>{}
+}
+
+export function mockResponse(): core.Response {
+    const response = {
+        status: undefined,
+        json: undefined,
+        end: undefined,
+    }
+
+    const mockImplementation = () => {
+        return response
+    }
+
+    response.status = vi.fn().mockImplementation(mockImplementation)
+    response.json = vi.fn()
+    response.end = vi.fn()
+
+    return <core.Response>response
+}
+
+export function getResolvingPromise<T>(value?: T): Promise<T> {
+    return new Promise((resolve) => {
+        resolve(value)
+    })
+}
+
+export function getMockCallArgument<T>(
+    value: any,
+    call: number,
+    argument: number,
+): T {
+    const calls = asMock(value).mock.calls
+
+    expect(calls.length).toBeGreaterThanOrEqual(call)
+    expect(calls[call].length).toBeGreaterThanOrEqual(argument)
+
+    return asMock(value).mock.calls[call][argument] as T
+}

--- a/tests/mocks/configSwizzleManager.ts
+++ b/tests/mocks/configSwizzleManager.ts
@@ -1,0 +1,35 @@
+import * as configSwizzleManager from "../../components/configSwizzleManager"
+import { readFileSync } from "fs"
+
+const originalFilePaths: Record<string, string> = {}
+
+Object.keys(configSwizzleManager.configs).forEach((config: string) => {
+    originalFilePaths[config] = <string>configSwizzleManager.configs[config]
+
+    configSwizzleManager.configs[config] = undefined
+})
+
+export function loadConfig(config: string) {
+    if (!originalFilePaths[config]) {
+        return
+    }
+
+    const contents = readFileSync(originalFilePaths[config], "utf-8")
+
+    configSwizzleManager.configs[config] = JSON.parse(contents)
+}
+
+export function setConfig(config: string, data: unknown) {
+    configSwizzleManager.configs[config] = data
+}
+
+const getConfigOriginal = configSwizzleManager.getConfig
+vi.spyOn(configSwizzleManager, "getConfig").mockImplementation(
+    (config: string, clone: boolean) => {
+        if (!configSwizzleManager.configs[config]) {
+            throw `Config '${config}' has not been loaded!`
+        }
+
+        return getConfigOriginal(config, clone)
+    },
+)

--- a/tests/setup/globalDefines.ts
+++ b/tests/setup/globalDefines.ts
@@ -1,0 +1,7 @@
+Object.assign(globalThis, {
+    PEACOCK_DEV: false,
+    HUMAN_VERSION: "test",
+    REV_IDENT: 1,
+})
+
+export {}

--- a/tests/src/oauthToken.test.ts
+++ b/tests/src/oauthToken.test.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { UserProfile } from "../../components/types/types"
+import { handleOauthToken } from "../../components/oauthToken"
+import { sign, verify } from "jsonwebtoken"
+import * as databaseHandler from "../../components/databaseHandler"
+import * as platformEntitlements from "../../components/platformEntitlements"
+import axios from "axios"
+
+import {
+    getMockCallArgument,
+    getResolvingPromise,
+    mockRequestWithJwt,
+    mockResponse,
+} from "../helpers/testHelpers"
+
+describe("oauthToken", () => {
+    const pId = "00000000-0000-0000-0000-000000000047"
+
+    const getExternalUserData = vi
+        .spyOn(databaseHandler, "getExternalUserData")
+        .mockResolvedValue("")
+    const loadUserData = vi
+        .spyOn(databaseHandler, "loadUserData")
+        .mockResolvedValue(undefined)
+    const getUserData = vi
+        .spyOn(databaseHandler, "getUserData")
+        .mockReturnValue(<UserProfile>{
+            Extensions: {},
+        })
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it("steam auth hitman 3", async () => {
+        vi.spyOn(axios, "post").mockImplementation((url) => {
+            if (url === "https://auth.hitman.io/oauth/token") {
+                return getResolvingPromise({})
+            } else if (
+                url ===
+                "https://hm3-service.hitman.io/authentication/api/userchannel/ProfileService/GetPlatformEntitlements"
+            ) {
+                return getResolvingPromise({
+                    data: ["mock"],
+                })
+            }
+
+            return undefined
+        })
+
+        const request = mockRequestWithJwt()
+        request.body = {
+            grant_type: "external_steam",
+            steam_userid: "000000000047",
+            steam_appid: "1659040",
+            pId: pId,
+        }
+
+        const response = mockResponse()
+
+        await handleOauthToken(request, response)
+
+        expect(getExternalUserData).toHaveBeenCalledWith(
+            "000000000047",
+            "steamids",
+            "h3",
+        )
+        expect(loadUserData).toHaveBeenCalledWith(pId, "h3")
+        expect(getUserData).toHaveBeenCalledWith(pId, "h3")
+
+        const jsonResponse = getMockCallArgument<any>(response.json, 0, 0)
+        const accessToken = verify(jsonResponse.access_token, "secret", {
+            complete: true,
+        })
+
+        expect(jsonResponse.token_type).toBe("bearer")
+        expect((accessToken.payload as any).unique_name).toBe(pId)
+    })
+
+    test("epic auth hitman 3", async () => {
+        vi.spyOn(platformEntitlements, "getEpicEntitlements").mockResolvedValue(
+            ["mock"],
+        )
+
+        const request = mockRequestWithJwt()
+        request.body = {
+            grant_type: "external_epic",
+            epic_userid: "0123456789abcdef0123456789abcdef",
+            access_token:
+                "eg1~" +
+                sign(
+                    {
+                        appid: "fghi4567xQOCheZIin0pazB47qGUvZw4",
+                        app: "Hitman 3",
+                    },
+                    "secret",
+                ),
+            pId: pId,
+        }
+
+        const response = mockResponse()
+
+        await handleOauthToken(request, response)
+
+        expect(getExternalUserData).toHaveBeenCalledWith(
+            "0123456789abcdef0123456789abcdef",
+            "epicids",
+            "h3",
+        )
+        expect(loadUserData).toHaveBeenCalledWith(pId, "h3")
+        expect(getUserData).toHaveBeenCalledWith(pId, "h3")
+
+        const jsonResponse = getMockCallArgument<any>(response.json, 0, 0)
+        const accessToken = verify(jsonResponse.access_token, "secret", {
+            complete: true,
+        })
+
+        expect(jsonResponse.token_type).toBe("bearer")
+        expect((accessToken.payload as any).unique_name).toBe(pId)
+    })
+
+    it("unsupported auth method", async () => {
+        const request = mockRequestWithJwt()
+        request.body = {}
+
+        const respose = mockResponse()
+
+        await handleOauthToken(request, respose)
+
+        expect(respose.status).toHaveBeenCalledWith(406)
+    })
+})

--- a/tests/src/scoreHandler.test.ts
+++ b/tests/src/scoreHandler.test.ts
@@ -1,0 +1,36 @@
+import { loadConfig } from "../mocks/configSwizzleManager"
+
+//NOTE: Required due to import of "./menus/destinations" on scoreHandler below
+loadConfig("MissionStories")
+
+import { calculatePlaystyle } from "../../components/scoreHandler"
+import { ContractSession, RatingKill } from "../../components/types/types"
+
+loadConfig("Playstyles")
+
+describe("calculatePlaystyle", () => {
+    test("default", () => {
+        const contractSession = <ContractSession>{
+            kills: new Set<RatingKill>(),
+        }
+
+        const result = calculatePlaystyle(contractSession)
+
+        expect(result[0].Type).toBe("HEAD_SHOT_ASSASSIN")
+    })
+
+    test("pistol", () => {
+        const ratingKill: RatingKill = <RatingKill>{
+            KillClass: "ballistic",
+            KillItemCategory: "pistol",
+        }
+
+        const contractSession = <ContractSession>{
+            kills: new Set<RatingKill>([ratingKill]),
+        }
+
+        const result = calculatePlaystyle(contractSession)
+
+        expect(result[0].Type).toBe("PISTOL_ASSASSIN")
+    })
+})

--- a/tests/src/vitest.test.ts
+++ b/tests/src/vitest.test.ts
@@ -1,0 +1,13 @@
+describe("vitest", () => {
+    /**
+     * This test will verify if globals are configured correctly
+     */
+    it("globals", () => {
+        const result =
+            !PEACOCK_DEV && HUMAN_VERSION === "test" && REV_IDENT === 1
+
+        expect(result).toBe(true)
+    })
+})
+
+export {}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        // Reset rootDir to default to make rootDirs take effect
+        "rootDir": null,
+        "rootDirs": ["../components", "."],
+        "types": ["vitest/globals"]
+    },
+    "include": ["../components", "**/*.ts"],
+    "exclude": []
+}

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -1,0 +1,43 @@
+import path from "path"
+import { defineConfig } from "vitest/config"
+import { Plugin } from "vite"
+
+function dontLoadJsonPlugin() {
+    const pluginName = "dontLoadJsonPlugin"
+    const resolvedIdPrefix = `\0${pluginName}:`
+    const jsonRegexResolve = /\.json$/
+    const jsonRegexLoad = /\.json.ignore$/
+    const ignoreExtension = ".ignore"
+
+    return <Plugin>{
+        name: pluginName,
+        enforce: "pre",
+        resolveId(id: string, importer: string) {
+            if (id.startsWith("\0") || !jsonRegexResolve.test(id)) {
+                return null
+            }
+
+            const filePath = path.join(path.dirname(importer), id)
+
+            return `${resolvedIdPrefix}${filePath}${ignoreExtension}`
+        },
+        load(id: string) {
+            if (!id.startsWith(resolvedIdPrefix) || !jsonRegexLoad.test(id)) {
+                return null
+            }
+
+            return `export default "\\"${id.substring(
+                resolvedIdPrefix.length,
+                id.length - ignoreExtension.length,
+            )}\\""`
+        },
+    }
+}
+
+export default defineConfig({
+    test: {
+        globals: true,
+        setupFiles: ["tests/setup/globalDefines.ts"],
+    },
+    plugins: [dontLoadJsonPlugin()],
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
         "stripInternal": true
     },
     "include": ["components"],
-    "exclude": ["packaging", "chunk0.js", "webui"]
+    "exclude": ["packaging", "chunk0.js", "webui", "tests"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,6 +457,7 @@ __metadata:
     eslint: "npm:^8.36.0"
     eslint-config-prettier: "npm:^8.7.0"
     eslint-formatter-pretty: "npm:^4.1.0"
+    eslint-plugin-custom-rules: "link:./packaging/eslint"
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     eslint-plugin-react-hooks: "npm:^4.6.0"
@@ -1902,6 +1903,12 @@ __metadata:
   checksum: ec4dbc21acecd06cd03a2f463b35f3b32b9db510706e0603c07ffb79bbc63623b9dac0d3e603d90c41e8192d77dea3b4c24256f08be0426ed36efc5498397e76
   languageName: node
   linkType: hard
+
+"eslint-plugin-custom-rules@link:./packaging/eslint::locator=%40peacockproject%2Fmonorepo%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "eslint-plugin-custom-rules@link:./packaging/eslint::locator=%40peacockproject%2Fmonorepo%40workspace%3A."
+  languageName: node
+  linkType: soft
 
 "eslint-plugin-prettier@npm:^4.2.1":
   version: 4.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,6 +443,7 @@ __metadata:
     "@types/send": "npm:^0.17.1"
     "@typescript-eslint/eslint-plugin": "npm:^5.55.0"
     "@typescript-eslint/parser": "npm:^5.55.0"
+    "@vitest/ui": "npm:0.29.6"
     "@yarnpkg/fslib": "npm:^3.0.0-rc.39"
     "@yarnpkg/libzip": "npm:^3.0.0-rc.39"
     atomically: "npm:^2.0.1"
@@ -481,6 +482,7 @@ __metadata:
     serve-static: "npm:^1.15.0"
     terser: "npm:^5.16.6"
     typescript: "npm:4.9.5"
+    vitest: "npm:0.29.6"
   languageName: unknown
   linkType: soft
 
@@ -517,6 +519,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@polka/url@npm:^1.0.0-next.20":
+  version: 1.0.0-next.21
+  resolution: "@polka/url@npm:1.0.0-next.21"
+  checksum: 1329b8590b529d068d76c89c7f2bd08c3fbde82f7ed2ed6dede29b6711f8a42f4206b0bd769e472177708f7388b6213501e48272a2602605a7577a52ef919034
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.25.16":
   version: 0.25.21
   resolution: "@sinclair/typebox@npm:0.25.21"
@@ -538,6 +547,22 @@ __metadata:
     "@types/connect": "npm:*"
     "@types/node": "npm:*"
   checksum: 839e71535a3085c49da7c4d64ab98b35056c3d7ae069b06f4731c0980d738267a2c46ba5ffba0702aece8c61a877272f9a20d89929000fead4aac5098793d0fb
+  languageName: node
+  linkType: hard
+
+"@types/chai-subset@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@types/chai-subset@npm:1.3.3"
+  dependencies:
+    "@types/chai": "npm:*"
+  checksum: 3a98fe94d2c1b939d17264d878795a3e240f0d1b49fb246f5c1b3ea178f701487e295be90636f5fb5f6dbe13b180cc38e9f217209d0ee0fd0cce39e9ef2f0120
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:*, @types/chai@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "@types/chai@npm:4.3.4"
+  checksum: 477e9eabcf92d43706ac874585c8eab97b3f7808d4cc10479208e8675186633c20f30993a4e3ca510c70489823c3fb3ede508cd8b172bcdd3ef66cec8235e73a
   languageName: node
   linkType: hard
 
@@ -874,6 +899,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:0.29.6":
+  version: 0.29.6
+  resolution: "@vitest/expect@npm:0.29.6"
+  dependencies:
+    "@vitest/spy": "npm:0.29.6"
+    "@vitest/utils": "npm:0.29.6"
+    chai: "npm:^4.3.7"
+  checksum: 6aea0926140e90e164cbea5a5ced0fc1ee0d228f76811c833944d3f1cd4e7c3f8641f2035dbcd03fa8a98a5793b1d7202c63c2e4e548ff5efb034c9cc84a52d4
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:0.29.6":
+  version: 0.29.6
+  resolution: "@vitest/runner@npm:0.29.6"
+  dependencies:
+    "@vitest/utils": "npm:0.29.6"
+    p-limit: "npm:^4.0.0"
+    pathe: "npm:^1.1.0"
+  checksum: 4bb6df1f85b04596716b6557f75f64f2526b0e071566b1a3298233a7176c00774afc693cf61020a0e2905993e82e472daf5959fd64596890a5d98da44bfa148e
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:0.29.6":
+  version: 0.29.6
+  resolution: "@vitest/spy@npm:0.29.6"
+  dependencies:
+    tinyspy: "npm:^1.0.2"
+  checksum: 208a32a2e0e6abd346823642f3bc64eebdb62b4e539214faf100dc3c60605bfdec8393db647a13defbffe338cdc22b60b01b20e519981d866e7eb9cc4ec51b99
+  languageName: node
+  linkType: hard
+
+"@vitest/ui@npm:0.29.6":
+  version: 0.29.6
+  resolution: "@vitest/ui@npm:0.29.6"
+  dependencies:
+    fast-glob: "npm:^3.2.12"
+    flatted: "npm:^3.2.7"
+    pathe: "npm:^1.1.0"
+    picocolors: "npm:^1.0.0"
+    sirv: "npm:^2.0.2"
+  checksum: 79b45c8df03daa09748c19155becfeb39287813c1eb7a810d90b497d7d94ce0ef73cc1e4244113ae920febed74f544c34901e44141888bd1799862ac876f9254
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:0.29.6":
+  version: 0.29.6
+  resolution: "@vitest/utils@npm:0.29.6"
+  dependencies:
+    cli-truncate: "npm:^3.1.0"
+    diff: "npm:^5.1.0"
+    loupe: "npm:^2.3.6"
+    pretty-format: "npm:^27.5.1"
+  checksum: 61c5fbed3fd8897ac2805c65078d1a381559a9842ff3854d441051cf90d6637392107f501fdfe86df2301cb6229f6dda17b8d1abe684534f6a87e778c6ace7db
+  languageName: node
+  linkType: hard
+
 "@yarnpkg/fslib@npm:^3.0.0-rc.39":
   version: 3.0.0-rc.39
   resolution: "@yarnpkg/fslib@npm:3.0.0-rc.39"
@@ -922,12 +1003,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: 389d3f19998ac0924a590485a6502b72059e3ab67cc820477c2c40cca06b6c50bb8d424bfbb8fe97955eb489b88cb5dc7ee6979fcf9321dce7eb451ba3456d3d
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.5.0, acorn@npm:^8.8.0":
   version: 8.8.1
   resolution: "acorn@npm:8.8.1"
   bin:
     acorn: bin/acorn
   checksum: f8a84cf59173c5c07cb6b8097c716370f799244189b23d58358eadf9729e0d62660bc11339e03f08517fa33d1ef4b69b84b0bdebe0c0d783acaa8d2c44a66345
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.8.1, acorn@npm:^8.8.2":
+  version: 8.8.2
+  resolution: "acorn@npm:8.8.2"
+  bin:
+    acorn: bin/acorn
+  checksum: 5a47325f0aa08202080cb167d5b8103720d8a1d199f57988afa48bdfbc3c9973270b00e38c2c874240a49929625beaaae8c4ec683f5272b5f07f1119a457e5d0
   languageName: node
   linkType: hard
 
@@ -989,6 +1086,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "ansi-regex@npm:6.0.1"
+  checksum: 53669c3634190ead828055bcae5f0feff485fd8d7d05538d4f753ad56ffedb7aa5bcc93efaa8e99e4907ad970682413f2407cf4acac8deb1d408bc564bca9027
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
@@ -1002,6 +1106,13 @@ __metadata:
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: be68c7c5f374e8d72174b43ff3ab5bdd0e2e024bcaace9c0d2bbcd0edef71281424a1d23e5b29c8c7911143e4c34090088287a15f36ed710167c5bcccc867c7e
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.0.0":
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: 86fe3fc999c89775171631b32920d1fbf8adc4225895db376057b5a5e6fdcf837ae994ca08756f0a676c0dd8c74e58a7e87515d1fa16d6fcfffdf9069d579e90
   languageName: node
   linkType: hard
 
@@ -1047,6 +1158,13 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 0644809ce6ada3bcf5d25379f3c96f0335dd45516da5303fcb9eb2477dc8ad222fe39be2d0b58a7bbc3207e68d714e5f592316b881e2b13a11cd705d11cc5d45
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "assertion-error@npm:1.1.0"
+  checksum: 8e52a3ca8f1f789419cfa4d6e77a4be12ca441ca9ed64a671fd28a0efb1eac304579ee1d5cceb92a43a61d8caac10e00c3b6326ede54c515e0929572320388c8
   languageName: node
   linkType: hard
 
@@ -1177,6 +1295,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 2cc8918bf80255abb06825da69275294c4cacf4a282c8a6297cce401f785e225c73c1aa2f32d615d9a77ba9ee9ced6cf3d3e606ddf594ab8d95f6b3525807c9e
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^16.1.0":
   version: 16.1.3
   resolution: "cacache@npm:16.1.3"
@@ -1220,6 +1345,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "chai@npm:4.3.7"
+  dependencies:
+    assertion-error: "npm:^1.1.0"
+    check-error: "npm:^1.0.2"
+    deep-eql: "npm:^4.1.2"
+    get-func-name: "npm:^2.0.0"
+    loupe: "npm:^2.3.1"
+    pathval: "npm:^1.1.1"
+    type-detect: "npm:^4.0.5"
+  checksum: 07600143d9c0530811acf71e3fe3d613b13c627d19890e220a01064d9187c49ccd6be76e572a90e061f010f940ca380e9364b383e8a8a3f83313890986f49414
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -1227,6 +1367,13 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: cb96ab47eb1b55525e72caac9eed1513bff28e686df7eee6b04379c80922df21c8283d9938af16a645826c94c9e19fb52ad63cbead6b5073d08ae5f8fa2661a2
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "check-error@npm:1.0.2"
+  checksum: 5ef1bce78b7105bd5b3f2e7d80a2c2d405a52c3f53d8c48da34d4b8d05f2a63cda26a66e058c4bcc4111be79246ba9ba93074bc4d8e2a65fe3566f8a3f2f7851
   languageName: node
   linkType: hard
 
@@ -1257,6 +1404,16 @@ __metadata:
   version: 2.7.0
   resolution: "cli-spinners@npm:2.7.0"
   checksum: 46b7cce5a56a9c2d062d84947c552f517e1d23eb88afc9f1835851e905f9324bd2f21eebb24a99a3143f508581dcbe372e7528d9adf019f73e01a4bcbee178df
+  languageName: node
+  linkType: hard
+
+"cli-truncate@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "cli-truncate@npm:3.1.0"
+  dependencies:
+    slice-ansi: "npm:^5.0.0"
+    string-width: "npm:^5.0.0"
+  checksum: 4d91d570b19e3800d1b8e83ca08f03e6453cc0f6ea081deca0e3458d42bb5c148890b8b2bf2b5db9d59cfe214eaaa0df078563e5d8892537e295a2938ca27b06
   languageName: node
   linkType: hard
 
@@ -1428,6 +1585,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^4.1.2":
+  version: 4.1.3
+  resolution: "deep-eql@npm:4.1.3"
+  dependencies:
+    type-detect: "npm:^4.0.0"
+  checksum: b70d39de74834eaa065651e347c41fa3c824f92f52b8c37298ad327e04776f0dfc3f45d8516dc92189f2f493c95b6bae7f91257f350408dc41b8943a7bba9adb
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -1486,6 +1652,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "diff@npm:5.1.0"
+  checksum: c241ce992c1b59de63637d5ea2c4ac36e5686a0c660830a2dea1c9963abbb83907bef6aebe2898a3e581483bf8b1073e806ad884bf8cafe2af4023fb8ecf0f58
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -1516,6 +1689,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 0b403fab07c8a53488ea6212435f12b8eeec0b0b828554381b333ea1e41104a137cfe812fa83d021ea0270eb6249226bb0dcb61f8f94bed52b943fa2f720542f
+  languageName: node
+  linkType: hard
+
 "ecdsa-sig-formatter@npm:1.0.11":
   version: 1.0.11
   resolution: "ecdsa-sig-formatter@npm:1.0.11"
@@ -1536,6 +1716,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: 0b84c9059a3f051e3da79112ee450f22bc8466dde2a7e09a0b1fc4eff3b98183596e6e2704d5356266851e2a013d95467421eb81c36408fbab1aeb3fc5e4764f
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: ef0642d76f5116a04296a85ec167696b91ca8a1373d3cd13ec3acfb0f6a77d4d1c6ce94192ab31f8bad5ca69fbd01b556638fdf389128fea48fb5f6c2c754b45
   languageName: node
   linkType: hard
 
@@ -1989,7 +2176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -2078,7 +2265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.1.0":
+"flatted@npm:^3.1.0, flatted@npm:^3.2.7":
   version: 3.2.7
   resolution: "flatted@npm:3.2.7"
   checksum: d57a559a56f8743f48067b992e70f222921bec6656de4617ee60dab5e531c2aeba67ace287965b759cca80fa0d3f0c7ffc39341ccc9bc874594f4b73c0fea48c
@@ -2175,6 +2362,13 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     wide-align: "npm:^1.1.5"
   checksum: 4fc68f770dba9962a326918f33f58f2458eddea08442c2d716238357e4291dee4223a812ce11084b54f928d607e4dfb6f380ba28d435b2721de94a22d5600669
+  languageName: node
+  linkType: hard
+
+"get-func-name@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "get-func-name@npm:2.0.0"
+  checksum: e56bed23b2160cf3aeedb2677ca019334543dd49790c1976e44d168b5f83283747b1a41675706bc114b7a1563da978dbdf6d2b5e9282534dbdeaa2c1184cae6a
   languageName: node
   linkType: hard
 
@@ -2542,6 +2736,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-fullwidth-code-point@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-fullwidth-code-point@npm:4.0.0"
+  checksum: 071ac737fb85429562e1835d423aaf0b369675bcf066681066bf71198bd85ccbc5e2d623a3ede0d8252c5d1b1d89d3b1d9920b42cba151822a0d056c49fad60f
+  languageName: node
+  linkType: hard
+
 "is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
@@ -2713,6 +2914,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "jsonc-parser@npm:3.2.0"
+  checksum: dffa53dd8b8aa897575bcd31b767f1a5c90a0229902e4fcf7aaae73d11a2a343eee6f852d432f7f9328b14520f487805014c2284fbe358e904c41f004964b54a
+  languageName: node
+  linkType: hard
+
 "jsonwebtoken@npm:^9.0.0":
   version: 9.0.0
   resolution: "jsonwebtoken@npm:9.0.0"
@@ -2763,6 +2971,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"local-pkg@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "local-pkg@npm:0.4.3"
+  checksum: 1f8d9b1e8ad319acbbeb5d74d53d808d26ac95111e4182a26dd9c826e1663eea48bbb6b84ae76d1b915c391259bd6d3315186c7a1a9b782c141c96786645eab7
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^6.0.0":
   version: 6.0.0
   resolution: "locate-path@npm:6.0.0"
@@ -2804,6 +3019,15 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 39c5fc44c6a8f7f8a92cccf174554fbb307477ef493760407920fdd4ed5f6cc1aec5b6a5ab3c3767ef79547b3e1aea09d8ca08d773232c662d910cfe473a0590
+  languageName: node
+  linkType: hard
+
+"loupe@npm:^2.3.1, loupe@npm:^2.3.6":
+  version: 2.3.6
+  resolution: "loupe@npm:2.3.6"
+  dependencies:
+    get-func-name: "npm:^2.0.0"
+  checksum: 5a74e2ed6e6578fc03d5a9a119382e74ad1c442445c7ffa27e88b51b4637ede09eb5b216a6a771781f3201c8e4fcd64dd55392c69bbd35f1d0b6b1f1f7501863
   languageName: node
   linkType: hard
 
@@ -3048,10 +3272,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.1.0, mlly@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "mlly@npm:1.2.0"
+  dependencies:
+    acorn: "npm:^8.8.2"
+    pathe: "npm:^1.1.0"
+    pkg-types: "npm:^1.0.2"
+    ufo: "npm:^1.1.1"
+  checksum: 4e0e4b9a1b25d0184d6e5af621a3b7e94f2339e5fcb3b478494b52eae0fba33a48a3f5ccd4d6238ed386e4d91eb79e4d8334a438bd6ddd9b65518f73de71fe88
+  languageName: node
+  linkType: hard
+
 "moment@npm:~2.29.3":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: d275537a30f155cae7f53f6e6d164ccb59b560935f3c6ed0f4a2e6f3503063b491ffa6b4f7e7207501f6fcab92a2d0bb78ed539cde33cadcb91df6b254f7328d
+  languageName: node
+  linkType: hard
+
+"mrmime@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mrmime@npm:1.0.1"
+  checksum: eed4c73cd1f7079f1d9a320e52ee539452a0980f054146ef11654aaabda67e6ad34b5645ad023726751fb85283fa36b0d48f5189fea7f3bfa32eeee6effafc06
   languageName: node
   linkType: hard
 
@@ -3288,6 +3531,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-limit@npm:4.0.0"
+  dependencies:
+    yocto-queue: "npm:^1.0.0"
+  checksum: ca073ed51f443fbc8346494b72190944decaeee6f020a977e3370b8072553172cccf5cde2531f3719a82b98eb03abd29111a053c40e57573f3396262e2383997
+  languageName: node
+  linkType: hard
+
 "p-locate@npm:^5.0.0":
   version: 5.0.0
   resolution: "p-locate@npm:5.0.0"
@@ -3381,6 +3633,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "pathe@npm:1.1.0"
+  checksum: 467cb4c0813dc810c8cd056c7c54ef628eb8ff4801057cd9861a8ff2e30143dbdf7e5765e2bd69c7ea65c151b84bbb9956afa9f1802683da2e3ce6565eadaae4
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pathval@npm:1.1.1"
+  checksum: 13fed3f7d8efa938ed9a5e3e5c6d35c6081e4d05b2fd97274702966477ff28af7599e44418bfeebf032acd407379a77b4db180cc78294e5b8dcd971567a0efe8
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:1.0.0, picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -3399,6 +3665,17 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 6ba5938c24af2c5918e94b39aa0ad48d71f2c30634de69d46e0bd32feb666de4e909406db6ffb78f98d39ef450d6a41b6fa3954dc3659d7b2b750766c1261e5e
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "pkg-types@npm:1.0.2"
+  dependencies:
+    jsonc-parser: "npm:^3.2.0"
+    mlly: "npm:^1.1.1"
+    pathe: "npm:^1.1.0"
+  checksum: e5da078c585c235cd3bdbb8a203c6e7620782abd3bb5c617ed6003ca42eacc10e5782f1030bcac2c3cc5c5f03e5989e6b936f5935733cc14b3e50cb83b95eda3
   languageName: node
   linkType: hard
 
@@ -3444,6 +3721,17 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: e8a99b3a385d8d09881a64b759b9cd88e44ab7ba09832d55608fd7203efdc78f0d94773532f3bb3bbb3f579096f7011883df06a26eb61792e786ea4f5fc984f0
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 757aecacd25b827c5985ae3fe24fac52910b9f56898319f020f4278b788016a25b12bcbd40fe44c466ee68791f11670e2152969b87b292c410f8e7280ca99aef
   languageName: node
   linkType: hard
 
@@ -3597,6 +3885,13 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 7c5b915fb793d63563cec1f721e059e6ff0e2855ac116ab5cb7450b6c59398f5e25f95c960ce5cb93504cc58ab724a75a78e99282354e702a0e667d0d787d028
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 24af7af3abd0bf94d4eb018a70db25fd4e23648eec7bb8b203bf59e24a715ac4eec8279939e15a4d90cbad19ed6be243a0f2c9aa0b1faec0a1c102d9c89ca3f9
   languageName: node
   linkType: hard
 
@@ -3922,10 +4217,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 60032bb006d872ff7f90145b65a9ea0ae9f32dd7ebd8527e1ec51be88c479ccb05454d757234aa1267afcf0dbf161ff91036862061ddcd9fb65256ccd4016d92
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 5cf7525c55a72d8d104d914acf2e470f74b2c156197277ad7b331bc5de3d8790170fed3c82ff98c7c31adaa8ff941bfd5ba44f55171cbe8ed0e939fa82a8322a
+  languageName: node
+  linkType: hard
+
+"sirv@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "sirv@npm:2.0.2"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.20"
+    mrmime: "npm:^1.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 090b4e70982631d28a62f4acd3b5166e9652fa2f81935dc0727fc1c93ab5cc0768d67821173eafff3d73087332bd0e673ba705ec1ce6f73ee1398c1a70cdbee3
   languageName: node
   linkType: hard
 
@@ -3940,6 +4253,16 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: b88a0f1086e3cd20c8b61f50d8afff5fba83f95167a86432f54387565c9424e5d1970612371f768c128ed4b5b1c427120382bafc8c9edf0b3737eb226b733687
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "slice-ansi@npm:5.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.0.0"
+    is-fullwidth-code-point: "npm:^4.0.0"
+  checksum: 6d94805ff2cc473bd610de967b60d915e6df967fad8d47b8ebcd8a02d915400f808e49c1982bcfbdc47fde230c0274f36e016ed2284ec9254e737c728ab3b59d
   languageName: node
   linkType: hard
 
@@ -3988,7 +4311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.0":
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: cba9f44c3a4a0485f44a7760ebe427eecdd3b58011ae0459c05506b54f898835b2302073d6afa563a19b60ee9e54c82e33bc4a032e28bebacdfc635f1d0bf7e0
@@ -4073,10 +4396,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 7210b6b555d9c330da64587c1d71362ca152189027ea04d4288ba0c0ecb5a1e210852904bec9197a28ee12331523207c519b8b5a76a91c64de6e75971feebd70
+  languageName: node
+  linkType: hard
+
 "statuses@npm:2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: a7e9d41901245a442e77b339f715d77ac113c03ab9434d9f81ae45d75ed3437d9824e601ae1a834ad3e471ae3fc78d3c00decec5e826c91552a58d4c38833ecf
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.3.1":
+  version: 3.3.2
+  resolution: "std-env@npm:3.3.2"
+  checksum: 383486453a3b34c9db54c3aab112e066f32c6afda55c89362fe56576a82564d60526578040f7fe3ff6173f18c426597cbf1be69be9de83f56b984533aa2c2599
   languageName: node
   linkType: hard
 
@@ -4095,6 +4432,17 @@ __metadata:
     is-fullwidth-code-point: "npm:^3.0.0"
     strip-ansi: "npm:^6.0.1"
   checksum: aa0f3e082b461e0dc8c54334ef2c748b777e7529c34d348ee16e69690da45e24f223804d94060633126462e2aa4906d6fbfab882f34036a9f4ccd3dbcd2d6931
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^5.0.0":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
+  dependencies:
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^9.2.2"
+    strip-ansi: "npm:^7.0.1"
+  checksum: cb2b2392bfd8114452b7adbe578d0472d706e01792a6b7cd35f15fe3afbda37fa26348cb984d01acebd5f9ccdb0e62a0c57cc0ec1fc7c2a5d01ef83e5afd8807
   languageName: node
   linkType: hard
 
@@ -4125,10 +4473,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-ansi@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "strip-ansi@npm:7.0.1"
+  dependencies:
+    ansi-regex: "npm:^6.0.1"
+  checksum: 552123468abae97929da64559af9c13f4518f8ea199038089bf5e49d7860d708e5e29b2e6401fcbab6f99f2c42f865c15a1976bcf51c5165f82152c7ce9a1043
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.0, strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 20cff3f15267a8b603c4dcec9c3cc5217bcf3f1a66481a4f9ecf262eacc1733a0457756288472328d24efef7705f7755e9511f9c383742389add93d4a9207ae5
+  languageName: node
+  linkType: hard
+
+"strip-literal@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "strip-literal@npm:1.0.1"
+  dependencies:
+    acorn: "npm:^8.8.2"
+  checksum: 96efed4f29818fe477f686f66ab4be69d584c256d342233182ed9d66ac2048dd46f0509fdc288f2e72a616fa3df0534b3144d6db0690afbbb069f81f241012af
   languageName: node
   linkType: hard
 
@@ -4229,6 +4595,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.3.1":
+  version: 2.4.0
+  resolution: "tinybench@npm:2.4.0"
+  checksum: 81c9b030af920dc0410af024e878e5c09912e0bd44d40f25a9c5927b5879582ae73dd6e9479186573fc82dbf0a282d9a3e710cf220e0f5916f5d0f0901dddb2a
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "tinypool@npm:0.4.0"
+  checksum: efa92ccef761e33f1a32e886f8b8b546eaf240e4f6d56e64a792ef1a9498a12088aa0707c17080aaf221049197d2aa5e074daabc9a1fca56e663465ce7904bc9
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "tinyspy@npm:1.1.1"
+  checksum: d61c5b72f27e3dae0c122891b9e9f48d869fec4d2aa89d2c56484202a0d3a03553af31178e73631ea00e5c39c479ece94f42db3fd8b48d5b8840094a37662eec
+  languageName: node
+  linkType: hard
+
 "to-absolute-glob@npm:^2.0.2":
   version: 2.0.2
   resolution: "to-absolute-glob@npm:2.0.2"
@@ -4252,6 +4639,13 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: ed889234ceb442c0d5f87ab3f2a8fc0679800baa41766c0d9ce1bb82c700052fd6cf5d1656e1304de13d7a7d5974962fedc1bbe9a0e4686c3d8743c716c7dd5f
+  languageName: node
+  linkType: hard
+
+"totalist@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "totalist@npm:3.0.0"
+  checksum: 612a1441460f894a571c2d0c4971eeeb34845262d1fe972d8402628aa23a4a164cd2b69e6a0f1b82b2323d6e6d1c4698d50a33cc6920284e9be2985bda61f5ad
   languageName: node
   linkType: hard
 
@@ -4296,6 +4690,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
+  version: 4.0.8
+  resolution: "type-detect@npm:4.0.8"
+  checksum: 2d2111a44529a381e9be7090066cc89b60ac2c822194e3d213a0d5f630e81abfd07d2b91a324ef4a173973c5b0c68b0bdf29ac6896459cf819914a6f56199e0f
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.20.2":
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
@@ -4337,6 +4738,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 09f82f25664c79d5cccc389502175093becf51d691b443c79294303681544a399fb42f8384b535ddeba48cadb64e7d14b42de40d8ade4418bb43174989dd8685
+  languageName: node
+  linkType: hard
+
+"ufo@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "ufo@npm:1.1.1"
+  checksum: 46c7403f2ef32569a8de94e5c90a68233f448127c14f25a392aab8d7793662439498432fe88fd351c46b91c19186ce49f53c3c1327eec757f722927e0477d7b2
   languageName: node
   linkType: hard
 
@@ -4412,6 +4820,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:0.29.6":
+  version: 0.29.6
+  resolution: "vite-node@npm:0.29.6"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.3.4"
+    mlly: "npm:^1.1.0"
+    pathe: "npm:^1.1.0"
+    picocolors: "npm:^1.0.0"
+    vite: "npm:^3.0.0 || ^4.0.0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 93fb2775de58ea2003534af0ddebba99ef3e967868ab9b748e5a1bb3f53394c0549778b6ad8c4eeec098fc9004d21afdc0c7ec4a82b8e4f087d73125ab07a841
+  languageName: node
+  linkType: hard
+
+"vite@npm:^3.0.0 || ^4.0.0":
+  version: 4.2.1
+  resolution: "vite@npm:4.2.1"
+  dependencies:
+    esbuild: "npm:^0.17.5"
+    fsevents: "npm:~2.3.2"
+    postcss: "npm:^8.4.21"
+    resolve: "npm:^1.22.1"
+    rollup: "npm:^3.18.0"
+  peerDependencies:
+    "@types/node": ">= 14"
+    less: "*"
+    sass: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 9b784639d35a074b12b72f60764ba6d6eedcaa112ac4b5df00a706e2d5a01d7d4b9ce19ddc5ce8b65260770e56e084fcf2ae7b7c763a0880a2d9f3bfb5fa3450
+  languageName: node
+  linkType: hard
+
 "vite@npm:^4.2.0":
   version: 4.2.0
   resolution: "vite@npm:4.2.0"
@@ -4450,6 +4912,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest@npm:0.29.6":
+  version: 0.29.6
+  resolution: "vitest@npm:0.29.6"
+  dependencies:
+    "@types/chai": "npm:^4.3.4"
+    "@types/chai-subset": "npm:^1.3.3"
+    "@types/node": "npm:*"
+    "@vitest/expect": "npm:0.29.6"
+    "@vitest/runner": "npm:0.29.6"
+    "@vitest/spy": "npm:0.29.6"
+    "@vitest/utils": "npm:0.29.6"
+    acorn: "npm:^8.8.1"
+    acorn-walk: "npm:^8.2.0"
+    cac: "npm:^6.7.14"
+    chai: "npm:^4.3.7"
+    debug: "npm:^4.3.4"
+    local-pkg: "npm:^0.4.2"
+    pathe: "npm:^1.1.0"
+    picocolors: "npm:^1.0.0"
+    source-map: "npm:^0.6.1"
+    std-env: "npm:^3.3.1"
+    strip-literal: "npm:^1.0.0"
+    tinybench: "npm:^2.3.1"
+    tinypool: "npm:^0.4.0"
+    tinyspy: "npm:^1.0.2"
+    vite: "npm:^3.0.0 || ^4.0.0"
+    vite-node: "npm:0.29.6"
+    why-is-node-running: "npm:^2.2.2"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@vitest/browser": "*"
+    "@vitest/ui": "*"
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    safaridriver:
+      optional: true
+    webdriverio:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: f1346bfe357e280c42c051e10981a40030c639c315866f868e8ac3930bfc9cde8ddbc50990db67b80cf6c7e7e65a3b95dcd24e6a5dde3ac0003a1e6f2d865af8
+  languageName: node
+  linkType: hard
+
 "wcwidth@npm:^1.0.1":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
@@ -4474,6 +4991,18 @@ __metadata:
   bin:
     node-which: ./bin/node-which
   checksum: 3728616c789b289c36ba2572887145e0736f06fe3435b8fef17e27eb5ec0696f61a21e356dd7fa58486346e57186863afa1b6c27c7665f7e674c8124f7f61157
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "why-is-node-running@npm:2.2.2"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: c2701bf75bcfa4f67929995d64d9c94782dcbe4da9038adb6c2ecd3d7ca18d226bad1c51fd4df8bf12901b797b84addf51e7664a6639f15b55e2fe49b1131b09
   languageName: node
   linkType: hard
 
@@ -4518,5 +5047,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 63eceacd482622afd71290541a9823a0e5eed88a6b58a5d136a5fb8151ed4d1549c80f28d74d4ad351582f9890635d49e6cf70f8d3cc64948640f839f6a37c70
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "yocto-queue@npm:1.0.0"
+  checksum: 4522405d36a190a188112c3bc9ae84ac5eeafee637417ec127c6defc28a75b745a6139f9178107389e5ae57c3a5523b0016aec5a1f23b228c7b17ca8b2869a9c
   languageName: node
   linkType: hard


### PR DESCRIPTION
Quite some hours (around 8) of configuration, playing with mocks and setting up a handful of useful examples.

The examples cover two situations that are very common in the code-base of Peacock:
- scoreHandler.ts* has a private method that should not be exported, but is interesting enough to actually test.
- oauthToken.ts uses other modules to do work. You could argue this is more of an integration test, but with the help of a few helper methods, you can easily mock these modules**.

\* We might actually just export it, since people will need it if the use the missionEnd hook to make their own scoring, but alas, it's an example on how to test such a method.

\** While jest also has a `jest.mock`, the `jest.spyOn` gives a lot more fine-grained control in that it doesn't mock the full module and proxies the call by default. This is useful if you want to check if it has been called, but still want to execute the actual logic.

That said, all roads lead to Rome in terms of when and how to mock something. 

I'll leave this as a draft for now, but I think it would be beneficial to the quality of Peacock to start minding the test-ability of the code-base as soon as possible. For example: there are a lot of API endpoints that have an inline function. This is very hard to test and would either require exposing the Express app (and then look for the routes we are interested in), or (the better solution) move them to internal functions and expose them the same way as I did for scoreHandler.ts and/or just export them.

Might look into Vitest on another branch and see what it takes to achieve the same.

Tests are setup using the Arrange-Act-Assert pattern.