### PR TITLE
Fix documentation for `addClientSideModDependency` and add new `modIsInstalled` function with more sensible naming and semantics

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -432,7 +432,7 @@ export class Controller {
      * Returns whether a mod is UNAVAILABLE.
      *
      * @param modId The mod's ID.
-     * @returns If the mod is unavailable. You should probably abort initialisation if true is returned. Also returns true if the `overrideFrameworkChecks` flag is set.
+     * @returns If the mod is unavailable. You should probably abort initialization if true is returned. Also returns true if the `overrideFrameworkChecks` flag is set.
      * @deprecated since v5.5.0
      */
     public addClientSideModDependency(modId: string): boolean {

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -427,15 +427,32 @@ export class Controller {
     }
 
     /**
-     * Adds a dependency on a client side mod through the Simple Mod Framework.
+     * You should use `modIsInstalled` instead!
+     *
+     * Returns whether a mod is UNAVAILABLE.
      * See the cookbook for a usage example!
      *
      * @param modId The mod's ID.
-     * @returns If the mod is available. You will probably want to abort plugin initialization if false is returned.
+     * @returns If the mod is unavailable. You should probably abort initialisation if true is returned. Also returns true if the `overrideFrameworkChecks` flag is set.
+     * @deprecated since v5.5.0
      */
     public addClientSideModDependency(modId: string): boolean {
         return (
             !this.installedMods.includes(modId) ||
+            getFlag("overrideFrameworkChecks") === true
+        )
+    }
+
+    /**
+     * Returns whether a mod is available and installed.
+     * See the cookbook for a usage example!
+     *
+     * @param modId The mod's ID.
+     * @returns If the mod is available (or the `overrideFrameworkChecks` flag is set). You should probably abort initialisation if false is returned.
+     */
+    public modIsInstalled(modId: string): boolean {
+        return (
+            this.installedMods.includes(modId) ||
             getFlag("overrideFrameworkChecks") === true
         )
     }

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -427,7 +427,7 @@ export class Controller {
     }
 
     /**
-     * You should use `modIsInstalled` instead!
+     * You should use {@link modIsInstalled} instead!
      *
      * Returns whether a mod is UNAVAILABLE.
      *

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -430,7 +430,6 @@ export class Controller {
      * You should use `modIsInstalled` instead!
      *
      * Returns whether a mod is UNAVAILABLE.
-     * See the cookbook for a usage example!
      *
      * @param modId The mod's ID.
      * @returns If the mod is unavailable. You should probably abort initialisation if true is returned. Also returns true if the `overrideFrameworkChecks` flag is set.
@@ -445,7 +444,6 @@ export class Controller {
 
     /**
      * Returns whether a mod is available and installed.
-     * See the cookbook for a usage example!
      *
      * @param modId The mod's ID.
      * @returns If the mod is available (or the `overrideFrameworkChecks` flag is set). You should probably abort initialisation if false is returned.


### PR DESCRIPTION
The `addClientSideModDependency` function used to do what it says; it would check if the mod was installed and abort the plugin loading if it wasn't. At some point, the semantics changed to supposedly "returning whether the mod is available", but even that has been broken for a long time, as it actually returns whether the mod is UNavailable. This has had a knock-on effect to the `overrideFrameworkChecks` flag, which is meant to make it so that checks always succeed; however, because a check succeeding means returning false in this broken function, the flag being set actually makes all plugins with mod dependencies abort initialisation.

This PR deprecates the old function and updates its documentation to describe the actual behaviour of the function. It also introduces a new function with a more sensible name that describes its more sensible semantics.