### PR TITLE
multiple contract creation fix

### DIFF
--- a/contractdata/HOKKAIDO/FLUCONTRACTCREATION.json
+++ b/contractdata/HOKKAIDO/FLUCONTRACTCREATION.json
@@ -3,7 +3,7 @@
         "Bricks": [
             "assembly:/_PRO/Scenes/Missions/Hokkaido/contractcreation_flu.brick"
         ],
-        "Entrances": ["8faca318-7c93-4abd-9ee3-f3c0c1577d77"],
+        "Entrances": [],
         "GameChangerReferences": [],
         "GameChangers": [
             "61a618c2-1cfc-46fa-846b-467de76042d6",
@@ -17,7 +17,7 @@
             "95690829-7da4-4225-a087-08918cccf120"
         ],
         "Objectives": [],
-        "Stashpoints": ["73d4bcd4-ec9f-4a6c-ae2d-1248109eadc3"]
+        "Stashpoints": []
     },
     "Metadata": {
         "CodeName_Hint": "Create contract Hokkaido Flu",

--- a/contractdata/HOKKAIDO/HOKKAIDOSNOWFESTIVAL.json
+++ b/contractdata/HOKKAIDO/HOKKAIDOSNOWFESTIVAL.json
@@ -27,7 +27,7 @@
         "Description": "UI_CONTRACT_MAMUSHI_TARGET_BRIEFING",
         "BriefingVideo": "briefing_mamushi",
         "DebriefingVideo": "debriefing_mamushi",
-        "Location": "LOCATION_HOKKAIDO",
+        "Location": "LOCATION_HOKKAIDO_SHIM_MAMUSHI",
         "ScenePath": "assembly:/_PRO/Scenes/Missions/Hokkaido/scene_mamushi.entity",
         "Type": "flashback",
         "Release": "2.13.x",

--- a/contractdata/HOKKAIDO/SNOWFESTIVALCREATION.json
+++ b/contractdata/HOKKAIDO/SNOWFESTIVALCREATION.json
@@ -18,7 +18,7 @@
         "IsLocked": false,
         "CreatorUserId": "fadb923c-e6bb-4283-a537-eb4d1150262e",
         "IsPublished": true,
-        "TileImage": "images/contracts/mamushi/tile.jpg",
+        "TileImage": "images/locations/location_hokkaido_mamushi/tile.jpg",
         "Location": "LOCATION_HOKKAIDO_SHIM_MAMUSHI",
         "Title": "UI_CONTRACT_CREATE_CONTRACT_TITLE",
         "ScenePath": "assembly:/_PRO/Scenes/Missions/Hokkaido/scene_mamushi.entity",

--- a/contractdata/SAPIENZA/EBOLACONTRACTCREATION.json
+++ b/contractdata/SAPIENZA/EBOLACONTRACTCREATION.json
@@ -1,7 +1,7 @@
 {
     "Data": {
-        "Bricks": [],
-        "Entrances": ["a28dd5e3-1f1d-408d-9387-945641c32218"],
+        "Bricks": ["assembly:/_PRO/Scenes/Missions/CoastalTown/override_constantjeff.brick"],
+        "Entrances": [],
         "GameChangerReferences": [],
         "GameChangers": [
             "61a618c2-1cfc-46fa-846b-467de76042d6",
@@ -15,22 +15,31 @@
             "95690829-7da4-4225-a087-08918cccf120"
         ],
         "Objectives": [],
-        "Stashpoints": ["e9c2f7ba-2d52-47a2-99b2-d14eba6d5278"]
+        "Stashpoints": []
     },
     "Metadata": {
         "CodeName_Hint": "Create contract Sapienza Ebola",
         "CreationTimestamp": "2018-02-13T12:50:53Z",
         "CreatorUserId": "fadb923c-e6bb-4283-a537-eb4d1150262e",
         "Description": "UI_CONTRACT_CREATE_CONTRACT_DESC",
+        "Entitlements": ["H1_LEGACY_EXPANSION"],
         "Id": "bc3eb4cb-3b7a-4a37-be41-fbc84669571a",
+        "IsFeatured": false,
         "IsLocked": false,
         "IsPublished": true,
+        "LastUpdate": "2022-11-24T12:17:52.3383209Z",
         "Location": "LOCATION_COASTALTOWN_EBOLA",
+        "OpportunityData": [],
+        "PublicId": "015451062447",
         "Release": {
             "Major": 3,
             "Minor": 100,
             "Build": 0,
             "Revision": -1
-        }
+        },
+        "RequiredUnlockable": [],
+        "ScenePath": "assembly:/_PRO/Scenes/Missions/CoastalTown/scene_ebola.entity",
+        "Title": "UI_CONTRACT_CREATE_CONTRACT_TITLE",
+        "Type": "creation"
     }
 }

--- a/contractdata/SGAIL/SGAILCONTRACTCREATION.json
+++ b/contractdata/SGAIL/SGAILCONTRACTCREATION.json
@@ -1,7 +1,7 @@
 {
     "Data": {
         "Objectives": [],
-        "Bricks": [],
+        "Bricks": ["assembly:/_PRO/Scenes/Missions/TheArk/gamechanger_no_constant_glow.brick"],
         "GameChangers": [
             "61a618c2-1cfc-46fa-846b-467de76042d6",
             "b48bb7f9-b630-48cb-a816-720ed7959319",


### PR DESCRIPTION
Fix the broken author contract creation.
Remove entrance and stashpoint restriction for patient zero and author contract creation because they are annoying, and the restriction does not transfer to the contract it creates in the first place (which is supposed to be a bug, but I'd prefer it stay as it is since it actually improves the mode).
Add the missing noconstantglow brick in sgail contract creation.
Change snow festival's location to the correct one (image replace coming with a separate commit)