### PR TITLE
Fixing content type that broke webui

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -125,6 +125,20 @@ const app = express()
 app.use(loggingMiddleware)
 app.use("/_wf", webFeaturesRouter)
 
+app.get("/", (req: Request, res) => {
+    if (PEACOCK_DEV) {
+        res.send("dev active, you need to access the UI from port 3000")
+    } else {
+        const data = readFileSync("webui/dist/index.html").toString()
+
+        res.contentType("text/html")
+        res.send(data)
+    }
+})
+
+serveStatic.mime.define({ "application/javascript": ["js"] })
+app.use("/assets", serveStatic("webui/dist/assets"))
+
 // make sure all responses have a default content-type set
 app.use(function (_req, res, next) {
     res.contentType("text/plain")
@@ -135,18 +149,6 @@ app.use(function (_req, res, next) {
 if (getFlag("loadoutSaving") === "PROFILES") {
     app.use("/loadouts", loadoutRouter)
 }
-
-app.get("/", (req: Request, res) => {
-    if (PEACOCK_DEV) {
-        res.send("dev active, you need to access the UI from port 3000")
-    } else {
-        const data = readFileSync("webui/dist/index.html").toString()
-
-        res.send(data)
-    }
-})
-
-app.use("/assets", serveStatic("webui/dist/assets"))
 
 app.get(
     "/config/:audience/:serverVersion(\\d+_\\d+_\\d+)",


### PR DESCRIPTION
Making the default content-type to "text/plain" broke webui.
![chrome_2022-11-28_02-46-11](https://user-images.githubusercontent.com/7538405/204178291-4cf3951c-9d9a-44e9-9a20-46618637b2ac.png)

To fix it, I just moved the middleware after webui route declaration and I also had to specify mime type for js files to fix a "strict MIME" rule in Chrome as serveStatic isn't able to do it by itself apparently.

Thanks Aspecticor for finding that bug with your Bird% run I guess 🙃 