### PR TITLE
Fixed issue with "invalid media type" errors

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -125,6 +125,13 @@ const app = express()
 app.use(loggingMiddleware)
 app.use("/_wf", webFeaturesRouter)
 
+// make sure all responses have a default content-type set
+app.use(function (_req, res, next) {
+    res.contentType("text/plain")
+
+    next()
+})
+
 if (getFlag("loadoutSaving") === "PROFILES") {
     app.use("/loadouts", loadoutRouter)
 }


### PR DESCRIPTION
Since the Yarn4 update, that also updated ExpressJS to a new version, it seems like that responses that immediately do .send don't have a media type set (anymore?). This sets the default media type to "text/plain", most likely like it always had before.

Tested in-game (H3 Epic) including full contract, no issues or weird logs anymore.