### PR TITLE
Livesplit - Provide a TimeCalc URL for Season/Trilogy speedruns

### DIFF
--- a/components/discordRp.ts
+++ b/components/discordRp.ts
@@ -312,11 +312,7 @@ export function scenePathToRpAsset(
         // haven
         case "assembly:/_pro/scenes/missions/opulent/mission_stingray/scene_stingray_basic.entity":
         case "assembly:/_pro/scenes/missions/opulent/mission_stingray/scene_stingray_arcticthyme.entity":
-            return [
-                "havenlastresort",
-                "The Last Resort",
-                "Haven - The Maldives",
-            ]
+            return ["havenlastresort", "The Last Resort", "Haven"]
 
         // miami
         case "assembly:/_pro/scenes/missions/miami/scene_et_sambuca.entity":
@@ -328,11 +324,11 @@ export function scenePathToRpAsset(
 
         // hawkes bay
         case "assembly:/_pro/scenes/missions/sheep/scene_adonis.entity":
-            return ["elusiveadonis", "The Politician", "New Zealand"]
+            return ["elusiveadonis", "The Politician", "Hawke's Bay"]
         case "assembly:/_pro/scenes/missions/sheep/scene_sheep.entity":
-            return ["hawkenightcall", "Nightcall", "New Zealand"]
+            return ["hawkenightcall", "Nightcall", "Hawke's Bay"]
         case "assembly:/_pro/scenes/missions/sheep/scene_opuntia.entity":
-            return ["opuntia", "Opuntia", "New Zealand"]
+            return ["opuntia", "Opuntia", "Hawke's Bay"]
 
         // sgail
         case "assembly:/_pro/scenes/missions/theark/scene_magpie.entity":

--- a/components/livesplit/liveSplitManager.ts
+++ b/components/livesplit/liveSplitManager.ts
@@ -228,9 +228,10 @@ export class LiveSplitManager {
                         await this._liveSplitClient.pause(),
                         "pause",
                     )
+
                     log(
-                        LogLevel.DEBUG,
-                        JSON.stringify(this._timeCalcEntries, null, "\t"),
+                        LogLevel.INFO,
+                        `TimeCalc link: ${this._generateTimeCalcLink()}`,
                     )
                 }
             }
@@ -429,6 +430,52 @@ export class LiveSplitManager {
         }
         log(LogLevel.DEBUG, `New TimeCalc entry: ${JSON.stringify(entry)}`)
         this._timeCalcEntries.push(entry)
+    }
+
+    private _generateTimeCalcLink() {
+        const url = new URL(
+            "https://solderq35.github.io/fg-time-calc/?mode=0&fs3=1&ft2=1&f3t1=1&f4t0=1&d=:&o1=1&fps=",
+        )
+
+        const searchParams = new URLSearchParams()
+
+        const completedEntries = this._timeCalcEntries.filter(
+            (e) => e.isCompleted,
+        )
+        const resetEntries = this._timeCalcEntries.filter((e) => !e.isCompleted)
+
+        let timecalcLine = 0
+
+        completedEntries.forEach((entry) => {
+            timecalcLine += 1
+            searchParams.set(`t${timecalcLine}`, `${Math.floor(entry.time)}`)
+            searchParams.set(`c${timecalcLine}`, entry.location)
+        })
+
+        let resetLocation = ""
+        let resetCount = 0
+
+        timecalcLine += 1
+
+        resetEntries.forEach((entry) => {
+            timecalcLine += 1
+            if (resetLocation === entry.location) {
+                resetCount += 1
+            } else {
+                resetLocation = entry.location
+                resetCount = 1
+            }
+            searchParams.set(`t${timecalcLine}`, `${Math.floor(entry.time)}`)
+            searchParams.set(
+                `c${timecalcLine}`,
+                `${entry.location} reset ${resetCount}`,
+            )
+        })
+
+        // Append new search
+        url.search += "&" + searchParams.toString().replaceAll("+", "%20")
+
+        return url.toString()
     }
 }
 

--- a/components/livesplit/liveSplitManager.ts
+++ b/components/livesplit/liveSplitManager.ts
@@ -19,17 +19,11 @@
 import { LiveSplitClient, LiveSplitResult } from "./liveSplitClient"
 import { log, LogLevel } from "../loggingInterop"
 import { getAllCampaigns } from "../menus/campaigns"
-import {
-    Campaign,
-    GameVersion,
-    IHit,
-    LiveSplitTimeCalcEntry,
-    Seconds,
-    StoryData,
-} from "../types/types"
+import { Campaign, GameVersion, IHit, Seconds, StoryData } from "../types/types"
 import { getFlag } from "../flags"
 import { controller } from "../controller"
 import { scenePathToRpAsset } from "../discordRp"
+import { LiveSplitTimeCalcEntry } from "../types/livesplit"
 
 export class LiveSplitManager {
     private readonly _liveSplitClient: LiveSplitClient

--- a/components/types/livesplit.ts
+++ b/components/types/livesplit.ts
@@ -1,0 +1,12 @@
+/**
+ * LiveSplit-related types
+ */
+
+import { Seconds } from "./types"
+
+export interface LiveSplitTimeCalcEntry {
+    contractId: string
+    time: Seconds
+    location: string
+    isCompleted: boolean
+}

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -1258,13 +1258,3 @@ export type ContextScopedStorageLocation = "profile" | "hit" | "session"
 export type CPDStore = Record<string, Record<string, string | number | boolean>>
 
 export type ContractProgressionData = Record<string, string | number | boolean>
-
-/**
- * LiveSplit-related types
- */
-export interface LiveSplitTimeCalcEntry {
-    contractId: string
-    time: Seconds
-    location: string
-    isCompleted: boolean
-}

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -1258,3 +1258,13 @@ export type ContextScopedStorageLocation = "profile" | "hit" | "session"
 export type CPDStore = Record<string, Record<string, string | number | boolean>>
 
 export type ContractProgressionData = Record<string, string | number | boolean>
+
+/**
+ * LiveSplit-related types
+ */
+export interface LiveSplitTimeCalcEntry {
+    contractId: string
+    time: Seconds
+    location: string
+    isCompleted: boolean
+}


### PR DESCRIPTION
Generating and printing a TimeCalc link as required for Season/Full game runs from Speedrun.com

This will print a link like this one in the console, ready to be submitted, using Livesplit output.
[https://solderq35.github.io/fg-time-calc/?mode=0&fs3=1&ft2=1&f3t1=1&f4t0=1&d=:&o1=1&fps=&t1=49&c1=Paris&t2=106&c2=Sapienza&t3=94&c3=Marrakesh&t4=79&c4=Bangkok&t5=76&c5=Colorado&t6=45&c6=Hokkaido&t8=74&c8=Sapienza%20reset%201&t9=75&c9=Sapienza%20reset%202&t10=42&c10=Sapienza%20reset%203&t11=42&c11=Sapienza%20reset%204&t12=27&c12=Colorado%20reset%201&t13=38&c13=Hokkaido%20reset%201](https://solderq35.github.io/fg-time-calc/?mode=0&fs3=1&ft2=1&f3t1=1&f4t0=1&d=:&o1=1&fps=&t1=49&c1=Paris&t2=106&c2=Sapienza&t3=94&c3=Marrakesh&t4=79&c4=Bangkok&t5=76&c5=Colorado&t6=45&c6=Hokkaido&t8=74&c8=Sapienza%20reset%201&t9=75&c9=Sapienza%20reset%202&t10=42&c10=Sapienza%20reset%203&t11=42&c11=Sapienza%20reset%204&t12=27&c12=Colorado%20reset%201&t13=38&c13=Hokkaido%20reset%201)