### PR TITLE
Update season 1 challenges and add challenges for the rest of the locations

### DIFF
--- a/contractdata/AMBROSE/_AMBROSE_CHALLENGES.json
+++ b/contractdata/AMBROSE/_AMBROSE_CHALLENGES.json
@@ -1,0 +1,2952 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_ROCKY"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "2638c6ab-20e5-4f5f-bcbb-2f940c7adee3",
+                    "Name": "UI_CHALLENGES_DUGONG_CRESTSLAPOUTCOME_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_SleepOnIt.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_CRESTSLAPOUTCOME_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SLEEPONIT": {
+                                    "Transition": "CheckKill"
+                                }
+                            },
+                            "CheckKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "4f80ca40-a8f3-4a5e-9add-4c74d3bb5bcc"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "CRESTLEFTAREA": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "2bbd5d4b-5d3b-405b-a003-f2baf61670b2",
+                    "Name": "UI_CHALLENGES_DUGONG_CRESTKILLEDBYBOAT_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_CrestKilledByEngine.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_CRESTKILLEDBYBOAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CRESTTHERE": {
+                                    "Transition": "CheckKill"
+                                }
+                            },
+                            "CheckKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "4f80ca40-a8f3-4a5e-9add-4c74d3bb5bcc"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_burn"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "CRESTNOTTHERE": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "577cb50a-8df2-4869-af93-f6fdff6daeac",
+                    "Name": "UI_CHALLENGES_DUGONG_ELIMINATE_AKKAKILLCREST_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_AkkaKillsCrest.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_ELIMINATE_AKKAKILLCREST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AKKAKILLCREST": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "5cd1be2d-06bb-4e2d-9f47-34ad6002a0b9",
+                    "Name": "UI_CHALLENGES_DUGONG_ELIMINATE_AKKASMOKINGDEATH_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_AkkaDiesWhileSmoking.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_ELIMINATE_AKKASMOKINGDEATH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AKKASMOKING": {
+                                    "Transition": "CheckKill"
+                                }
+                            },
+                            "CheckKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "666521d2-1efe-4d0a-b7f7-2afeb08262b6"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AKKANOTSMOKING": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "76e77c1b-fa6d-4949-84b8-df5be2db5f4a",
+                    "Name": "UI_CHALLENGES_DUGONG_AKKACAGE_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_AkkaCageKill.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_AKKACAGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AKKAINCAGE": {
+                                    "Transition": "CheckKill"
+                                }
+                            },
+                            "CheckKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "666521d2-1efe-4d0a-b7f7-2afeb08262b6"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "Electric"
+                                                        ]
+                                                    },
+                                                    "in": "$Value.DamageEvents"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AKKANOTINCAGE": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "83254586-bf80-414e-bcb3-97c64793205f",
+                    "Name": "UI_CHALLENGES_DUGONG_PIRATESLIFE_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_PiratesLifeForMe.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_PIRATESLIFE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Targets": [
+                                "4f80ca40-a8f3-4a5e-9add-4c74d3bb5bcc",
+                                "666521d2-1efe-4d0a-b7f7-2afeb08262b6"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$inarray": {
+                                                    "in": "$.Targets",
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "052cbf5d-e268-479a-a705-17609d528182"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "fba6e133-78d1-4af1-8450-1ff30466c553"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$remove": [
+                                            "Targets",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "SecondTarget"
+                                }
+                            },
+                            "SecondTarget": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$inarray": {
+                                                    "in": "$.Targets",
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "052cbf5d-e268-479a-a705-17609d528182"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "fba6e133-78d1-4af1-8450-1ff30466c553"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "af3285ff-d2c8-462d-9372-f728de6239f7",
+                    "Name": "UI_CHALLENGES_DUGONG_CRESTLETHALCOOKPOISON_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_CrestLethalCook.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_CRESTLETHALCOOKPOISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CRESTEATING": {
+                                    "Transition": "CheckKill"
+                                }
+                            },
+                            "CheckKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "4f80ca40-a8f3-4a5e-9add-4c74d3bb5bcc"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "consumed_poison"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillClass",
+                                                            "poison"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "CRESTNOTEATING": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "d634562c-c265-4b62-b123-d93b89d81c9f",
+                    "Name": "UI_CHALLENGES_DUGONG_CRESTROPEBRIDGETRAP_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_CrestBridgeTrap.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_CRESTROPEBRIDGETRAP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "4f80ca40-a8f3-4a5e-9add-4c74d3bb5bcc"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f4ebf9f6-6151-4304-9612-5473a38916d2"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "e4ebc1fa-d048-48cb-82bc-447ff81504b5",
+                    "Name": "UI_CHALLENGES_DUGONG_HEADCANON_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_2Targets1Cannon.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_HEADCANON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HEADCANON": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "f2c6a306-f472-41e0-ade4-80ff05466ba5",
+                    "Name": "UI_CHALLENGES_DUGONG_AKKAKILLEDBYHIPPIE_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_AkkaKilledByHippie.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_AKKAKILLEDBYHIPPIE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "666521d2-1efe-4d0a-b7f7-2afeb08262b6"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "9f95337d-0316-4cfc-9881-13080e2bc365"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "0826ff92-2b4c-48fe-9ad6-b3e513fd4607",
+                    "Name": "UI_CHALLENGES_ROCKY_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "70bfea02-e316-4e3d-ae42-a52731647d0e",
+                    "Name": "UI_CHALLENGES_ROCKY_KILLTARGETWMEATHOOK_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_KillTargetwMeatHook.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_KILLTARGETWMEATHOOK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "58a036dc-79d4-4d64-8bf5-3faafa3cfead"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"]
+                },
+                {
+                    "Id": "bb9e24b5-0741-4f24-b2f0-6b437d21d091",
+                    "Name": "UI_CHALLENGES_ROCKY_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "d34be7aa-94d7-43e5-84a6-c472cfad2d7b",
+                    "Name": "UI_CHALLENGES_ROCKY_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "da8be740-a942-476c-a97e-9d9876e1fe7f",
+                    "Name": "UI_CHALLENGES_ROCKY_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "e9f62515-0803-41c6-88b2-ac9a5fc2b1f8",
+                    "Name": "UI_CHALLENGES_ROCKY_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "f1c44b70-324c-4497-9c5f-5aed7f0fd2c8",
+                    "Name": "UI_CHALLENGES_ROCKY_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0826ff92-2b4c-48fe-9ad6-b3e513fd4607",
+                                "da8be740-a942-476c-a97e-9d9876e1fe7f",
+                                "e9f62515-0803-41c6-88b2-ac9a5fc2b1f8",
+                                "d34be7aa-94d7-43e5-84a6-c472cfad2d7b",
+                                "bb9e24b5-0741-4f24-b2f0-6b437d21d091"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "ad549a16-c8c7-40af-9265-f5c42065be87",
+                    "Name": "UI_CHALLENGES_DUGONG_HSUPICTURETAKEN_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_LanceHsuPicture.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_HSUPICTURETAKEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HSUPICTURETAKEN": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "0421b082-32c1-4f16-8c85-31abe0f27f65",
+                    "Name": "UI_CHALLENGES_ROCKY_HIPPIESUB_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_HippieSubExit.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_HIPPIESUB_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "YESHIPPIE": {
+                                    "Transition": "HIPPIEOUTFIT"
+                                }
+                            },
+                            "HIPPIEOUTFIT": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "59897578-7001-432e-b4e6-0f4a58d10c23"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "NOTHIPPIE": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "0ca05d13-dbab-4b0f-8752-5b30c85cdca3",
+                    "Name": "UI_CHALLENGES_ROCKY_MILITABOATEXIT_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_MilitiaBoatExit.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_MILITABOATEXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "105a1c9a-6b89-4495-8220-056950e9eb0c"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "1517bef5-6202-4c2d-9a79-fad624d90148",
+                    "Name": "UI_CHALLENGES_ROCKY_FINDMEATHOOK_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_FindMeatHook.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_FINDMEATHOOK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FOUNDMEATHOOK": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "1a1eec22-fba3-4806-8e1e-fb92a1bc27b6",
+                    "Name": "UI_CHALLENGES_ROCKY_SMITHDIARY_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_SmithDiaries.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_SMITHDIARY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 4
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DIARYFOUND": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "1c6b0a02-4791-4101-979c-b4ffdc460dcc",
+                    "Name": "UI_CHALLENGES_ROCKY_LADDER_B_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_PersistentShortcut_B.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_LADDER_B_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Dugong_Ladder_B_Down": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "594170f9-4803-4284-8c23-a0e74b04cc6b",
+                    "Name": "UI_CHALLENGES_ROCKY_WORKSHOPBOATEXIT_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_WorkshopBoatExit.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_WORKSHOPBOATEXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "f5e1c363-ab7a-445b-bed9-c90096d2ef04"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "2dfd2737-d24c-4269-ab2d-12d89f262afe"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "5f8c0e45-771e-441d-adc3-ea8a5c8813eb",
+                    "Name": "UI_CHALLENGES_ROCKY_FINDDURIAN_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_FindDurian.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_FINDDURIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DURIANFOUND": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "66aaf0a6-1203-4acc-aa51-da75cb995d0c",
+                    "Name": "UI_CHALLENGES_ROCKY_BONELOCKPICK_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_BonyLockpick.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_BONELOCKPICK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BONYLOCKPICK": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "6b108609-cc2c-43f0-827f-99179d9a8b48",
+                    "Name": "UI_CHALLENGES_ROCKY_FINDMOLOTOV_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_FindMolotov.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_FINDMOLOTOV_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FOUNDMOLOTOV": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "9e1ff84d-323b-4d7d-897b-1010272e004d",
+                    "Name": "UI_CHALLENGES_ROCKY_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_LocationDiscovery.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 12
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_ROCKY_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a84aef06-6003-412a-978d-70f28fe22fc1",
+                    "Name": "UI_CHALLENGES_ROCKY_HELICOPTEREXIT_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_HelicopterExit.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_HELICOPTEREXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GreyExit": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "ac6f5524-82e2-4d41-a155-e7f916e4559c",
+                    "Name": "UI_CHALLENGES_ROCKY_LADDER_A_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_PersistentShortcut_A.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_LADDER_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Dugong_Ladder_A_Down": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "bbc48bd0-54cd-416c-a037-a91f3ae8e980",
+                    "Name": "UI_CHALLENGES_ROCKY_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "c3af265c-7648-4ddb-a02b-ab605a053886",
+                                "afdb3b2b-7e5d-4c9a-be6e-4ebc41879e02",
+                                "d9d95b38-3708-4220-9838-597c078a1081",
+                                "9f95337d-0316-4cfc-9881-13080e2bc365",
+                                "f011f287-ea39-42a4-be1d-17ba5b783611",
+                                "1cec2601-c1ed-474f-ac70-ff8614799fcc",
+                                "052cbf5d-e268-479a-a705-17609d528182"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "d9b3cf85-d750-4003-8255-f4b3e252ad4b",
+                    "Name": "UI_CHALLENGES_ROCKY_COVEBOATEXIT_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_CoveBoatExit.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_COVEBOATEXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "b54d5f68-900f-4749-9465-7c596230392f"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "e7c13acf-4793-49f2-a65c-457ed02d21a7",
+                    "Name": "UI_CHALLENGES_ROCKY_BECOMEHIPPIE_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_BecomeHippie.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_BECOMEHIPPIE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "9f95337d-0316-4cfc-9881-13080e2bc365"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "8d27e376-c658-4f1a-8b97-a76e99575539",
+                    "Name": "UI_CHALLENGES_DUGONG_BIGMCGUFFIN_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_DestroyBigMcGuffin_Loud.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_BIGMCGUFFIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MCGUFFINDESTROYED": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "99b26a0e-69ca-42a2-a7a0-b8e84448df2e",
+                    "Name": "UI_CHALLENGES_DUGONG_PRISONEREVIDENCE_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_PrisonerEvidence.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_PRISONEREVIDENCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PROVIDEDEVIDENCE": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "a2c4a3ec-c15e-4530-ab40-8add6b5afd92",
+                    "Name": "UI_CHALLENGES_DUGONG_MEETINGTRIGGERED_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_MeetingTriggered.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_MEETINGTRIGGERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MEETINGTRIGGERED": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "d6a989ed-d156-4a09-bff7-9ef1dfbc1e8a",
+                    "Name": "UI_CHALLENGES_DUGONG_MCGUFFINPIECES_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_GetBothMcGuffins.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_MCGUFFINPIECES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 2
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GOTKEY": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "dc6eaa8a-dd80-482d-997e-682831e53f7a",
+                    "Name": "UI_CHALLENGES_DUGONG_BIGMCGUFFINQUIET_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_DestroyBigMcGuffin_Quiet.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_BIGMCGUFFINQUIET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MCGUFFINDESTROYEDQUIET": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "8b7c9a5f-0800-414b-a1d3-3c5a1758b933",
+                    "Name": "UI_CHALLENGES_ROCKY_SMITH_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_SmithReleased.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_SMITH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SMITHESCAPE": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "ca9e885d-dd71-4609-8ec9-adc73a791b4b",
+                    "Name": "UI_CHALLENGES_DUGONG_HAPPYSLAPPING_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_Slap5.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_HAPPYSLAPPING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 4
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "47SLAPPEDHARD": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "cdfd8347-d908-41b6-aed8-353fb5657da1",
+                    "Name": "UI_CHALLENGES_ROCKY_STUDENT_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_HelpStudent.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_STUDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "STUDENTCOMPLETED": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "dc53af70-4ade-4e8a-8010-85de1a8f5b75",
+                    "Name": "UI_CHALLENGES_ROCKY_FARAHCOCONUT_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_FarahCoconut.jpg",
+                    "Description": "UI_CHALLENGES_ROCKY_FARAHCOCONUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "232cf45d-d95f-4dd5-b20f-4f846739f435"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "22183fd3-d837-47c6-9c44-05637300af93"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "b5213925-b20e-4ce9-9c70-d60b2771d541",
+                    "Name": "UI_CHALLENGES_DUGONG_ELIMINATE_NOELCREST_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_EliminateCrest.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_ELIMINATE_NOELCREST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "4f80ca40-a8f3-4a5e-9add-4c74d3bb5bcc"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "cae0b1b1-a26f-49a0-8ea3-d0c49f677109",
+                    "Name": "UI_CHALLENGES_DUGONG_ELIMINATE_AKKA_NAME",
+                    "ImageName": "images/challenges/Rocky/Rocky_EliminateAkka.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_ELIMINATE_AKKA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "666521d2-1efe-4d0a-b7f7-2afeb08262b6"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "425a7a49-1892-4a24-aa40-f46cdb8d6c7f",
+                    "Name": "UI_CHALLENGES_DUGONG_SILENT_ASSASSIN_SUIT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_SILENT_ASSASSIN_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "suitonly", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "647ac859-f0ac-4a49-9138-f8d8dd8dfc1e",
+                    "Name": "UI_CHALLENGES_DUGONG_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "745f3087-1765-49ab-9a0f-5a37c769471f",
+                    "Name": "UI_CHALLENGES_DUGONG_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "82871d72-c1f2-4401-a33e-10730100af70",
+                    "Name": "UI_CHALLENGES_DUGONG_BIG4_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_BIG4_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "647ac859-f0ac-4a49-9138-f8d8dd8dfc1e",
+                                "425a7a49-1892-4a24-aa40-f46cdb8d6c7f",
+                                "c143b485-92af-4994-8bfd-03251a1f3905",
+                                "745f3087-1765-49ab-9a0f-5a37c769471f"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                },
+                {
+                    "Id": "c143b485-92af-4994-8bfd-03251a1f3905",
+                    "Name": "UI_CHALLENGES_DUGONG_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_DUGONG_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ROCKY",
+                    "ParentLocationId": "LOCATION_PARENT_ROCKY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "sniper", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["b2aac100-dfc7-4f85-b9cd-528114436f6c"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/BERLIN/_BERLIN_CHALLENGES.json
+++ b/contractdata/BERLIN/_BERLIN_CHALLENGES.json
@@ -1,0 +1,4278 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_EDGY"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "2f812cf3-8ff2-4fbe-a74d-1f589cd86083",
+                    "Name": "UI_CHALLENGES_FOX_SNIPE_THE_SNIPER_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_Snipe_the_Sniper.jpg",
+                    "Description": "UI_CHALLENGES_FOX_SNIPE_THE_SNIPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Gameplay": {
+                                    "range": 1,
+                                    "damage": 1,
+                                    "clipsize": 0.2,
+                                    "rateoffire": 0.3
+                                },
+                                "Name": "firearms_hero_sniper_heavy_jaeger_covert_name",
+                                "Description": "firearms_hero_sniper_heavy_jaeger_covert_desc",
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "eedb7f84-896d-403b-905b-11b105e7ce35"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_HERO_SNIPER_HEAVY_009_SU_SUB_SCOUT_SKIN03_NAME",
+                            "Id": "FIREARMS_HERO_SNIPER_HEAVY_009_SU_SUB_SCOUT_SKIN03",
+                            "Type": "weapon",
+                            "Subtype": "sniperrifle",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ec11ff00-d0a1-4262-8158-ab43188ac5ef"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "252428ca-3f8e-4477-b2b9-58f18cff3e44"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "4ab5bd8d-932e-4fb9-a3aa-4498a29b8761",
+                    "Name": "UI_CHALLENGES_FOX_COCONUT_KILLEDWITHCRANE_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_COCONUT_KillWithCrane.jpg",
+                    "Description": "UI_CHALLENGES_FOX_COCONUT_KILLEDWITHCRANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "28cb7e91-bf9c-46ee-a371-1bd1448f1994"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "4259a6e3-b20d-4614-b34c-0332c1949bb7"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "5351401a-2f15-4367-bf7b-3c2d5ae4cc89",
+                    "Name": "UI_CHALLENGES_FOX_DJDOUBLEKILL_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_DJDoubleKill.jpg",
+                    "Description": "UI_CHALLENGES_FOX_DJDOUBLEKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DJDOUBLEKILL": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "720f6d58-1780-4be6-8d73-b9deac650dff",
+                    "Name": "UI_CHALLENGES_FOX_10TARGETS_ONESESSION_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_10TARGETS_ONESESSION_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_10TARGETS_ONESESSION_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 6
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "Targets": [
+                                "8b29da09-461f-44d7-9042-d4fde829b9f2",
+                                "b8e7e65b-587e-471b-894d-282cda6614d4",
+                                "922deccd-7fb4-45d9-ae3d-2cf11915c403",
+                                "28cb7e91-bf9c-46ee-a371-1bd1448f1994",
+                                "633398ac-c4b4-4441-852d-ae6460172025",
+                                "1305c2e4-6394-4cfa-b873-22adbd0c9702",
+                                "abd1c0e7-e406-43bd-9185-419029c5bf3d",
+                                "eb024a5e-9580-49dc-a519-bb92c886f3b1",
+                                "252428ca-3f8e-4477-b2b9-58f18cff3e44",
+                                "2ab07903-e958-4af6-b01c-b62058745ce1",
+                                "f83376a4-6e56-4f2a-8122-151b272108fd"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$inarray": {
+                                                "in": "$.Targets",
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "81c487dd-6c2e-4947-9379-3f98cbbb0e24",
+                    "Name": "UI_CHALLENGES_FOX_3SNIPEDAGENTS_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_3SniperAgents.jpg",
+                    "Description": "UI_CHALLENGES_FOX_3SNIPEDAGENTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Enter_Volume": {
+                                    "Transition": "InPosition"
+                                }
+                            },
+                            "InPosition": {
+                                "Exit_Volume": {
+                                    "Transition": "Start"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$contains": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "d4a0874c-6e55-43a1-ae46-2049324d7d3e",
+                    "Name": "UI_CHALLENGES_FOX_LEMON_KILLEDWOWNRIFLE_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_LEMON_EliminatedwOWNRIFLE.jpg",
+                    "Description": "UI_CHALLENGES_FOX_LEMON_KILLEDWOWNRIFLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "252428ca-3f8e-4477-b2b9-58f18cff3e44"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "719ba201-3688-4984-afb0-81dc2cc95ec1"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "b70e2825-dd28-45b3-9f3f-aadca2265494",
+                    "Name": "UI_CHALLENGE_GRASSSNAKE_DUCKHUNT_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Grassnake_DuckHunt.jpg",
+                    "Description": "UI_CHALLENGE_GRASSSNAKE_DUCKHUNT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "16be233a-1eb8-4736-b87f-c2a69a2db14b",
+                                "OrderIndex": 938,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_EASTER_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_EASTER_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "themed",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "4c7942ab-5cfc-4398-bf2d-a4e7a8af6aaa"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "WhiteRabbitActive": {
+                                    "Transition": "KillStandby"
+                                }
+                            },
+                            "KillStandby": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "2264ea12-1ba1-4b32-be82-ca8bdb1e7ad2"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "256ac829-2ec6-44de-8d5f-16801a0491df"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["9d88605f-6871-46a8-bd46-9804ea04fca9"]
+                    }
+                },
+                {
+                    "Id": "a1d2ec29-dfc6-4bee-aba9-b6529c1fcdce",
+                    "Name": "UI_CHALLENGE_AMBROSIA_PRETENDERS_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Ambrosia_Pretenders.jpg",
+                    "Description": "UI_CHALLENGE_AMBROSIA_PRETENDERS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "KilledAllPosers": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["e3b65e65-636b-4dfd-bb42-65a18c5dce4a"]
+                    }
+                },
+                {
+                    "Id": "010a8509-3f78-4285-b83c-445a1cd281f5",
+                    "Name": "UI_CHALLENGES_EDGY_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "6205c5cf-f2a2-48d2-990e-22eb5d7ddabd",
+                                "730873dd-3fe4-4143-b7c3-d96fae3f17a5",
+                                "756763c0-a477-4854-99f3-2eeabafa5098",
+                                "a1c23426-0cac-41d9-b615-b15a2188f42f",
+                                "a9933f46-646d-4116-8efe-f2cdd98d6b49"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "38c24658-7f0b-4384-bd27-9eaecda7c4c0",
+                    "Name": "UI_CHALLENGES_EDGY_BAGOFBRICKSKILL_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_BagOfBricksKill.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_BAGOFBRICKSKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "SetPiece": "56032dcb-27c3-446c-9ce2-5b5049520150"
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "5975028d-2b15-4663-b1bb-9b777a37ae94",
+                    "Name": "UI_CHALLENGES_EDGY_SCRAPSWORDELIMINATION_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_ScrapSwordElimination.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_SCRAPSWORDELIMINATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "d73251b4-4860-4b5b-8376-7c9cf2a054a2"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"]
+                },
+                {
+                    "Id": "6205c5cf-f2a2-48d2-990e-22eb5d7ddabd",
+                    "Name": "UI_CHALLENGES_EDGY_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "730873dd-3fe4-4143-b7c3-d96fae3f17a5",
+                    "Name": "UI_CHALLENGES_EDGY_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "756763c0-a477-4854-99f3-2eeabafa5098",
+                    "Name": "UI_CHALLENGES_EDGY_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "a1c23426-0cac-41d9-b615-b15a2188f42f",
+                    "Name": "UI_CHALLENGES_EDGY_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "a9933f46-646d-4116-8efe-f2cdd98d6b49",
+                    "Name": "UI_CHALLENGES_EDGY_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "2113732a-0518-4b50-b490-45422d9fcf29",
+                    "Name": "UI_CHALLENGES_EDGY_OBTAINJUICEBARTOKEN_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_ObtainJuiceBarToken.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_OBTAINJUICEBARTOKEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OBTAINJUICETOKEN": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "22beecc8-16e9-4ca3-9197-b4e82275c06b",
+                    "Name": "UI_CHALLENGES_EDGY_SCOOTEREXIT_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_ScooterExit.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_SCOOTEREXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "13e2b848-18d4-460b-9225-e27763716aae"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "4700aad3-4c99-403d-8b5a-afa7ff693a69"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "2f68f1d4-e7d7-4f10-8f38-df014a900b12",
+                    "Name": "UI_CHALLENGES_EDGY_DOOR_B_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_persistentdoor_b.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_DOOR_B_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Edgy_Door_B_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "907eecd0-8a79-4e89-89a0-579b147b18da",
+                    "Name": "UI_CHALLENGES_EDGY_GETSCRAPSWORD_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_ObtainJScrapIronSword.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_GETSCRAPSWORD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OBTAINSCRAPSWORD": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "92aadfac-7824-4a0a-9b47-c2c2458ae128",
+                    "Name": "UI_CHALLENGES_EDGY_BECOMEPUSHER_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_BecomePusher.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_BECOMEPUSHER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "4c379903-4cf2-49cf-953f-db7b31d2987d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "9cb0d0e2-cb57-4aa1-8525-038cc2c707ad",
+                    "Name": "UI_CHALLENGES_EDGY_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_locationdiscovery.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 22
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_EDGY_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "a1febb00-8fb6-4ed5-910b-31527b01d08b",
+                    "Name": "UI_CHALLENGES_EDGY_MOTORCYCLEEXIT_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_MotorcycleExit.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_MOTORCYCLEEXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "bc78a7db-0e76-4ed8-aa1f-1ea272ff638d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "e5268cf7-e1b6-4597-a18c-d1abac4646e7"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "a3b12ddf-65ad-499e-92bd-266999ad407c",
+                    "Name": "UI_CHALLENGES_EDGY_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "f724d6b9-a45b-425f-84f1-c27dedd1fd07",
+                                "0e931214-6ba9-4763-b7e1-32ca64dd864a",
+                                "2e5bdc9b-822d-4f5f-bc16-bd99729ef4f5",
+                                "4c379903-4cf2-49cf-953f-db7b31d2987d",
+                                "590629f7-19a3-4eb8-88a6-94e550cd1c07",
+                                "6e84215c-28b7-44b2-9d15-83e9be490965",
+                                "816cf012-ab64-48a0-b4cc-ff7470874007",
+                                "95918f14-fa9f-4315-be95-bf4b9efe6ee6",
+                                "8e41db54-b097-4704-8a88-83043e6557f7",
+                                "ac636da9-fd3a-4019-816a-6333e0c4298e"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "b1df314f-4c76-48c6-931b-bfdc171d0c8d",
+                    "Name": "UI_CHALLENGES_EDGY_DOOR_A_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_persistentdoor_a.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_DOOR_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Edgy_Door_A_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "bc650b9e-6040-4d59-b4b7-fffcdf0edfc4",
+                    "Name": "UI_CHALLENGES_EDGY_BECOMEDJ_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_BecomeDJ.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_BECOMEDJ_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "ac636da9-fd3a-4019-816a-6333e0c4298e"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "c64de151-22e3-4801-8954-51445525a185",
+                    "Name": "UI_CHALLENGES_EDGY_LADDER_A_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_persistentladder_a.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_LADDER_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Edgy_Ladder_A_Down": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "ecf4c767-a13d-45b4-a492-5a633e10521c",
+                    "Name": "UI_CHALLENGES_EDGY_BECOMEFLORIDAMAN_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_BecomeFloridaMan.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_BECOMEFLORIDAMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "0e931214-6ba9-4763-b7e1-32ca64dd864a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f11161c9-1fa8-4904-b398-3d65b3e3c0be",
+                    "Name": "UI_CHALLENGES_EDGY_BECOMEDELIVERYGUY_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_BecomeDeliveryGuy.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_BECOMEDELIVERYGUY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "2e5bdc9b-822d-4f5f-bc16-bd99729ef4f5"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f4ed6a60-9636-4945-8a09-1a7cc0ee009b",
+                    "Name": "UI_CHALLENGES_EDGY_BECOMEOWNER_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_BecomeOwner.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_BECOMEOWNER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "8e41db54-b097-4704-8a88-83043e6557f7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "fd9677ba-86a7-4bda-b919-91ef08862f77",
+                    "Name": "UI_CHALLENGES_EDGY_COCAINEBRICK_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_GetCocaineBrick.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_COCAINEBRICK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "COCAINEBRICK": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "1ae5e7db-7cec-468c-bb98-0335836e8d8d",
+                    "Name": "UI_CHALLENGES_FOX_FOODDELIVERED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_CompleteFoodDeliveryMS.jpg",
+                    "Description": "UI_CHALLENGES_FOX_FOODDELIVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FOODDELIVERED": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "4cf9dc47-3830-4006-adb3-df19751fa185",
+                    "Name": "UI_CHALLENGES_FOX_RAVE_ON_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_Rave_On.jpg",
+                    "Description": "UI_CHALLENGES_FOX_RAVE_ON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "3c6a9b35-82ac-4e08-8e32-d9fd77cbd7d3",
+                                "OrderIndex": 937,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_REWARD_HERO_RAVING_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_REWARD_HERO_RAVING_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "themed",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "4832005e-e0f5-40af-b230-4230e190284d"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RaveOnComplete": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "8b5bb691-45fe-4d90-9c16-646126239c4c",
+                    "Name": "UI_CHALLENGES_FOX_DRUGMANGO_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_DrugMango.jpg",
+                    "Description": "UI_CHALLENGES_FOX_DRUGMANGO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DRUGMANGO": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "b798d4cf-6ebd-436d-a1a6-d16cec6005a5",
+                    "Name": "UI_CHALLENGES_FOX_TERMINATOR_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_Terminator.jpg",
+                    "Description": "UI_CHALLENGES_FOX_TERMINATOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "Session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "shotgun"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.OutfitRepositoryId",
+                                                        "95918f14-fa9f-4315-be95-bf4b9efe6ee6"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Terminator"
+                                    }
+                                ]
+                            },
+                            "Terminator": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "bc78a7db-0e76-4ed8-aa1f-1ea272ff638d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "e5268cf7-e1b6-4597-a18c-d1abac4646e7"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "NOTBIKER": {
+                                    "Transition": "NotDressed"
+                                }
+                            },
+                            "NotDressed": {
+                                "BIKER": {
+                                    "Transition": "Terminator"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "bc9879d1-0704-4f25-8b8a-e7ff694329e4",
+                    "Name": "UI_CHALLENGES_FOX_FUMIGATEGRAPE_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_FumigateGrape.jpg",
+                    "Description": "UI_CHALLENGES_FOX_FUMIGATEGRAPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FUMIGATEGRAPE": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "c03b570d-7e30-4576-aa31-93d5c16651e5",
+                    "Name": "UI_CHALLENGES_FOX_COMPLETECONFRONTATION_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_CompleteConfrontationMS.jpg",
+                    "Description": "UI_CHALLENGES_FOX_COMPLETECONFRONTATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "THEREWASAFIREFIGHT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "fb7d6017-e1ca-4e36-acb7-bfb8f5c9ce4f",
+                    "Name": "UI_CHALLENGES_FOX_COMPLETEGUESTLIST_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_CompleteGuestList.jpg",
+                    "Description": "UI_CHALLENGES_FOX_COMPLETEGUESTLIST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GUESTLIST": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "ffcbf95c-666c-45d2-aaa3-b13d696d0dd2",
+                    "Name": "UI_CHALLENGES_FOX_JUICEBAR_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_JuiceBar.jpg",
+                    "Description": "UI_CHALLENGES_FOX_JUICEBAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "JUICEBAR": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "59c0b3dd-da63-4e22-a6a4-08fef4dec8e0",
+                    "Name": "UI_CONTRACT_SMILAX_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Smilax_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "a0f26534-0fb5-4762-83e6-f7dcd674614c",
+                                "OrderIndex": 939,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_BBW_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_BBW_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "themed",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "94f55803-dfe0-48c1-bdf5-9a2d69309f47"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["12d83cb0-a2d6-4c01-b9d8-675ac635ee61"]
+                    }
+                },
+                {
+                    "Id": "d0a36ff5-4532-4760-b0ce-f3527569bbf4",
+                    "Name": "UI_CONTRACT_SMILAX_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Smilax.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "75baec01-41ce-4b7d-b5ea-0ef40f377482"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["12d83cb0-a2d6-4c01-b9d8-675ac635ee61"]
+                    }
+                },
+                {
+                    "Id": "a015ff25-f9e8-481e-ab60-203eb8ecac40",
+                    "Name": "UI_CONTRACT_GRASSSNAKE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Grasssnake.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "e21c192f-429b-404a-9be7-bc2d0473ea9d",
+                                "OrderIndex": 647,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_EASTER_RAVER_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_EASTER_RAVER_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "casual",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c3a71288-0b64-4092-9a70-632e78f38658"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f5ebd915-3fc8-4cb7-95fd-f666f98e8b45"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["9d88605f-6871-46a8-bd46-9804ea04fca9"]
+                    }
+                },
+                {
+                    "Id": "879f252a-2802-4382-a95e-af623c177190",
+                    "Name": "UI_CHALLENGE_AMBROSIA_GREYCELLS_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Ambrosia_GreyCells.jpg",
+                    "Description": "UI_CHALLENGE_AMBROSIA_GREYCELLS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GreyCellsComplete": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["e3b65e65-636b-4dfd-bb42-65a18c5dce4a"]
+                    }
+                },
+                {
+                    "Id": "a18f553f-4262-4e24-b84c-19f05437d5d5",
+                    "Name": "UI_CONTRACT_AMBROSIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Ambrosia_ItemReward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 2,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "aaffeb68-c597-4ca8-9b8d-802ce08e1187"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_DEVICE_REMOTE_EXPLOSIVE_LUST_NAME",
+                            "Id": "PROP_DEVICE_REMOTE_EXPLOSIVE_LUST",
+                            "Type": "gear",
+                            "Subtype": "explosive",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3045308a-7a22-444a-9baa-b721780ebdeb"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "concealedweapon",
+                                "RepositoryId": "adced1ef-ecb5-4d46-ab73-d955d4b1fa1d"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_PISTOL_DARTGUN_BLINDING_LUST_NAME",
+                            "Id": "FIREARMS_PISTOL_DARTGUN_BLINDING_LUST",
+                            "Type": "weapon",
+                            "Subtype": "pistol",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "d1f6be11-eff0-4a96-a60a-73ef2f729566"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "cb712a0c-cf36-4c36-86d8-f57502e594bd"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["e3b65e65-636b-4dfd-bb42-65a18c5dce4a"]
+                    }
+                },
+                {
+                    "Id": "d5519e96-e038-4e15-acba-dd85d02fbf80",
+                    "Name": "UI_CONTRACT_AMBROSIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Ambrosia_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "833835aa-e982-48b4-9fa5-681972027ab0",
+                                "OrderIndex": 1024,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_LUST_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_LUST_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "sins",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "b9c91f98-57a4-4276-ac38-52b790a4ba12"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["e3b65e65-636b-4dfd-bb42-65a18c5dce4a"]
+                    }
+                },
+                {
+                    "Id": "ea512951-d4ec-435d-8301-541b892a6fd8",
+                    "Name": "UI_CHALLENGE_AMBROSIA_SAFEOPTION_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Ambrosia_SafeOption.jpg",
+                    "Description": "UI_CHALLENGE_AMBROSIA_SAFEOPTION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AllClues": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["e3b65e65-636b-4dfd-bb42-65a18c5dce4a"]
+                    }
+                },
+                {
+                    "Id": "f09c79a6-d971-4595-b320-026d39a971b3",
+                    "Name": "UI_CONTRACT_AMBROSIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Ambrosia.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "cb712a0c-cf36-4c36-86d8-f57502e594bd"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["e3b65e65-636b-4dfd-bb42-65a18c5dce4a"]
+                    }
+                },
+                {
+                    "Id": "83272630-9271-489b-9312-19cded398d65",
+                    "Name": "UI_CONTRACT_CORNFLOWER_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Cornflower_Reward_Suit.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "b262d4bb-6445-43cb-bb7c-fde6fe990aa7",
+                                "OrderIndex": 1006,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_ASYLUM_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_ASYLUM_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "deluxe",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "09f02352-627f-4f15-bccb-8584d9161b05"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["079876de-ddd7-47aa-8719-abe97d82fc12"]
+                    }
+                },
+                {
+                    "Id": "84c4146a-ce20-4dd6-8403-1d8b79182135",
+                    "Name": "UI_CONTRACT_CORNFLOWER_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Cornflower.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "c151a573-7571-4f7b-b5a3-178dd2d58601"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["079876de-ddd7-47aa-8719-abe97d82fc12"]
+                    }
+                },
+                {
+                    "Id": "ca58a6bf-426b-46c3-8fca-64d60a57a1fb",
+                    "Name": "UI_CONTRACT_CORNFLOWER_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Cornflower_Reward_Items.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 2,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "14aea5f5-82b8-447e-b7f6-042f24d11a15",
+                                "OrderIndex": 720,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_MELEE_LEATHERBELT_ASYLUM_NAME",
+                            "Id": "PROP_MELEE_LEATHERBELT_ASYLUM",
+                            "Type": "weapon",
+                            "Subtype": "melee",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "11dd5291-a437-4201-995a-3bb9a46605d5"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "concealedweapon",
+                                "RepositoryId": "8762d292-91ce-4385-9f78-dbf845f8366d"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_PISTOL_DARTGUN_SEDATIVE_ASYLUM_NAME",
+                            "Id": "FIREARMS_PISTOL_DARTGUN_SEDATIVE_ASYLUM",
+                            "Type": "weapon",
+                            "Subtype": "pistol",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "e988835e-2b95-4a13-af1a-8bb3da1dff40"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "9b42b7fe-e9be-4e81-abc8-7f3189c8b018"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["079876de-ddd7-47aa-8719-abe97d82fc12"]
+                    }
+                },
+                {
+                    "Id": "69c5d4b6-2867-436b-9659-2596a3ba0f1e",
+                    "Name": "UI_CONTRACT_NIGHTPHLOX_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Edgy_Night-Phlox.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f7a322dc-630d-4391-a367-f59168e64847"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5bb29a6b-7384-4641-944c-3540fa5cd8aa"]
+                    }
+                },
+                {
+                    "Id": "37da38ce-45aa-48e9-950f-135b41ba5cbc",
+                    "Name": "UI_CHALLENGES_FOX_DRUGPROBLEM_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_DrugProblem.jpg",
+                    "Description": "UI_CHALLENGES_FOX_DRUGPROBLEM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "a326595c-bf01-431a-b8c4-abccadc8a2ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "c6e9414e-e2ce-470a-95bd-14cd25225878"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                },
+                {
+                    "Id": "542d5ac3-68d2-4602-af35-89d49dfdbb5e",
+                    "Name": "UI_CHALLENGES_EDGY_DUMPANYONEINCANALS_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_DumpAnyoneInCanals.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_DUMPANYONEINCANALS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DUMP_CANALS_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "6ce2fde0-8eef-45b4-b5a5-a1843a9ea0b1",
+                    "Name": "UI_CHALLENGES_EDGY_PHOTOGRAPHTHEBIRDS_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_PhotographAllTheBirds.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_PHOTOGRAPHTHEBIRDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 7
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BIRDWATCHER": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"]
+                },
+                {
+                    "Id": "c9141cc3-4a33-4dd7-8899-4d09d9bfe592",
+                    "Name": "UI_CHALLENGES_EDGY_ENGARMYNDIR_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_EngarMyndir.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_ENGARMYNDIR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ENGARMYNDIR": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "cdccbe99-c1e7-42a4-9680-5271fa4c0517",
+                    "Name": "UI_CHALLENGES_EDGY_COCONUTBALLSURPRISE_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_CoconutBallSurprise.jpg",
+                    "Description": "UI_CHALLENGES_EDGY_COCONUTBALLSURPRISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "parentlocation",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3926e7ce-cb06-412a-a206-a864188d9987"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "22183fd3-d837-47c6-9c44-05637300af93"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "3926e7ce-cb06-412a-a206-a864188d9987"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "36c368c2-5808-40b5-8805-f62e458ac87c",
+                    "Name": "UI_CHALLENGES_FOX_GRAPE_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_GRAPE_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_GRAPE_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "eb024a5e-9580-49dc-a519-bb92c886f3b1"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "5ee6096a-d0b1-4bd0-b5e1-25ed8c872ad9",
+                    "Name": "UI_CHALLENGES_FOX_BANANA_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_banana_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_BANANA_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "922deccd-7fb4-45d9-ae3d-2cf11915c403"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "6af51bb4-00c2-4fdd-995d-19779fdea554",
+                    "Name": "UI_CHALLENGES_FOX_FIG_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_FIG_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_FIG_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "abd1c0e7-e406-43bd-9185-419029c5bf3d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "88248b70-0ebe-4f61-8c10-043ee2ab823f",
+                    "Name": "UI_CHALLENGES_FOX_LEMON_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_LEMON_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_LEMON_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "252428ca-3f8e-4477-b2b9-58f18cff3e44"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "885e4a29-6d57-4326-ac02-2c627511564e",
+                    "Name": "UI_CHALLENGES_FOX_10TARGETS_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_10TARGETS_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_10TARGETS_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "abe18eb2-b608-4410-ba25-671a1c363a03",
+                                "cc206a73-e78d-4183-9d7b-1e2969b1c9da",
+                                "5ee6096a-d0b1-4bd0-b5e1-25ed8c872ad9",
+                                "9637c654-d6bd-4afd-b0bc-cfcff1a4a525",
+                                "95040a91-cf5d-439b-954e-c2d68fe5486c",
+                                "992767fe-0e46-417a-a7f6-a1e7f8d2352b",
+                                "6af51bb4-00c2-4fdd-995d-19779fdea554",
+                                "36c368c2-5808-40b5-8805-f62e458ac87c",
+                                "88248b70-0ebe-4f61-8c10-043ee2ab823f",
+                                "b64f06eb-ed0d-44b4-a764-80ccfebd083b"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "95040a91-cf5d-439b-954e-c2d68fe5486c",
+                    "Name": "UI_CHALLENGES_FOX_DURIAN_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_durian_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_DURIAN_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "633398ac-c4b4-4441-852d-ae6460172025"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "9637c654-d6bd-4afd-b0bc-cfcff1a4a525",
+                    "Name": "UI_CHALLENGES_FOX_COCONUT_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_COCONUT_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_COCONUT_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "28cb7e91-bf9c-46ee-a371-1bd1448f1994"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "992767fe-0e46-417a-a7f6-a1e7f8d2352b",
+                    "Name": "UI_CHALLENGES_FOX_MANGO_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_MANGO_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_MANGO_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "1305c2e4-6394-4cfa-b873-22adbd0c9702"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "abe18eb2-b608-4410-ba25-671a1c363a03",
+                    "Name": "UI_CHALLENGES_FOX_MONTGOMERY_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_Montgomery_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_MONTGOMERY_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "8b29da09-461f-44d7-9042-d4fde829b9f2"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "b64f06eb-ed0d-44b4-a764-80ccfebd083b",
+                    "Name": "UI_CHALLENGES_FOX_PLUM_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_PLUM_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_PLUM_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "2ab07903-e958-4af6-b01c-b62058745ce1"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "cc206a73-e78d-4183-9d7b-1e2969b1c9da",
+                    "Name": "UI_CHALLENGES_FOX_APPLE_KILLED_NAME",
+                    "ImageName": "images/challenges/Edgy/Edgy_apple_Eliminated.jpg",
+                    "Description": "UI_CHALLENGES_FOX_APPLE_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "b8e7e65b-587e-471b-894d-282cda6614d4"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "0b63d39b-c53e-4fa4-a2a3-310a973eb819",
+                    "Name": "UI_CHALLENGES_FOX_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_FOX_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "4f73814b-2119-4683-bea0-b5659163f8d7",
+                    "Name": "UI_CHALLENGES_FOX_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_FOX_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "5b9eaeb1-eae8-4029-ad55-ccf4beab5f6b",
+                    "Name": "UI_CHALLENGES_FOX_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_FOX_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "sniper", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "6ca5490e-b6c1-420d-b4bd-3469ef253983",
+                    "Name": "UI_CHALLENGES_FOX_SILENT_ASSASSIN_SUIT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_FOX_SILENT_ASSASSIN_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "suitonly", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                },
+                {
+                    "Id": "ef48ba8c-d127-4040-b948-2e9115eb67a5",
+                    "Name": "UI_CHALLENGES_FOX_BIG4_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_FOX_BIG4_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0b63d39b-c53e-4fa4-a2a3-310a973eb819",
+                                "6ca5490e-b6c1-420d-b4bd-3469ef253983",
+                                "5b9eaeb1-eae8-4029-ad55-ccf4beab5f6b",
+                                "4f73814b-2119-4683-bea0-b5659163f8d7"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["ebcd14b2-0786-4ceb-a2a4-e771f60d0125"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "06a991c4-12f6-43b9-8574-c0f0fc9e3609",
+                    "Name": "UI_GRAPEFRUIT_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Grapefruit_Group.jpg",
+                    "Description": "UI_GRAPEFRUIT_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["be787ec9-e7b9-4984-bb39-fda4c71705ec"]
+                    }
+                },
+                {
+                    "Id": "514d855a-a565-40b9-9e5f-3e99e2dce585",
+                    "Name": "UI_BLACKBERRY_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Blackberry_Group.jpg",
+                    "Description": "UI_BLACKBERRY_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["d21e2e91-602c-49d2-9d42-e8bcfb810e9a"]
+                    }
+                },
+                {
+                    "Id": "5f1ae900-2413-411e-8a7a-e91878cf8170",
+                    "Name": "UI_LEMON_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Lemon_Group.jpg",
+                    "Description": "UI_LEMON_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_EDGY",
+                    "ParentLocationId": "LOCATION_PARENT_EDGY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["e4b29c19-13b4-471b-b188-cd9c0a788cd0"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/CARPATHIAN/_CARPATHIAN_CHALLENGES.json
+++ b/contractdata/CARPATHIAN/_CARPATHIAN_CHALLENGES.json
@@ -1,0 +1,1799 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_TRAPPED"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "3d0ff5c3-6e51-4827-951f-d45d8d21b3ea",
+                    "Name": "UI_CHALLENGES_WOLVERINE_CONSTANT_SERUM_NAME",
+                    "ImageName": "images/challenges/Trapped/wolverine_constant_serum.jpg",
+                    "Description": "UI_CHALLENGES_WOLVERINE_CONSTANT_SERUM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "POISON_CONSTANT_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"]
+                    }
+                },
+                {
+                    "Id": "97b0f181-d018-4fe4-8fb2-8b1737ece7b9",
+                    "Name": "UI_CHALLENGES_TRAPPED_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "18636f91-e1a9-4091-935c-adbf6cc3de55",
+                    "Name": "UI_CHALLENGES_TRAPPED_DOOR_A_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_door_a.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_DOOR_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Wolverine_Door_A_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "221141ee-00eb-4f91-911c-870a86f3aa01",
+                    "Name": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_UNIQUE_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_become_guard_unique.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_UNIQUE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "36402728-1197-4a3c-a8ac-1fed399a2344"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "459d0f57-04ce-42cf-9edb-22a10bfb43a1",
+                    "Name": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_TIER_3_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_become_guard_tier_3.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_TIER_3_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "e77b5340-41d3-448a-84d3-a4f7f6426634"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "46efb488-b731-47f0-b0b3-ee0185a5185b",
+                    "Name": "UI_CHALLENGES_TRAPPED_BECOME_SCIENTIST_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_become_scientist.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_BECOME_SCIENTIST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "abe4b536-1f09-421e-916b-20af142c6adb"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "5d5e9a47-7350-41f3-ba9a-576b94c6e994",
+                    "Name": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_TIER_1_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_become_guard_tier_1.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_TIER_1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "c3239200-0f56-4b45-9be5-e514bdf59d26"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "688c1211-2c11-4ee9-8a96-421aceb0ffb9",
+                    "Name": "UI_CHALLENGES_TRAPPED_GET_SMG_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_get_smg.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_GET_SMG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "a494c3c8-9a41-4398-9542-559e6a5dc1cb"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "7c383e7c-07e9-4ffa-a0f2-e54d5885a19a",
+                    "Name": "UI_CHALLENGES_TRAPPED_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "653ad7d6-7d5d-4554-9551-7573be7205be",
+                                "e77b5340-41d3-448a-84d3-a4f7f6426634",
+                                "36402728-1197-4a3c-a8ac-1fed399a2344",
+                                "68225457-66b3-457c-a6ec-065b001f5151",
+                                "c3239200-0f56-4b45-9be5-e514bdf59d26",
+                                "abe4b536-1f09-421e-916b-20af142c6adb",
+                                "81fc37ca-e20b-495f-961f-d5be311a6e6d"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "9d940a7c-3a1d-45b7-826d-8c239c0032e5",
+                    "Name": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_TIER_2_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_become_guard_tier_2.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_BECOME_GUARD_TIER_2_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "68225457-66b3-457c-a6ec-065b001f5151"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "d6194c1a-4cba-47a3-b001-98137fea975e",
+                    "Name": "UI_CHALLENGES_TRAPPED_GET_GRENADE_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_get_grenade.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_GET_GRENADE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "3f9cf03f-b84f-4419-b831-4704cff9775c"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "e8bbf9e7-46c6-4b21-b63e-511ff6c8912b",
+                    "Name": "UI_CHALLENGES_TRAPPED_GET_SHOTGUN_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_get_shotgun.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_GET_SHOTGUN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "4e92b3c5-3358-44aa-8a87-f7f349f46f44"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "fcddb4fe-1a44-414d-b769-bef1307ed05b",
+                    "Name": "UI_CHALLENGES_TRAPPED_DOOR_B_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_door_b.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_DOOR_B_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Wolverine_Door_B_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "22070cef-2ecb-4a65-ab16-cb4bfd63785e",
+                    "Name": "UI_CHALLENGES_WOLVERINE_COMPLETE_NAME",
+                    "ImageName": "images/contracts/wolverine/wolverine_tile.jpg",
+                    "Description": "UI_CHALLENGES_WOLVERINE_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "concealedweapon",
+                                "RepositoryId": "028bcbf4-a0a3-42b5-beaf-163a777164e8",
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_PISTOL_GOLD_BALLER_NAME",
+                            "Id": "FIREARMS_PISTOL_GOLD_BALLER",
+                            "Type": "weapon",
+                            "Subtype": "pistol",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "71b2182b-3be8-4326-b2ba-7bc3a46ea82c"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"]
+                    }
+                },
+                {
+                    "Id": "a2a750bb-12ee-4731-893c-6ace08bf4a53",
+                    "Name": "UI_CHALLENGES_WOLVERINE_ENDING_HM_SERUM_NAME",
+                    "ImageName": "images/challenges/Trapped/wolverine_ending_hm_serum.jpg",
+                    "Description": "UI_CHALLENGES_WOLVERINE_ENDING_HM_SERUM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ENDING_HM_SERUM": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"]
+                    }
+                },
+                {
+                    "Id": "260d3a23-a8ec-4d77-800c-c323158a7bd3",
+                    "Name": "UI_CONTRACT_BELLFLOWER_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Trapped_Bellflower_Reward_Items.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "LoadoutSlot": "carriedweapon",
+                                "Rarity": "common",
+                                "RepositoryId": "cdab8f33-0491-497c-91c2-316c77d59e55",
+                                "Quality": "1"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_MELEE_KATANA_WHITE_NINJA_NAME",
+                            "Id": "PROP_MELEE_KATANA_WHITE_NINJA",
+                            "Type": "weapon",
+                            "Subtype": "melee",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "0af3c113-fead-497d-9769-f576f026956d"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "8d22cea9-68db-458d-a8ee-9937128f1729"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_SNIPER_SIEGER_300_WHITE_NINJA_NAME",
+                            "Id": "FIREARMS_SNIPER_SIEGER_300_WHITE_NINJA",
+                            "Type": "weapon",
+                            "Subtype": "sniperrifle",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "969ce4ac-24e4-4d3a-ba40-419d5160e97f"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "645c9dd8-19e6-4cce-87ab-0e731fbaeab9"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["078a50d1-6427-4fc3-9099-e46390e637a0"]
+                    }
+                },
+                {
+                    "Id": "77a47b92-c287-4ceb-bbda-a04e174a900e",
+                    "Name": "UI_CONTRACT_BELLFLOWER_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Trapped_Bellflower.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "40651beb-edaa-41d0-aa9d-6bd4a14a8f81"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["078a50d1-6427-4fc3-9099-e46390e637a0"]
+                    }
+                },
+                {
+                    "Id": "b9b3c47b-1236-4597-98e0-62829428cbab",
+                    "Name": "UI_CONTRACT_BELLFLOWER_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Trapped_Bellflower_Reward_Suit.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "44540c7c-fcbb-4de2-8983-523997584ed0",
+                                "OrderIndex": 1005,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_WHITE_NINJA_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_WHITE_NINJA_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "deluxe",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "d0f915f7-54a6-4e81-a5b4-358001e4f5a4"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["078a50d1-6427-4fc3-9099-e46390e637a0"]
+                    }
+                },
+                {
+                    "Id": "02fcea9d-18df-4c12-859b-4e46fc0cf2e2",
+                    "Name": "UI_CHALLENGES_TRAPPED_PUSH_GUARD_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_push_guard.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_PUSH_GUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Constants": {
+                            "Targets": [
+                                "006bff27-d8b9-480e-9308-fac9a447d038",
+                                "0f8fd017-f30f-48aa-bb95-f0eed8f99eb0",
+                                "1063ec04-ae7f-47ce-9f67-e3ed87b910fb",
+                                "10a1344f-25b5-4d9b-99df-cc1a3e132701",
+                                "16bc3b56-63a5-48fd-beab-d4d2adf13b29",
+                                "17aa42ce-9de5-42c3-a0d7-42650aeb5ccb",
+                                "28a8ac36-edba-4b02-81f9-4d8e85a6e37c",
+                                "29f7350c-f28d-4756-b03b-8158806c1a19",
+                                "2db48fc3-1f43-4681-82b4-26289c7373bc",
+                                "3354e12a-3e7b-4693-bb63-a73d12a682e3",
+                                "49c4b42b-773d-416a-a48d-5cb7f6254290",
+                                "4c549646-3605-406a-8eb6-a56da52045a1",
+                                "56ba1725-4d2b-4ba0-9842-79457af2eca3",
+                                "5a62d8d2-1208-4f11-b95d-8f6cb11cd02b",
+                                "5b82b41f-f95e-4403-919c-6a67522fc94e",
+                                "606d9bbb-76b7-4e0f-a24f-e5b7a1257313",
+                                "6504cb26-c5d0-4c99-9aa2-7df9d18c5201",
+                                "6c232a4d-cd64-42d8-a78f-e0570dae7cd2",
+                                "6ecd7f77-bebc-4f7a-939d-7e16f4b678b1",
+                                "71854eb2-8e6c-4d19-83d2-fbdc7879bf6f",
+                                "759c67d0-18e2-49b2-a417-5daa9a450819",
+                                "796b0ee9-9261-4e55-ab6f-5a4c53f86e4e",
+                                "7bba60be-4b86-4a3c-be67-3937ab982ef2",
+                                "8255c9aa-1a59-4750-89f1-46542207e00d",
+                                "82615a87-f968-4be8-82d9-eb8089ad92ee",
+                                "8d6aebab-d94a-4adf-8770-5985a3809ece",
+                                "9830d3c6-93e3-49c8-b0c8-abdf3dc018ce",
+                                "a0766e5c-fadb-4900-8cb1-c776b56fabf5",
+                                "a3570e03-43f8-46ae-896a-e0a5803cfb6f",
+                                "a6f7e9f3-e25c-48c6-8f0b-755a2e864123",
+                                "aaafb8c3-8697-4121-8c97-1ec2c3502742",
+                                "b3840fb0-e732-4f35-b858-fc4bed036e46",
+                                "bb3efb54-cb83-4c63-adda-12b7da545a77",
+                                "bb7b6b31-adce-4a50-91fe-7447128b874b",
+                                "bbfbf4da-e6e1-4f14-b2ee-9325f9615408",
+                                "bdf572b3-7e6e-46f6-98b6-887ec99804de",
+                                "c2dcbadf-4101-4172-b458-0f02b9145c0b",
+                                "c7840085-c12a-4438-b032-f54bbe006030",
+                                "c9e0a95c-48ba-4809-b443-cdc63a084484",
+                                "cd6e9ee7-282c-49fa-a537-1802b4749e2c",
+                                "ce95c773-3153-4909-a356-16f071297582",
+                                "ced15cfa-21f7-4078-9ee7-f8b3ef1b1b59",
+                                "cf3c9e6e-4e3c-43dd-a663-897ffaa165f2",
+                                "d47a96d9-91cb-42cf-8193-6bccc74a775e",
+                                "d4fea004-6a7d-409f-bf4b-b229ca3cb355",
+                                "dca83dc1-c96e-4b75-b252-8abddd08617d",
+                                "f423f166-ed6d-4c3b-8d55-cd1c8a8b84ac"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "$.#"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_push"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "23f88163-097e-4c71-82e6-80f5f9624491",
+                    "Name": "UI_CHALLENGES_TRAPPED_CONSTRUCT_SILENCER_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_construct_silencer.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_CONSTRUCT_SILENCER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CONSTRUCT_SILENCER": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"]
+                },
+                {
+                    "Id": "2e876c4e-36d0-4840-8521-ca359d7d5c16",
+                    "Name": "UI_CHALLENGES_TRAPPED_SHOOT_TRAIN_SIGNAL_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_shoot_train_signal.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_SHOOT_TRAIN_SIGNAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TRAIN_SIGNAL_SHOT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "c36e81a3-5749-490d-bf31-697e4dead09d",
+                    "Name": "UI_CHALLENGES_TRAPPED_SODA_PACIFY_GUARD_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_soda_pacify_guard.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_SODA_PACIFY_GUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Constants": {
+                            "Goal": 3,
+                            "Targets": [
+                                "006bff27-d8b9-480e-9308-fac9a447d038",
+                                "0f8fd017-f30f-48aa-bb95-f0eed8f99eb0",
+                                "1063ec04-ae7f-47ce-9f67-e3ed87b910fb",
+                                "10a1344f-25b5-4d9b-99df-cc1a3e132701",
+                                "16bc3b56-63a5-48fd-beab-d4d2adf13b29",
+                                "17aa42ce-9de5-42c3-a0d7-42650aeb5ccb",
+                                "28a8ac36-edba-4b02-81f9-4d8e85a6e37c",
+                                "29f7350c-f28d-4756-b03b-8158806c1a19",
+                                "2db48fc3-1f43-4681-82b4-26289c7373bc",
+                                "3354e12a-3e7b-4693-bb63-a73d12a682e3",
+                                "49c4b42b-773d-416a-a48d-5cb7f6254290",
+                                "4c549646-3605-406a-8eb6-a56da52045a1",
+                                "56ba1725-4d2b-4ba0-9842-79457af2eca3",
+                                "5a62d8d2-1208-4f11-b95d-8f6cb11cd02b",
+                                "5b82b41f-f95e-4403-919c-6a67522fc94e",
+                                "606d9bbb-76b7-4e0f-a24f-e5b7a1257313",
+                                "6504cb26-c5d0-4c99-9aa2-7df9d18c5201",
+                                "6c232a4d-cd64-42d8-a78f-e0570dae7cd2",
+                                "6ecd7f77-bebc-4f7a-939d-7e16f4b678b1",
+                                "71854eb2-8e6c-4d19-83d2-fbdc7879bf6f",
+                                "759c67d0-18e2-49b2-a417-5daa9a450819",
+                                "796b0ee9-9261-4e55-ab6f-5a4c53f86e4e",
+                                "7bba60be-4b86-4a3c-be67-3937ab982ef2",
+                                "8255c9aa-1a59-4750-89f1-46542207e00d",
+                                "82615a87-f968-4be8-82d9-eb8089ad92ee",
+                                "8d6aebab-d94a-4adf-8770-5985a3809ece",
+                                "9830d3c6-93e3-49c8-b0c8-abdf3dc018ce",
+                                "a0766e5c-fadb-4900-8cb1-c776b56fabf5",
+                                "a3570e03-43f8-46ae-896a-e0a5803cfb6f",
+                                "a6f7e9f3-e25c-48c6-8f0b-755a2e864123",
+                                "aaafb8c3-8697-4121-8c97-1ec2c3502742",
+                                "b3840fb0-e732-4f35-b858-fc4bed036e46",
+                                "bb3efb54-cb83-4c63-adda-12b7da545a77",
+                                "bb7b6b31-adce-4a50-91fe-7447128b874b",
+                                "bbfbf4da-e6e1-4f14-b2ee-9325f9615408",
+                                "bdf572b3-7e6e-46f6-98b6-887ec99804de",
+                                "c2dcbadf-4101-4172-b458-0f02b9145c0b",
+                                "c7840085-c12a-4438-b032-f54bbe006030",
+                                "c9e0a95c-48ba-4809-b443-cdc63a084484",
+                                "cd6e9ee7-282c-49fa-a537-1802b4749e2c",
+                                "ce95c773-3153-4909-a356-16f071297582",
+                                "ced15cfa-21f7-4078-9ee7-f8b3ef1b1b59",
+                                "cf3c9e6e-4e3c-43dd-a663-897ffaa165f2",
+                                "d47a96d9-91cb-42cf-8193-6bccc74a775e",
+                                "d4fea004-6a7d-409f-bf4b-b229ca3cb355",
+                                "dca83dc1-c96e-4b75-b252-8abddd08617d",
+                                "f423f166-ed6d-4c3b-8d55-cd1c8a8b84ac"
+                            ],
+                            "Sodacans": [
+                                "004ecac9-6aee-4b30-a073-4399a94535d8",
+                                "4fbe2d58-5088-4155-805f-fe4c5789b8bb",
+                                "afd1f201-d2a5-4d40-80b1-d81b0d9d2541",
+                                "c19f796e-e23f-4429-a046-47ed3d324359",
+                                "de69ce1e-a24d-4acc-895f-4c3a71f47ba8"
+                            ]
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$Value.RepositoryId",
+                                                                "$.#"
+                                                            ]
+                                                        },
+                                                        "in": "$.Targets"
+                                                    }
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "$.#"
+                                                            ]
+                                                        },
+                                                        "in": "$.Sodacans"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "d73fdcb3-3c53-4df2-bc0c-0943ba249daf",
+                    "Name": "UI_CHALLENGES_TRAPPED_UNLOCK_KEYPAD_NAME",
+                    "ImageName": "images/challenges/Trapped/trapped_unlock_keypad.jpg",
+                    "Description": "UI_CHALLENGES_TRAPPED_UNLOCK_KEYPAD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_TRAPPED_WOLVERINE",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "UNLOCK_KEYPAD": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "3210fa62-67a5-4e1f-ba50-02c451d47875",
+                    "Name": "UI_CHALLENGES_WOLVERINE_ELIMINATE_CONSTANT_NAME",
+                    "ImageName": "images/challenges/Trapped/wolverine_eliminate_constant.jpg",
+                    "Description": "UI_CHALLENGES_WOLVERINE_ELIMINATE_CONSTANT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "17c40b70-506a-494e-89ef-31360cdead47"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "CompleteObjective": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "92643706-6f98-4b1c-9700-ee4819aaadb4",
+                    "Name": "UI_CHALLENGES_WOLVERINE_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_WOLVERINE_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"]
+                    }
+                },
+                {
+                    "Id": "a8af382f-1689-42ed-94e6-1ec1ab74bf1f",
+                    "Name": "UI_CHALLENGES_WOLVERINE_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_WOLVERINE_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"]
+                    }
+                },
+                {
+                    "Id": "f84b1f7c-540d-4237-a73b-cde321af6ff3",
+                    "Name": "UI_CHALLENGES_WOLVERINE_SILENT_ASSASSIN_SUIT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_WOLVERINE_SILENT_ASSASSIN_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_TRAPPED",
+                    "ParentLocationId": "LOCATION_PARENT_TRAPPED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "suitonly", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/CHONGQING/_CHONGQING_CHALLENGES.json
+++ b/contractdata/CHONGQING/_CHONGQING_CHALLENGES.json
@@ -1,0 +1,4473 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_WET"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "00fcea23-9659-447a-a717-9502810e2930",
+                    "Name": "UI_CHALLENGES_RAT_HUSH_ELIMINATE_HOMELESS_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_Hush_Eliminate_Homeless.jpg",
+                    "Description": "UI_CHALLENGES_RAT_HUSH_ELIMINATE_HOMELESS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "967abcf9-2672-4e81-8fef-211aaa366747"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "ba4e595e-da3b-4902-8622-40889fc088db"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "05abe50e-5aee-4cfb-aa01-8b4aacaa4d4b",
+                    "Name": "UI_CHALLENGES_RAT_BREAKROOM_ROYCE_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_BreakRoomPoison.jpg",
+                    "Description": "UI_CHALLENGES_RAT_BREAKROOM_ROYCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "a7fd7a4f-2bee-4787-bc60-90f9dd64233b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "546c1256-4f32-439c-813f-a15cbcafdf2b"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "51fa4447-1c58-489f-afb8-da1ba5d29f27",
+                    "Name": "UI_CHALLENGES_RAT_HUSH_DEPRIVATION_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_Deprivation.jpg",
+                    "Description": "UI_CHALLENGES_RAT_HUSH_DEPRIVATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DEPRIVATION_ENTERED_EVENT": {
+                                    "Transition": "Deprivation_State"
+                                }
+                            },
+                            "Deprivation_State": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "967abcf9-2672-4e81-8fef-211aaa366747"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "DEPRIVATION_LEFT_EVENT": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "6f7225da-10bb-4cde-b6fe-9f0ca08aeaa9",
+                    "Name": "UI_CHALLENGES_RAT_HUSH_ELIMINATE_OVERLOAD_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_Mnemonic.jpg",
+                    "Description": "UI_CHALLENGES_RAT_HUSH_ELIMINATE_OVERLOAD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MNEMONIC_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "88d953f7-0b1b-41e4-93f2-32c31e95088d",
+                    "Name": "UI_CHALLENGES_RAT_DOUBLEKILL_EXPLOSION_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_double_explosion.jpg",
+                    "Description": "UI_CHALLENGES_RAT_DOUBLEKILL_EXPLOSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Targets": [
+                                "a7fd7a4f-2bee-4787-bc60-90f9dd64233b",
+                                "967abcf9-2672-4e81-8fef-211aaa366747"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.5
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "9b8dfe5b-9f81-4efc-bd7d-9028ad4ef226",
+                    "Name": "UI_CHALLENGES_RAT_ROYCE_ELECTRICKILL_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_ShockSystem.jpg",
+                    "Description": "UI_CHALLENGES_RAT_ROYCE_ELECTRICKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "a7fd7a4f-2bee-4787-bc60-90f9dd64233b"
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "accident_electric"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "$Value.KillMethodBroad",
+                                                            "$Value.KillMethodStrict"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "b7d375e8-eb57-4cdb-ab26-4b79de18c211",
+                    "Name": "UI_CHALLENGES_RAT_ROYCE_DROWN_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_Royce_Drown.jpg",
+                    "Description": "UI_CHALLENGES_RAT_ROYCE_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {},
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "a7fd7a4f-2bee-4787-bc60-90f9dd64233b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_push"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "CheckWater"
+                                }
+                            },
+                            "CheckWater": {
+                                "ROYCE_IN_WATER": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "d2bbb7e1-2b0f-4a7a-97f1-1d53138e50ee",
+                    "Name": "UI_CHALLENGES_RAT_DOUBLE_SNIPER_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_BulletPoints.jpg",
+                    "Description": "UI_CHALLENGES_RAT_DOUBLE_SNIPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Targets": [
+                                "a7fd7a4f-2bee-4787-bc60-90f9dd64233b",
+                                "967abcf9-2672-4e81-8fef-211aaa366747"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.5
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "e869adc4-0c4c-4458-a6b2-24d28f5b2a9f",
+                    "Name": "UI_CHALLENGES_RAT_ELIMINATE_ROYCE_CORE_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_RoyceEmployeClensing.jpg",
+                    "Description": "UI_CHALLENGES_RAT_ELIMINATE_ROYCE_CORE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ARCHIVIST_TERMINAL_CORRECT": {
+                                    "Transition": "TurnonCleansing"
+                                }
+                            },
+                            "TurnonCleansing": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "a7fd7a4f-2bee-4787-bc60-90f9dd64233b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_burn"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "03b90b72-0310-4660-bc82-6defa01305e8",
+                    "Name": "UI_CHALLENGES_WET_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_WET_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "57c2b8fa-d7ec-4607-a7ec-0d575cbe0ca7",
+                    "Name": "UI_CHALLENGES_WET_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_WET_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "b09f9982-aa62-464d-91a9-fb6ea59cec3b",
+                                "6ba3702d-d760-4725-a85b-0f8321cbfa1c",
+                                "cec8afe0-ef8c-4b55-be9e-a49e407956aa",
+                                "03b90b72-0310-4660-bc82-6defa01305e8",
+                                "bd61611d-0a08-4639-aeb3-fc8629eb2adb"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "6ba3702d-d760-4725-a85b-0f8321cbfa1c",
+                    "Name": "UI_CHALLENGES_WET_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_WET_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "b09f9982-aa62-464d-91a9-fb6ea59cec3b",
+                    "Name": "UI_CHALLENGES_WET_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_WET_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "bd61611d-0a08-4639-aeb3-fc8629eb2adb",
+                    "Name": "UI_CHALLENGES_WET_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_WET_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "cec8afe0-ef8c-4b55-be9e-a49e407956aa",
+                    "Name": "UI_CHALLENGES_WET_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_WET_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "04ef301f-a62d-47f6-8cb8-3b8697e0c06c",
+                    "Name": "UI_CHALLENGES_RAT_DOOR_A_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_door_c.jpg",
+                    "Description": "UI_CHALLENGES_RAT_DOOR_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Rat_Door_B_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "16a62d47-a524-4c44-ac32-cac8ede71498",
+                    "Name": "UI_CHALLENGES_RAT_EXIT_METRO_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Exit_Metro.jpg",
+                    "Description": "UI_CHALLENGES_RAT_EXIT_METRO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "22c30622-968a-4e71-b1d6-0a9134e7d8af"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "2692f310-cd77-4e52-8245-2df12188a89f",
+                    "Name": "UI_CHALLENGES_WET_BECOME_STREETGUARD_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Become_StreetGuard.jpg",
+                    "Description": "UI_CHALLENGES_WET_BECOME_STREETGUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "86bdb741-6810-4610-8e21-799c93c71849"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4b095154-100b-4165-8153-920b5b302e3c",
+                    "Name": "UI_CHALLENGES_WET_BECOME_DENGUARD_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Become_DenGuard.jpg",
+                    "Description": "UI_CHALLENGES_WET_BECOME_DENGUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "4dd90d10-ac5f-404f-9c20-4428653ca7ba"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "5f8cef5b-c631-4304-af90-46efa4ca7deb",
+                    "Name": "UI_CHALLENGES_RAT_DOOR_B_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_door_a.jpg",
+                    "Description": "UI_CHALLENGES_RAT_DOOR_B_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Rat_Door_A_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "6a7aab65-9f76-4545-8771-8eb8bd2bd5fd",
+                    "Name": "UI_CHALLENGES_WET_SECRET_HATCH_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Secret_Hatch.jpg",
+                    "Description": "UI_CHALLENGES_WET_SECRET_HATCH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HATCH_OPEN_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "6ae05beb-d061-4386-9166-35b9bc790ca8",
+                    "Name": "UI_CHALLENGES_WET_BECOME_CONTROLLER_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Become_Controller.jpg",
+                    "Description": "UI_CHALLENGES_WET_BECOME_CONTROLLER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "fd1d39d8-db06-47b3-8f4b-eb1febf5ccb7"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "6cc832f7-b8f9-4b10-9912-166633272c1d",
+                    "Name": "UI_CHALLENGES_RAT_EXIT_SCOOTER_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Exit_StreetScooter.jpg",
+                    "Description": "UI_CHALLENGES_RAT_EXIT_SCOOTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "e2a1710e-e74f-424e-89b2-1e2d4a404b8e"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "7cf91ba7-c695-4823-97a7-54571f80f41d",
+                    "Name": "UI_CHALLENGES_RAT_EXIT_FACILITY_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Exit_FacilityDoor.jpg",
+                    "Description": "UI_CHALLENGES_RAT_EXIT_FACILITY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FACILITY_EXIT_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "7d7815ad-13c6-4532-aca4-b609e55d7050",
+                    "Name": "UI_CHALLENGES_WET_BECOME_HOMELESS_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Become_Homeless.jpg",
+                    "Description": "UI_CHALLENGES_WET_BECOME_HOMELESS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "ba4e595e-da3b-4902-8622-40889fc088db"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "8dbc1b53-2a9d-4477-978f-00ad7a700367",
+                    "Name": "UI_CHALLENGES_WET_GET_TEST_FLYER_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Get_Flyer.jpg",
+                    "Description": "UI_CHALLENGES_WET_GET_TEST_FLYER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "Targets": ["918de690-aff2-41cc-acdd-e1ebb3953a9d"],
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.Targets"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a73e93a2-1bc4-4890-a102-62f961dbeb74",
+                    "Name": "UI_CHALLENGES_RAT_EXIT_ROOFTOP_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Exit_Rooftop_Door.jpg",
+                    "Description": "UI_CHALLENGES_RAT_EXIT_ROOFTOP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "5b9f6976-7ccf-46fd-97b4-e145403c9b0b"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "aa4982db-045c-47d0-aabb-42b86a0714fb",
+                    "Name": "UI_CHALLENGES_RAT_LADDER_A_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_ladder_a.jpg",
+                    "Description": "UI_CHALLENGES_RAT_LADDER_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Rat_Ladder_A_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "ae1348f0-d9c5-46c7-b5b4-a476b122dca0",
+                    "Name": "UI_CHALLENGES_WET_BECOME_CHEFF_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Become_DumplingCheff.jpg",
+                    "Description": "UI_CHALLENGES_WET_BECOME_CHEFF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "c5f6dd2a-3600-40be-9a82-bbf5d360c379"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "b1cdf7bc-7606-43d2-b322-bd8eab819094",
+                    "Name": "UI_CHALLENGES_RAT_EXIT_MANHOLE_A_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Exit_Manhole_A.jpg",
+                    "Description": "UI_CHALLENGES_RAT_EXIT_MANHOLE_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": [
+                                                        "abfe62f7-e359-45ef-804f-354c3209be3e",
+                                                        "ddecb62c-70bb-4417-8863-1656af5e345c"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "bae5445d-3fdf-415d-be64-dce39f713162",
+                    "Name": "UI_CHALLENGES_WET_ACCES_DONGLE_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_acces_dongle.jpg",
+                    "Description": "UI_CHALLENGES_WET_ACCES_DONGLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CollectOneAccedDongle": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "c35ba257-a3f1-4bc1-9dab-2c92cd2fda4e",
+                    "Name": "UI_CHALLENGES_WET_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Area_Discovered.jpg",
+                    "Description": "UI_CHALLENGES_WET_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 29
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_WET_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "de516526-5f5d-4b31-967c-7f2c565123ef",
+                    "Name": "UI_CHALLENGES_WET_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_WET_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "86bdb741-6810-4610-8e21-799c93c71849",
+                                "ba4e595e-da3b-4902-8622-40889fc088db",
+                                "c5f6dd2a-3600-40be-9a82-bbf5d360c379",
+                                "fd1d39d8-db06-47b3-8f4b-eb1febf5ccb7",
+                                "9c07a86c-2d03-417b-b46f-cb433481080e",
+                                "8fc343f2-6e9a-4e06-9342-705e5b171895",
+                                "553bb399-2ee0-41bb-a76b-b7ec6d49f5a3",
+                                "4dd90d10-ac5f-404f-9c20-4428653ca7ba",
+                                "9cd5fbd7-903c-4ab7-afe8-01eb755ce9da",
+                                "b3515a1e-4a32-475c-bd61-4fdae243a7e5",
+                                "f5c73d58-a24f-4957-b80d-5efb6771ad9b"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "1a68c357-02a0-40a2-99e7-73d76ec5095d",
+                    "Name": "UI_CHALLENGES_RAT_NOSAFTY_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_NoSafty.jpg",
+                    "Description": "UI_CHALLENGES_RAT_NOSAFTY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "NOSAFTY_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "29573c7e-26af-4022-9336-398cc7d7533c",
+                    "Name": "UI_CHALLENGES_RAT_MINDDISTRACTION_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_MindDestraction.jpg",
+                    "Description": "UI_CHALLENGES_RAT_MINDDISTRACTION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MINDDESTRACTION_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "2fa0eb6e-2efd-4cd7-b953-1d3284043c13",
+                    "Name": "UI_CHALLENGES_RAT_PACIFY_BUST_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Pacify_Buste.jpg",
+                    "Description": "UI_CHALLENGES_RAT_PACIFY_BUST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "3b964eaf-fde2-41d9-9211-af8e16f25a56",
+                            "Item": "c86ce2f4-7bd1-4949-acc4-54e5428d9396"
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "$.Item"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "3c82b9cf-6872-4fae-b5c2-05309ac9c7e6",
+                    "Name": "UI_CHALLENGES_RAT_HAIRSOUP_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_HairSoup.jpg",
+                    "Description": "UI_CHALLENGES_RAT_HAIRSOUP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Actorsick": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.actor_R_ID",
+                                            "a2429d84-2b78-42c4-a88d-82b8984ca92d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "a2429d84-2b78-42c4-a88d-82b8984ca92d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "9d316f01-7701-41b8-a9bb-153908768168"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "4a9e4c2a-f73c-42bc-ac8b-673225972097",
+                    "Name": "UI_CHALLENGES_RAT_MISSIONSTORY_THEMEETUP_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_MS_TheMeetup.jpg",
+                    "Description": "UI_CHALLENGES_RAT_MISSIONSTORY_THEMEETUP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "98265e5a-00ad-4189-b49e-b3ebf47798f8"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "a4d7e3ba-f6d0-4b07-8833-80dce85de017",
+                    "Name": "UI_CHALLENGES_RAT_PACIFY_TANK_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Pacify_Tank.jpg",
+                    "Description": "UI_CHALLENGES_RAT_PACIFY_TANK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "Targets": [
+                                "18e6ca13-0cdd-46f8-a129-ef554c586671",
+                                "401af328-85e2-415c-acee-43dab42e3722",
+                                "07923f4a-01d0-46b8-85ec-8cba445dd3a0",
+                                "965fdd6f-6aab-4743-9416-9831306bea48",
+                                "3743c0c9-06de-4422-84f9-8ad2f2f0f511",
+                                "f61656ed-c51a-448b-a772-aad7dbe7f36f",
+                                "cb7b9923-0098-4336-8bff-6ca0d5d46440",
+                                "9cfd6570-9538-4750-8994-f5807b4016e9",
+                                "6927fbc1-8cbb-4c7a-9098-0b041fe120df"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "ce8e7099-e60d-47e8-bfd6-4918777f2c8b"
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": "$.Targets"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "a9f1014c-def7-486c-8669-9d37a02f607f",
+                    "Name": "UI_CHALLENGES_RAT_PACIFY_POST_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Pacify_Post.jpg",
+                    "Description": "UI_CHALLENGES_RAT_PACIFY_POST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "2cad6321-fc52-4f71-a484-e47d57774c70",
+                            "Item": "bad168bb-3629-42b3-bc57-604b03a81d30"
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "$.Item"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "b10d37d7-b39e-4d05-ada3-a0c73982e354",
+                    "Name": "UI_CHALLENGES_RAT_KILLTHEPAST_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_KillThePast.jpg",
+                    "Description": "UI_CHALLENGES_RAT_KILLTHEPAST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "KILLINGTHEPAST_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "c5d02359-0ae2-4ea2-93fb-f3a57b948934",
+                    "Name": "UI_CHALLENGES_RAT_PACIFY_UMBRELLA_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Pacify_Umbrella.jpg",
+                    "Description": "UI_CHALLENGES_RAT_PACIFY_UMBRELLA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "b1d9d1db-44df-44ad-99df-356fff777697",
+                            "Item": "e98f44fd-7f36-46a8-ae3c-bf080e8454d3"
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "$.Item"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "d2facde9-f262-4efb-91aa-6ff4d0c4cda2",
+                    "Name": "UI_CHALLENGES_RAT_MISSIONSTORY_TESTSUBJECT_NAME",
+                    "ImageName": "images/challenges/Wet/RAT_MS_TestSubject.jpg",
+                    "Description": "UI_CHALLENGES_RAT_MISSIONSTORY_TESTSUBJECT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "165fee0e-f109-4578-9954-bdf87e4da32e"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "d99aa484-510b-41e6-954f-3e7d07d4b46e",
+                    "Name": "UI_CHALLENGES_RAT_DRONE_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_Drones.jpg",
+                    "Description": "UI_CHALLENGES_RAT_DRONE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DRONE_DESTROYED": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "e8bb700d-faff-4d1d-8877-6a57659b1cd9",
+                    "Name": "UI_CHALLENGES_RAT_PACIFY_UMBRELLA_2X_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Pacify_Umbrella_2x.jpg",
+                    "Description": "UI_CHALLENGES_RAT_PACIFY_UMBRELLA_2X_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 2
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "b1d9d1db-44df-44ad-99df-356fff777697"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "e98f44fd-7f36-46a8-ae3c-bf080e8454d3"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "e944126c-362c-44af-822c-a8d496835936",
+                    "Name": "UI_CHALLENGES_RAT_BREAKSIGNAL_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_BreakSignal.jpg",
+                    "Description": "UI_CHALLENGES_RAT_BREAKSIGNAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BREAKSIGNAL_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "f250b65d-b1d5-4c20-944c-d419ba570cc7",
+                    "Name": "UI_CHALLENGES_RAT_MISSIONSTORY_THECONTROLLER_NAME",
+                    "ImageName": "images/challenges/Wet/RAT_MS_TheController.jpg",
+                    "Description": "UI_CHALLENGES_RAT_MISSIONSTORY_THECONTROLLER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "d741f698-c08c-4760-891c-44e34b2ce2d3"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "f95db3ac-e1b9-40a9-9af9-50454c9b2de2",
+                    "Name": "UI_CHALLENGES_RAT_MAINTENANCE_NAME",
+                    "ImageName": "images/challenges/Wet/Rat_Maintenance.jpg",
+                    "Description": "UI_CHALLENGES_RAT_MAINTENANCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MAINTENANCE_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "2aa7bbe6-f3eb-4355-88de-378253aedab9",
+                    "Name": "UI_CHALLENGE_AZALEA_L3_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_PerfectDesert.jpg",
+                    "Description": "UI_CHALLENGE_AZALEA_L3_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "SecondaryObjecviveComplete": "false"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FEEDDESERT": {
+                                    "$set": [
+                                        "SecondaryObjecviveComplete",
+                                        "true"
+                                    ]
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.SecondaryObjecviveComplete",
+                                            "true"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "344077c5-9235-4f31-98fc-bf837d655a72",
+                    "Name": "UI_CONTRACT_AZALEA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "ce31f5de-18ae-42a3-8b6a-c94a0aa3e4f9",
+                                "OrderIndex": 1025,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_GLUTTONY_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_GLUTTONY_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "sins",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "6acd4acf-8835-46df-afb8-3bff9a2527e4"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "3b4f2a93-f2c4-4919-90b2-429f21826422",
+                    "Name": "UI_CHALLENGE_AZALEA_FEED_MUFFIN_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_Muffin.jpg",
+                    "Description": "UI_CHALLENGE_AZALEA_FEED_MUFFIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FEEDMUFFIN": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "54fc63f8-2ac4-47bc-892b-282fd6561143",
+                    "Name": "UI_CONTRACT_AZALEA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_ItemReward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 4,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "ddaf38de-2ad3-467d-bdd0-2f6b13cd3f51"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_POISON_SEDATIVE_GUM_GLUTTONY_NAME",
+                            "Id": "PROP_POISON_SEDATIVE_GUM_GLUTTONY",
+                            "Type": "gear",
+                            "Subtype": "poison",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ec5cd7a4-7c5f-4244-9d26-f8c9e734dd92"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "d4f6e560-cf9f-4a0a-955d-787577b073d6"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_HERO_SHOTGUN_SAWED_OFF_GLUTTONY_NAME",
+                            "Id": "FIREARMS_HERO_SHOTGUN_SAWED_OFF_GLUTTONY",
+                            "Type": "weapon",
+                            "Subtype": "shotgun",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "815729cf-2df7-4850-9de6-9da5c7434b11"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "d3f078c4-9644-4e83-9e5d-dd2942b5a032"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "689c6319-c8a3-4483-b27b-e6ac9cb7c876",
+                    "Name": "UI_CHALLENGE_AZALEA_FEED_BUST_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_Cowboy.jpg",
+                    "Description": "UI_CHALLENGE_AZALEA_FEED_BUST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FEEDBUST": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "c91b1a86-4166-4909-a1b4-99c805ef1b4c",
+                    "Name": "UI_CHALLENGE_AZALEA_L2_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_PerfectMainCourse.jpg",
+                    "Description": "UI_CHALLENGE_AZALEA_L2_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "SecondaryObjecviveComplete": "false"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FEEDMAINCOURSE": {
+                                    "$set": [
+                                        "SecondaryObjecviveComplete",
+                                        "true"
+                                    ]
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.SecondaryObjecviveComplete",
+                                            "true"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "d12e5eac-bb63-4d0c-83ac-66a31c22f053",
+                    "Name": "UI_CONTRACT_AZALEA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_Complete.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "28554a75-1e86-46f7-ae1c-638d76295566"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "fab1c0ec-c9c1-4a3a-b46e-f25e175d7b9a",
+                    "Name": "UI_CHALLENGE_AZALEA_L1_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Azalea_PerfectAppetite.jpg",
+                    "Description": "UI_CHALLENGE_AZALEA_L1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "SecondaryObjecviveComplete": "false"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FEEDAPPETITE": {
+                                    "$set": [
+                                        "SecondaryObjecviveComplete",
+                                        "true"
+                                    ]
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.SecondaryObjecviveComplete",
+                                            "true"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["5121acde-313d-4517-ae70-6a54ca5d775a"]
+                    }
+                },
+                {
+                    "Id": "4a069dc0-ab87-4368-895e-aa8a754c24b9",
+                    "Name": "UI_CHALLENGE_MAKOYANA_ALLDISOBEDIENT_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Makoyana_Challenge_AllDisobedient.jpg",
+                    "Description": "UI_CHALLENGE_MAKOYANA_ALLDISOBEDIENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ALLDISOBEDIENT": {
+                                    "Transition": "CheckContract"
+                                }
+                            },
+                            "CheckContract": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "4d0e0458-1aba-4017-a3bd-629cfdac3916"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["494d97a6-9e31-45e0-9dae-f3793c731336"]
+                    }
+                },
+                {
+                    "Id": "64d170ac-fb8b-4d73-a861-a74e5f775585",
+                    "Name": "UI_CHALLENGE_MAKOYANA_ALLOBEDIENT_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Makoyana_Challenge_AllObedient.jpg",
+                    "Description": "UI_CHALLENGE_MAKOYANA_ALLOBEDIENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ALLOBEDIENT": {
+                                    "Transition": "CheckContract"
+                                }
+                            },
+                            "CheckContract": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "4d0e0458-1aba-4017-a3bd-629cfdac3916"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["494d97a6-9e31-45e0-9dae-f3793c731336"]
+                    }
+                },
+                {
+                    "Id": "a3f5c9a5-ea3d-4dad-ba89-0dae94bb8f30",
+                    "Name": "UI_CONTRACT_MAKOYANA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Makoyana_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "c4fe3a20-f62a-4154-ae91-7d163d5b99fd",
+                                "OrderIndex": 1022,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_PRIDE_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_PRIDE_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "sins",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3c15e0ac-d31a-4ba5-8f55-c4b6f0e43b90"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["494d97a6-9e31-45e0-9dae-f3793c731336"]
+                    }
+                },
+                {
+                    "Id": "bb480187-eefb-4dfe-bbc9-0728b999be46",
+                    "Name": "UI_CONTRACT_MAKOYANA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Makoyana_ItemReward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "f9d471fc-a3d0-49bd-8e2d-af7fb8cedf6f"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_SNIPER_PRIDE_NAME",
+                            "Id": "FIREARMS_SNIPER_PRIDE",
+                            "Type": "weapon",
+                            "Subtype": "sniperrifle",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "4dfab684-d350-42d0-9e26-e32849024628"
+                        },
+                        {
+                            "Properties": {
+                                "LoadoutSlot": "carriedweapon",
+                                "Rarity": "common",
+                                "RepositoryId": "5b28437f-e440-40e0-ba77-426c1ee9fe0c",
+                                "Quality": "2",
+                                "UnlockOrder": 5
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_MELEE_PRIDE_SABER_NAME",
+                            "Id": "PROP_MELEE_PRIDE_SABER",
+                            "Type": "weapon",
+                            "Subtype": "melee",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "6917fa5b-da39-487c-a923-28defaec63c7"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "605ccf31-14b3-42d1-b2ff-22710fc87168"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["494d97a6-9e31-45e0-9dae-f3793c731336"]
+                    }
+                },
+                {
+                    "Id": "c98c6fab-8238-49ef-a486-89cf5d638914",
+                    "Name": "UI_CHALLENGE_MAKOYANA_MIXED_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Makoyana_Challenge_MixedEnding.jpg",
+                    "Description": "UI_CHALLENGE_MAKOYANA_MIXED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MIXEDENDING": {
+                                    "Transition": "CheckContract"
+                                }
+                            },
+                            "CheckContract": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "4d0e0458-1aba-4017-a3bd-629cfdac3916"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["494d97a6-9e31-45e0-9dae-f3793c731336"]
+                    }
+                },
+                {
+                    "Id": "ffa8d1da-e1df-4979-a02f-49d00f1d4ff0",
+                    "Name": "UI_CONTRACT_MAKOYANA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Makoyana.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "4d0e0458-1aba-4017-a3bd-629cfdac3916"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["494d97a6-9e31-45e0-9dae-f3793c731336"]
+                    }
+                },
+                {
+                    "Id": "438a98d0-4dc7-4270-931e-de40ff66d3fb",
+                    "Name": "UI_CONTRACT_MAGNOLIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Magnolia.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "84299364-8abf-467d-a4dc-eb71ba578e7a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["542108f2-f82f-4a04-bfec-efa92785fec1"]
+                    }
+                },
+                {
+                    "Id": "4e1a5d26-ea56-45e6-95ee-7614a58dcdda",
+                    "Name": "UI_CONTRACT_GINSENG_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Ginseng_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "628fc47d-db6d-4522-b50a-514f5dafb419",
+                                "OrderIndex": 1003,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_CHINESE_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_CHINESE_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "deluxe",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "6b9992fe-fbec-4d59-a7dc-369e402aed0e"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["84bf03cc-3055-4fd4-a691-d8b0ac61a51f"]
+                    }
+                },
+                {
+                    "Id": "95787436-b6be-4e29-a992-e8d7e882a63c",
+                    "Name": "UI_CONTRACT_GINSENG_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wet_Ginseng.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 3,
+                                "LoadoutSlot": "gear",
+                                "IsContainer": true,
+                                "Rarity": "common",
+                                "RepositoryId": "7ef0c49f-a5dc-421e-abe9-c94fe17ea0f9",
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_CONTAINER_SUITCASE_CHINESE_NAME",
+                            "Id": "PROP_CONTAINER_SUITCASE_CHINESE",
+                            "Type": "gear",
+                            "Subtype": "container",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "e489e01c-bf57-4b12-970c-2cd8f9a5b718"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "559d8002-9dc5-4da7-ab54-18c8ad20f047"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_SNIPER_CHINESE_DRAGON_NAME",
+                            "Id": "FIREARMS_SNIPER_CHINESE_DRAGON",
+                            "Type": "weapon",
+                            "Subtype": "sniperrifle",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "52200631-dacb-4f29-92e7-90c65603daf5"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "699ae3bf-1c0a-479c-b150-5ef90a2ccc2c"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["84bf03cc-3055-4fd4-a691-d8b0ac61a51f"]
+                    }
+                },
+                {
+                    "Id": "af1cd7e8-3ea3-4ab4-9252-30df7841f731",
+                    "Name": "UI_CHALLENGES_WET_PACIFY_HAMMER_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Pacify_Hammer.jpg",
+                    "Description": "UI_CHALLENGES_WET_PACIFY_HAMMER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_WET_RAT",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "HitmanIsInBlock": false
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$.HitmanIsInBlock",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "3c24c96a-557c-472a-9d71-1a235d7383a7"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.ActorType",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "HitmanBlock"
+                                            ]
+                                        },
+                                        "$set": ["HitmanIsInBlock", true]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "HitmanOutsideBlock"
+                                            ]
+                                        },
+                                        "$set": ["HitmanIsInBlock", false]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "09675ea9-4cf3-4b80-a722-329b8e48e687",
+                    "Name": "UI_CHALLENGES_RAT_ELIMINATE_HUSH_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_Hush.jpg",
+                    "Description": "UI_CHALLENGES_RAT_ELIMINATE_HUSH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "967abcf9-2672-4e81-8fef-211aaa366747"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "37454687-1888-4b38-ae3e-6c210ac0c5ef",
+                    "Name": "UI_CHALLENGES_RAT_ELIMINATE_ARCHIVIST_NAME",
+                    "ImageName": "images/challenges/Wet/Wet_Rat_TheArchivist.jpg",
+                    "Description": "UI_CHALLENGES_RAT_ELIMINATE_ARCHIVIST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "a7fd7a4f-2bee-4787-bc60-90f9dd64233b"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "0af3980d-6bcb-42f6-ac4c-d0241606500a",
+                    "Name": "UI_CHALLENGES_RAT_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_RAT_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "b6a3ae7c-dbd3-45ac-bb47-e413ac5ac232",
+                    "Name": "UI_CHALLENGES_RAT_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_RAT_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "sniper", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "ba5b886b-393c-42e0-8f2b-e335d89d5ef5",
+                    "Name": "UI_CHALLENGES_RAT_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_RAT_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "cba9f315-1e45-45a1-997a-15ed7743449d",
+                    "Name": "UI_CHALLENGES_RAT_SILENT_ASSASSIN_SUIT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_RAT_SILENT_ASSASSIN_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "suitonly", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                },
+                {
+                    "Id": "ea96b5e9-2f1c-4b64-ae99-6c086f3623a1",
+                    "Name": "UI_CHALLENGES_RAT_BIG4_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_RAT_BIG4_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0af3980d-6bcb-42f6-ac4c-d0241606500a",
+                                "cba9f315-1e45-45a1-997a-15ed7743449d",
+                                "b6a3ae7c-dbd3-45ac-bb47-e413ac5ac232",
+                                "ba5b886b-393c-42e0-8f2b-e335d89d5ef5"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["3d0cbb8c-2a80-442a-896b-fea00e98768c"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "a5efa667-0078-4873-bf4d-28df3d3973a4",
+                    "Name": "UI_STRAWBERRY_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Strawberry_Group.jpg",
+                    "Description": "UI_STRAWBERRY_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["dd68d30f-3900-415f-bb17-84681a2cd4fc"]
+                    }
+                },
+                {
+                    "Id": "6a9d724e-5e37-40e4-8c51-1c1387157806",
+                    "Name": "UI_TANGELO_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Tangelo_Group.jpg",
+                    "Description": "UI_TANGELO_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_WET",
+                    "ParentLocationId": "LOCATION_PARENT_WET",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["9cbdb972-95df-4e0a-be77-7937ec6f2fb0"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/COLORADO/_COLORADO_CHALLENGES.json
+++ b/contractdata/COLORADO/_COLORADO_CHALLENGES.json
@@ -4791,6 +4791,28 @@
             "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
             "Challenges": [
                 {
+                    "Id": "a5a2dfca-9c78-4720-9bdb-173bb441e1da",
+                    "Name": "UI_HONEYDEW_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Honeydew_Group.jpg",
+                    "Description": "UI_HONEYDEW_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["ff5b4e53-49ea-4d85-b94e-d3c8b3fc7ab3"]
+                    }
+                },
+                {
                     "Id": "873cb734-e1f5-43b5-ac5c-0fbf406fe5bc",
                     "Name": "UI_PEAR_COMPLETION_CHALLENGE_NAME",
                     "ImageName": "images/contracts/arcade/Arcade_Pear_Group.jpg",

--- a/contractdata/DARTMOOR/_DARTMOOR_CHALLENGES.json
+++ b/contractdata/DARTMOOR/_DARTMOOR_CHALLENGES.json
@@ -1,0 +1,5822 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_ANCESTRAL"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "150f0c8a-34a7-4bdf-8d92-97915c8ac64d",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_EMMA_KILL_NAME",
+                    "ImageName": "images/challenges/Ancestral/emma_kill_alexa.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_EMMA_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "EmmaPoison": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EmmaPoisonGlass": {
+                                    "$set": ["EmmaPoison", true]
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "080efb03-a66a-401e-b6df-4eac496e9e2d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "cd0769a7-ff21-450c-8fcc-91ac5982b036"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [true, "$.EmmaPoison"]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "1e8c63e8-ddc7-4c2d-aa70-81f70bed2a1e",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_PHOTO_SHOOT_NAME",
+                    "ImageName": "images/challenges/Ancestral/photo_electrocution_kill.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_PHOTO_SHOOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaEliminatePhotoShootElectro": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "b0e74a9f-a799-49e7-86be-a7839b3b5375",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_CHANDELIER_NAME",
+                    "ImageName": "images/challenges/Ancestral/chandelier_kill.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_CHANDELIER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "080efb03-a66a-401e-b6df-4eac496e9e2d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_suspended_object"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "0f10f4d2-e959-4505-9d2d-5d04ff39c6bf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "d4bc65ff-7853-4547-b7bb-2ac6b4e97e7b"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "bae028b7-3128-4602-89fa-4141bdd6e32e",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_GRAVE_NAME",
+                    "ImageName": "images/challenges/Ancestral/grave_kill.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_GRAVE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaEliminateGrave": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "c32e5117-e29a-41e4-86e4-847caa1d4685",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_ROOF_SNIPER_NAME",
+                    "ImageName": "images/challenges/Ancestral/roof_kill.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_ROOF_SNIPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OnRoofChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "OnRoof"
+                                }
+                            },
+                            "OnRoof": {
+                                "OnRoofChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "d8ec36c0-a38e-4855-b098-c04363899a37",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_PRIVATE_ROOM_NAME",
+                    "ImageName": "images/challenges/Ancestral/alexa_eliminate_private_room.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_ELIMINATE_PRIVATE_ROOM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaEliminatePrivateRoom": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "3c702493-da33-4f54-aff7-95d382fa8cf0",
+                    "Name": "UI_CHALLENGE_SMOOTHSNAKE_FLOWERPOWER_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake_FlowerPOwer.jpg",
+                    "Description": "UI_CHALLENGE_SMOOTHSNAKE_FLOWERPOWER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Gameplay": {
+                                    "range": 0.5,
+                                    "damage": 0.6,
+                                    "clipsize": 0.2,
+                                    "rateoffire": 0.6
+                                },
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "concealedweapon",
+                                "RepositoryId": "2dfacef2-57f6-4b8d-a1ae-f1f7ada4ec22",
+                                "UnlockOrder": 10
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_HERO_PISTOL_FLOWERBALLER_NAME",
+                            "Id": "FIREARMS_HERO_PISTOL_FLOWERBALLER",
+                            "Type": "weapon",
+                            "Subtype": "pistol",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "fae2f769-6532-4319-a9a6-c0d971314e3a"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "GardenShredder": false,
+                            "GardenFork": false,
+                            "GardenShears": false
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$.GardenShredder",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "InCloset"
+                                                            ]
+                                                        },
+                                                        "in": "$Value.DamageEvents"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": ["GardenShredder", true]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$.GardenFork",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "1a105af8-fd30-447f-8b2c-f908f702e81c"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": ["GardenFork", true]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$.GardenShears",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "42c7bb52-a71b-489c-8a74-7db0c09ba313"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": ["GardenShears", true]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ]
+                            },
+                            "CheckCount": {
+                                "-": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Transition": "Start"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "6dd88c76-bae6-408e-9e92-6e96a3a9da8c",
+                    "Name": "UI_CHALLENGE_SMOOTHSNAKE_MIGRATINGCOCONUTS_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake_MigratingCoconuts.jpg",
+                    "Description": "UI_CHALLENGE_SMOOTHSNAKE_MIGRATINGCOCONUTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "20bed705-9f0f-4a3e-ad07-2a7ef3938868"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "b5cc4963-4027-4bcf-a660-ff5d28c7f964",
+                    "Name": "UI_CHALLENGE_SMOOTHSNAKE_DANGERDANGER_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake_DangerDanger.jpg",
+                    "Description": "UI_CHALLENGE_SMOOTHSNAKE_DANGERDANGER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "TargetsKilled": []
+                        },
+                        "ContextListeners": {
+                            "TargetsKilled": {
+                                "type": "challengecounter",
+                                "count": "($.TargetsKilled).Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "accident_electric"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "$Value.KillMethodBroad",
+                                                            "$Value.KillMethodStrict"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "TargetsKilled",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.TargetsKilled).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "ff861061-b0d6-437d-a2a1-d7678a45e786",
+                    "Name": "UI_CHALLENGE_SMOOTHSNAKE_HOLYMOLY_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake_HolyMoly.jpg",
+                    "Description": "UI_CHALLENGE_SMOOTHSNAKE_HOLYMOLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Cornelia_Close_And_Bomb_Ready"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Cornelia_Not_Close_Or_Bomb_Not_Ready"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "14cedf30-b652-4095-8904-f265da1d6571"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "0cf902df-f594-4593-b1d9-f81745d7cb7e",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_1_JOGGER_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level1_Jogger.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_1_JOGGER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "ThisContractId": "64d93c47-bcc0-400c-8b8a-e97ff14e94d2"
+                        },
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ded52369-4237-4c96-9f62-122f580eb281"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$ContractId",
+                                                    "$.ThisContractId"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "60bb3987-c9b8-4695-8b00-8bf51ade9d3d",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_2_JOGGER_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level2_Jogger.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_2_JOGGER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "ThisContractId": "135bb8a1-1b8f-4f43-8f8a-6eebf72d86e7"
+                        },
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ded52369-4237-4c96-9f62-122f580eb281"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$ContractId",
+                                                    "$.ThisContractId"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "9c78888a-8b1e-43c7-bb29-e7b9926069a0",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_3_JOGGER_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level3_Jogger.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_3_JOGGER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "ThisContractId": "b8201747-5bb5-47d4-9a9b-1bd851317206"
+                        },
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ded52369-4237-4c96-9f62-122f580eb281"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$ContractId",
+                                                    "$.ThisContractId"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "23f22844-b059-4c20-9a03-26ac5d988916",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "a4b0c440-a115-4cc7-85d3-25f938951e1e",
+                                "d0af296c-6b89-41bf-9334-a781f77aee4d",
+                                "45b6d37b-e1ac-4eb8-bdbf-23353babe867",
+                                "7d505b21-61ac-409a-90ba-52675a58a81f",
+                                "c1e05d69-c196-4690-87d0-740703eed22a"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "45b6d37b-e1ac-4eb8-bdbf-23353babe867",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "7d505b21-61ac-409a-90ba-52675a58a81f",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "a4b0c440-a115-4cc7-85d3-25f938951e1e",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "c1e05d69-c196-4690-87d0-740703eed22a",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "d0af296c-6b89-41bf-9334-a781f77aee4d",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "43186811-5dab-4378-be8d-3e742eac6159",
+                    "Name": "UI_CHALLENGES_BULLDOG_FIND_TOKENS_NAME",
+                    "ImageName": "images/challenges/Ancestral/find_tokens.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_FIND_TOKENS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TokensFound": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "f472f020-f43f-4b6e-9167-43bb9f648612",
+                    "Name": "UI_CHALLENGES_BULLDOG_MURDER_CLUES_NAME",
+                    "ImageName": "images/challenges/Ancestral/murder_clues.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_MURDER_CLUES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ButlerRoomCluesFound": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "RebeckaRoomCluesFound": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "EmmaGregoryRoomCluesFound": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "GreenHouseClueFound": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "ZacharyRoomClueFound": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "043708ab-5cfd-4fa1-a33e-05367c0323bc",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_EXIT_RIVER_NAME",
+                    "ImageName": "images/challenges/Ancestral/exit_river.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_EXIT_RIVER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "bead6735-25c9-4583-90e2-d60be03ec797"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "09cd0cd9-3492-4d2e-b1fd-cbc0fad0c224",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_OBTAIN_UNICORN_NAME",
+                    "ImageName": "images/challenges/Ancestral/obtain_unicorn.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_OBTAIN_UNICORN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "58769c58-3e70-4746-be8e-4c7114f8c2bb"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "1c68a4fa-9c88-497c-890c-f4a9911ac517",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_MASTER_KEY_NAME",
+                    "ImageName": "images/challenges/Ancestral/master_key.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_MASTER_KEY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CollectOneMansionKey": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "23ff6a96-6540-4f24-9bd2-a62c3580ab8e",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_LADDER_A_NAME",
+                    "ImageName": "images/challenges/Ancestral/Bulldog_ladder_a.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_LADDER_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Bulldog_Ladder_A_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "2ec0098f-8bce-4955-919e-d50c634d18a1",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_BECOME_PI_NAME",
+                    "ImageName": "images/challenges/Ancestral/disguise_PI.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_BECOME_PI_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "12f5bdb5-7e71-4f48-9740-13d0211f48c6"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "3f582c37-9ff1-4d8e-a3af-45233d62b28d",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Ancestral/Ancestral_Area_Discovered_Bulldog.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 22
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_ANCESTRAL_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "86231583-c587-4183-bb30-dd5cb6620aa4",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "12f5bdb5-7e71-4f48-9740-13d0211f48c6",
+                                "dc3c386d-52c2-4e17-855d-6c15e080ccf3",
+                                "ffb2e3a8-728b-4a54-95cb-55eaf616b422",
+                                "7062bd6b-4926-4ab3-932c-de7d63c095b7",
+                                "c3349736-91d1-48e3-bc62-fc16a7d8d6f1",
+                                "29389af2-4fe4-4f72-917a-d9747adc0f3d",
+                                "4115e440-fdf8-44d2-a3ba-a1bb2285e542",
+                                "88246749-2118-2101-5575-991052571240"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "87d616bc-37d9-47ef-8efd-01b621e5a54c",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_LADDER_B_NAME",
+                    "ImageName": "images/challenges/Ancestral/Bulldog_ladder_b.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_LADDER_B_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Bulldog_Ladder_B_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "8ac39695-2569-4116-afdb-79f15110c798",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_CANE_NAME",
+                    "ImageName": "images/challenges/Ancestral/cane.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_CANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CaneUsed": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "9337f5e7-9807-459d-bb65-522279578595",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_BECOME_PHOTOGRAPHER_NAME",
+                    "ImageName": "images/challenges/Ancestral/disguise_photographer.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_BECOME_PHOTOGRAPHER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "7062bd6b-4926-4ab3-932c-de7d63c095b7"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "98c21d0e-838f-4823-8c8d-3174ba66ebaa",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_EXIT_BOAT_NAME",
+                    "ImageName": "images/challenges/Ancestral/exit_boat.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_EXIT_BOAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "00602c6d-053f-474f-b82d-7cb13396f977"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "abc08e47-e3b8-403b-8b23-452a1a79e69a",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_OBTAIN_CANE_NAME",
+                    "ImageName": "images/challenges/Ancestral/obtain_cane.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_OBTAIN_CANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "4eede7ee-582b-49a4-b438-2418d82671d9"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "bd763a08-6632-4eec-bc65-19755bd05b26",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_BECOME_LAWYER_NAME",
+                    "ImageName": "images/challenges/Ancestral/disguise_lawyer.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_BECOME_LAWYER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "ffb2e3a8-728b-4a54-95cb-55eaf616b422"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "c5247978-7dcd-4cb7-99b3-06ac5c8da679",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_OBTAIN_SHOTGUN_NAME",
+                    "ImageName": "images/challenges/Ancestral/obtain_shotgun.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_OBTAIN_SHOTGUN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShotgunPickUp": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "ecc36639-9783-472c-ac4f-a56cb7070d0a",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_EXIT_DEFAULT_NAME",
+                    "ImageName": "images/challenges/Ancestral/exit_default.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_EXIT_DEFAULT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "d40d28d2-1ebf-48b6-9eba-57bc3ed36bc7"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "7256c470-23f6-445b-a6ef-027fc1b6ab84"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f45f9c18-6a07-44f5-9c96-c7a6c6120153",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_BECOME_UNDERTAKER_NAME",
+                    "ImageName": "images/challenges/Ancestral/disguise_Undertaker.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_BECOME_UNDERTAKER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "dc3c386d-52c2-4e17-855d-6c15e080ccf3"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f6442042-0b1e-4dab-82da-f2f0dc4f67b8",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_EXIT_HEARSE_NAME",
+                    "ImageName": "images/challenges/Ancestral/exit_hearse.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_EXIT_HEARSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "6ba50216-dd5b-49e1-a05d-5e01827560d8"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "12e2d93c-1433-429f-a802-32e611a7ba64",
+                    "Name": "UI_CHALLENGES_BULLDOG_CASE_FILE_NAME",
+                    "ImageName": "images/challenges/Ancestral/case_file.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_CASE_FILE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "6402fd8f-adcf-42c5-adba-49b9bed22c64"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "27cd912c-ded0-4f41-81fa-3fa7418feebd",
+                    "Name": "UI_CHALLENGES_BULLDOG_PHOTO_COWORKER_NAME",
+                    "ImageName": "images/challenges/Ancestral/coworker_photo.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_PHOTO_COWORKER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CoWorkerPhoto": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "3d47f287-79a4-490f-ba21-f11355ab4a45",
+                    "Name": "UI_CHALLENGES_BULLDOG_UNDERTAKER_PRESENTATION_NAME",
+                    "ImageName": "images/challenges/Ancestral/undertaker_presentation.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_UNDERTAKER_PRESENTATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "UndertakerPresentation": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "4e5fd70b-6712-48d2-9349-979798f6c91d",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_PEEP_NAME",
+                    "ImageName": "images/challenges/Ancestral/alexa_peep.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_PEEP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaPeepHole": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "66ec6cbf-3995-4413-85f3-fa5a13bf11f5",
+                    "Name": "UI_CHALLENGES_BULLDOG_EMMA_DID_IT_NAME",
+                    "ImageName": "images/challenges/Ancestral/murder_ms_emma.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_EMMA_DID_IT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaThinksEmmaDidIt": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "8099674b-df64-45b0-a08d-4e5711c17adb",
+                    "Name": "UI_CHALLENGES_BULLDOG_FAMILY_GATHERING_NAME",
+                    "ImageName": "images/challenges/Ancestral/family_gathering.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_FAMILY_GATHERING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FamilyGathering": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "882e9ecb-1149-47f4-bf82-7173f0c3cf4a",
+                    "Name": "UI_CHALLENGES_BULLDOG_EDWARD_PIANO_NAME",
+                    "ImageName": "images/challenges/Ancestral/edward_piano.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_EDWARD_PIANO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PlayingPianoChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "PlayingPiano"
+                                }
+                            },
+                            "PlayingPiano": {
+                                "PlayingPianoChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Pacify": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "0fee1154-c66b-41e1-b504-897374cfdaff"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "8d93dcbe-7606-4ae2-97c2-a520f5e3e7b1",
+                    "Name": "UI_CHALLENGES_BULLDOG_MISSIONSTORY_PHOTO_NAME",
+                    "ImageName": "images/challenges/ancestral/ms_photo.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_MISSIONSTORY_PHOTO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "dcdf2ec2-64f2-493d-80ea-641f32a53794"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "8fbd09c1-7f2a-431e-b375-4f4bd9f85245",
+                    "Name": "UI_CHALLENGES_BULLDOG_GREGORY_NEWS_NAME",
+                    "ImageName": "images/challenges/Ancestral/gregory_news.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_GREGORY_NEWS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "445ef39d-ba5c-4e62-a9ca-02a2f5ade4ce"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "a96cdbd8-9657-416a-87bf-d2ed21840794"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "94614058-7c77-43c4-8372-72662738aa8b",
+                    "Name": "UI_CHALLENGES_BULLDOG_PATRICK_POOL_NAME",
+                    "ImageName": "images/challenges/Ancestral/patrick_pool.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_PATRICK_POOL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "02bdd2c2-4311-4d62-a699-fa4ee07fc55f"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "95d1c5bd-72de-4236-97c0-b96fc5d92fa8"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "9cd0871b-370a-4b86-a6db-effee4061be5",
+                    "Name": "UI_CHALLENGES_BULLDOG_MISSIONSTORY_MURDER_NAME",
+                    "ImageName": "images/challenges/ancestral/ms_murder.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_MISSIONSTORY_MURDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "81a84bc1-3219-4f40-8f42-7c49de5166f7"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "ab57920c-c6a3-41d5-8635-a506eba035d1",
+                    "Name": "UI_CHALLENGES_BULLDOG_ZACHARY_DID_IT_NAME",
+                    "ImageName": "images/challenges/Ancestral/murder_ms_zachary.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ZACHARY_DID_IT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaThinksZacharyDidIt": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "aeafaa50-f7c8-4050-9cee-79da752789ee",
+                    "Name": "UI_CHALLENGES_BULLDOG_MISSIONSTORY_BURIAL_NAME",
+                    "ImageName": "images/challenges/ancestral/ms_burial.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_MISSIONSTORY_BURIAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "0da56b6a-5462-4bec-8721-d36ab91cf4d6"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "bef1189e-1c84-412e-b4f8-e744e6ab990f",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_LOST_MONEY_NAME",
+                    "ImageName": "images/challenges/Ancestral/alexa_lost_money.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_LOST_MONEY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "InspectComputer": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "c599655f-2e8f-4c06-bd30-efc244ae326d",
+                    "Name": "UI_CHALLENGES_BULLDOG_RING_BELL_NAME",
+                    "ImageName": "images/challenges/Ancestral/ring_bell.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_RING_BELL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaReactsToBell": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "cac34adb-56ca-4ed1-86d8-14620f31d46e",
+                    "Name": "UI_CHALLENGES_BULLDOG_BUTLER_DID_IT_NAME",
+                    "ImageName": "images/challenges/Ancestral/murder_ms_butler.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_BUTLER_DID_IT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaThinksButlerDidIt": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "cb560351-229a-4b03-b127-743c5bc89bf5",
+                    "Name": "UI_CHALLENGES_BULLDOG_PHOTOGRAPHER_FAMILY_PHOTO_NAME",
+                    "ImageName": "images/challenges/Ancestral/photographer_family_photo.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_PHOTOGRAPHER_FAMILY_PHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PhotographerFamilyPhoto": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "dcfc8dde-dfa0-4d0a-876a-336e97ff0c3d",
+                    "Name": "UI_CHALLENGES_BULLDOG_ALEXA_PHOTO_NAME",
+                    "ImageName": "images/challenges/Ancestral/alexa_photo.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ALEXA_PHOTO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AlexaPhotoZachary": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "2695fba3-b843-460d-b084-0df72d618b0e",
+                    "Name": "UI_CONTRACT_HOLLYHOCK_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Hollyhock_All_Complete.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "08989af9-8270-4875-9dbe-af068cce2ba0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["8e95dcd0-704f-4121-8be6-088a3812f838"]
+                    }
+                },
+                {
+                    "Id": "2f1c51d1-9ac5-4e7b-acb5-8e000482db91",
+                    "Name": "UI_CONTRACT_HOLLYHOCK_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Hollyhock_Level1_Start.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "e57564ba-d3e4-455b-bc1b-d0b64352c0d3",
+                                "OrderIndex": 1027,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_WRATH_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_WRATH_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "sins",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "81117d9f-4bdb-4e77-b556-31bd0b3432a2"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["8e95dcd0-704f-4121-8be6-088a3812f838"]
+                    }
+                },
+                {
+                    "Id": "450621fb-6590-49af-b440-7e3293d9033f",
+                    "Name": "UI_CONTRACT_HOLLYHOCK_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Hollyhock_Level1_Complete.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 2,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "637a7b20-39b1-48c6-9908-8fb628488262"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_DEVICE_PROXIMITY_FLASH_WRATH_NAME",
+                            "Id": "PROP_DEVICE_PROXIMITY_FLASH_WRATH",
+                            "Type": "gear",
+                            "Subtype": "explosive",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ce87bdf2-1374-46c9-a62a-f2d91dcb9382"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "74562c61-4405-413f-8d69-353688942390"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_HERO_RIFLE_SHASKA_A33_WRATH_NAME",
+                            "Id": "FIREARMS_HERO_RIFLE_SHASKA_A33_WRATH",
+                            "Type": "weapon",
+                            "Subtype": "assaultrifle",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "2205e6a0-e176-4907-8d67-04abddf420a3"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "2b6f918f-079e-46b4-9ee0-bcceee3a7362"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["8e95dcd0-704f-4121-8be6-088a3812f838"]
+                    }
+                },
+                {
+                    "Id": "7e8761f6-32b3-498d-ae12-286c50852579",
+                    "Name": "UI_CHALLENGE_HOLLYHOCK_LEVEL2_TOPFLOOR_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Hollyhock_Level2_No_Access.jpg",
+                    "Description": "UI_CHALLENGE_HOLLYHOCK_LEVEL2_TOPFLOOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EXTRACTORREACHTOPFLOOR": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "0a25518e-3b06-4e01-b619-6d3bb814523f"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["8e95dcd0-704f-4121-8be6-088a3812f838"]
+                    }
+                },
+                {
+                    "Id": "9c13cfe2-7b3f-4ece-b07c-3692c924fd17",
+                    "Name": "UI_CHALLENGE_HOLLYHOCK_LEVEL3_TOPFLOOR_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Hollyhock_Level3_No_Access.jpg",
+                    "Description": "UI_CHALLENGE_HOLLYHOCK_LEVEL3_TOPFLOOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EXTRACTORREACHTOPFLOOR": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "08989af9-8270-4875-9dbe-af068cce2ba0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["8e95dcd0-704f-4121-8be6-088a3812f838"]
+                    }
+                },
+                {
+                    "Id": "ff9990b8-19fe-452a-8255-f4fc87fdc9b1",
+                    "Name": "UI_CHALLENGE_HOLLYHOCK_LEVEL1_TOPFLOOR_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Hollyhock_Level1_No_Access.jpg",
+                    "Description": "UI_CHALLENGE_HOLLYHOCK_LEVEL1_TOPFLOOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EXTRACTORREACHTOPFLOOR": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "2b6f918f-079e-46b4-9ee0-bcceee3a7362"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["8e95dcd0-704f-4121-8be6-088a3812f838"]
+                    }
+                },
+                {
+                    "Id": "3c1b1cce-5626-48e2-a157-446097b95c6a",
+                    "Name": "UI_CHALLENGE_SMOOTHSNAKE_DETERMINED_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake_Determined.jpg",
+                    "Description": "UI_CHALLENGE_SMOOTHSNAKE_DETERMINED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "1ad1ec9b-1e96-4fac-b0e6-8817a46da9db",
+                                "OrderIndex": 610,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_FLAMINGO_ELUSIVE_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_FLAMINGO_ELUSIVE_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "casual",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "d4a84131-aabc-48b9-9849-979280aa8ff8"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "DeterministicMode": {
+                                    "Transition": "CheckCompletion"
+                                }
+                            },
+                            "CheckCompletion": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f7ad71b6-9553-4d58-86dc-e3e288849849"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "3ecd3c26-abf7-4420-846c-f733397860cd",
+                    "Name": "UI_CHALLENGE_SMOOTHSNAKE_FROGETESCAPING_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake_FrogetEscaping.jpg",
+                    "Description": "UI_CHALLENGE_SMOOTHSNAKE_FROGETESCAPING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "SetPiece": "",
+                            "Goal": 4
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FrogCaught": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "77d27d10-72f6-4014-ba5d-1171916873e2",
+                    "Name": "UI_CHALLENGE_SMOOTHSNAKE_VOYEURIST_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake_Voyeurist.jpg",
+                    "Description": "UI_CHALLENGE_SMOOTHSNAKE_VOYEURIST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "KissPhoto": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "d1b90b5a-9d21-461f-83ce-ec7b40d7fa1a",
+                    "Name": "UI_CONTRACT_SMOOTHSNAKE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SmoothSnake.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Location": "LOCATION_PARENT_ANCESTRAL",
+                                "RepositoryId": "45ae9b57-9fd1-497f-ad53-78e8523b3a7a",
+                                "UnlockOrder": 16
+                            },
+                            "Rarity": null,
+                            "DisplayNameLocKey": "UI_STARTING_LOCATION_ANCESTRAL_SMOOTHSNAKE_FRONTMANSION_SUIT_B_NAME",
+                            "Id": "STARTING_LOCATION_ANCESTRAL_SMOOTHSNAKE_FRONTMANSION_SUIT_B",
+                            "Type": "access",
+                            "Subtype": "startinglocation",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "d95f5e6b-bcb6-466f-8209-01e1a98ade9b"
+                        },
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "99ab8f84-6488-4362-ab6a-9e7343128f15",
+                                "OrderIndex": 622,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_SUMMER_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_SUMMER_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "casual",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "dc587469-6f70-460c-8745-bc605b8e0d1a"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f7ad71b6-9553-4d58-86dc-e3e288849849"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5680108a-19dc-4448-9344-3d0290217162"]
+                    }
+                },
+                {
+                    "Id": "2d9f974b-8523-49a6-b4bd-4f3657c1dc21",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_1_TIER_2_SA_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level1_Tier2.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_1_TIER_2_SA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Vitality": 1,
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Constants": {
+                            "Goal": 50
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "VitalityChanged": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["Vitality", "$Value"]
+                                        }
+                                    }
+                                ],
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$ContractId",
+                                                        "64d93c47-bcc0-400c-8b8a-e97ff14e94d2"
+                                                    ]
+                                                },
+                                                {
+                                                    "$ge": ["$.Vitality", "50"]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "3ddc1bbe-c835-46f3-9328-0f87576edc4f",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_3_TIER_2_SA_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level3_Tier2.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_3_TIER_2_SA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Vitality": 1,
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Constants": {
+                            "Goal": 50
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "VitalityChanged": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["Vitality", "$Value"]
+                                        }
+                                    }
+                                ],
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$ContractId",
+                                                        "b8201747-5bb5-47d4-9a9b-1bd851317206"
+                                                    ]
+                                                },
+                                                {
+                                                    "$ge": ["$.Vitality", "30"]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "44ec0754-91a5-4899-9f37-4a2d522389b4",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_3_TIER_1_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level3_Tier1.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_3_TIER_1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Vitality": 1
+                        },
+                        "Constants": {
+                            "Goal": 30
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VitalityChanged": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["Vitality", "$Value"]
+                                        }
+                                    }
+                                ],
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$ContractId",
+                                                        "b8201747-5bb5-47d4-9a9b-1bd851317206"
+                                                    ]
+                                                },
+                                                {
+                                                    "$ge": ["$.Vitality", "30"]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "90c4915f-9c87-4810-aeef-38507fa80d7f",
+                    "Name": "UI_CHALLENGES_HAREBELL_START_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level1_Start.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_START_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "22a2ba57-09ab-4147-a6e7-aa6a319b72fa",
+                                "OrderIndex": 1023,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_SLOTH_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_SLOTH_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "sins",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "b6b25326-02dc-4f45-8577-72b3c317b9f6"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "9e15a399-1bea-4ad8-946e-b91f67dc698f",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_2_TIER_2_SA_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level2_Tier2.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_2_TIER_2_SA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Vitality": 1,
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Constants": {
+                            "Goal": 50
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "VitalityChanged": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["Vitality", "$Value"]
+                                        }
+                                    }
+                                ],
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$ContractId",
+                                                        "135bb8a1-1b8f-4f43-8f8a-6eebf72d86e7"
+                                                    ]
+                                                },
+                                                {
+                                                    "$ge": ["$.Vitality", "50"]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "a72ae9da-2bf4-413f-aa00-968b0c5b6633",
+                    "Name": "UI_CHALLENGES_HAREBELL_COMPLETE_ALL_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Complete.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_COMPLETE_ALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "b8201747-5bb5-47d4-9a9b-1bd851317206"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "e551ed25-7b47-4606-8725-e39bf2b36e7b",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_1_TIER_1_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level1_Tier1.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_1_TIER_1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Vitality": 1
+                        },
+                        "Constants": {
+                            "Goal": 50
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VitalityChanged": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["Vitality", "$Value"]
+                                        }
+                                    }
+                                ],
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$ContractId",
+                                                        "64d93c47-bcc0-400c-8b8a-e97ff14e94d2"
+                                                    ]
+                                                },
+                                                {
+                                                    "$ge": ["$.Vitality", "50"]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "f919f8ee-1e8e-40cb-9946-2f880008a8cf",
+                    "Name": "UI_CHALLENGES_HAREBELL_LEVEL_2_TIER_1_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level2_Tier1.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_LEVEL_2_TIER_1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Vitality": 1
+                        },
+                        "Constants": {
+                            "Goal": 50
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VitalityChanged": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["Vitality", "$Value"]
+                                        }
+                                    }
+                                ],
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$ContractId",
+                                                        "135bb8a1-1b8f-4f43-8f8a-6eebf72d86e7"
+                                                    ]
+                                                },
+                                                {
+                                                    "$ge": ["$.Vitality", "50"]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "f97e751b-2f85-4cb1-8657-5966e09a172a",
+                    "Name": "UI_CHALLENGES_HAREBELL_COMPLETE_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell_Level1_Complete.jpg",
+                    "Description": "UI_CHALLENGES_HAREBELL_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 3,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "09c37e1a-c2b3-4dba-9e26-50fac96d3f65",
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_DEVICE_AUDIO_SEDATIVE_MINE_SLOTH_NAME",
+                            "Id": "PROP_DEVICE_AUDIO_SEDATIVE_MINE_SLOTH",
+                            "Type": "gear",
+                            "Subtype": "explosive",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "0934d125-9305-4b31-bd70-e6c2b4f9fd6d"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "concealedweapon",
+                                "RepositoryId": "f6d61543-405b-411f-b0c7-a5befc1c62cd",
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_HERO_SMG_DAKX2_COVERT_SLOTH_NAME",
+                            "Id": "FIREARMS_HERO_SMG_DAKX2_COVERT_SLOTH",
+                            "Type": "weapon",
+                            "Subtype": "smg",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "214aaec0-8136-420a-8d4b-72dca5f480ef"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "64d93c47-bcc0-400c-8b8a-e97ff14e94d2"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
+                    }
+                },
+                {
+                    "Id": "c195f240-a233-4aa1-b974-f0f3747f2a02",
+                    "Name": "UI_CONTRACT_SNAKESHEAD_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_SnakesHead.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "77bcec76-323d-4e1e-bd0e-bf6d777c3745"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["b12d08ea-c842-498a-82ea-889653588592"]
+                    }
+                },
+                {
+                    "Id": "14acdbfd-57b6-48b9-9146-c5fa6741a06a",
+                    "Name": "UI_CONTRACT_FERN_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Fern.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 3,
+                                "LoadoutSlot": "gear",
+                                "IsContainer": true,
+                                "Rarity": "common",
+                                "RepositoryId": "7185b682-6c9d-4684-9b5d-d25c336f5cbd",
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_CONTAINER_SUITCASE_HUNTING_NAME",
+                            "Id": "PROP_CONTAINER_SUITCASE_HUNTING",
+                            "Type": "gear",
+                            "Subtype": "container",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "d35c95ae-6909-4306-a188-d7bc5e376240"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "6696a10d-9138-4184-8104-a6c7ec2e0eb1"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_HUNTING_SHOTGUN_REWARD_DELUXE_NAME",
+                            "Id": "HUNTING_SHOTGUN_REWARD_DELUXE",
+                            "Type": "weapon",
+                            "Subtype": "shotgun",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "6156b229-97c8-4382-9ce5-1250e5ae88c5"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f893555c-c0f6-4630-ba67-66e4cbea0017"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["4689ef5e-0ddd-44b3-adca-aebf3293d9e1"]
+                    }
+                },
+                {
+                    "Id": "aeedf125-a5aa-485b-ad76-f80eadad439b",
+                    "Name": "UI_CONTRACT_FERN_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Fern_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "ae7358ae-ac6d-4217-b86e-efffde5b90dd",
+                                "OrderIndex": 1002,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_HUNTING_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_HUNTING_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "deluxe",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "05b43f65-6fc4-4a19-bed8-f65aae543ad5"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["4689ef5e-0ddd-44b3-adca-aebf3293d9e1"]
+                    }
+                },
+                {
+                    "Id": "43768065-b552-411e-bb6e-74650b0ccf48",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_BIRDS_LEAVE_NAME",
+                    "ImageName": "images/challenges/Ancestral/birds_leave.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_BIRDS_LEAVE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BirdsLeave": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "4c51d754-e921-46da-ac26-c4862ae5d575",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_FHAMMERLY_AFFAIR_NAME",
+                    "ImageName": "images/challenges/Ancestral/Ancestral_Fhammerly_Affair.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_FHAMMERLY_AFFAIR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "c4747fa2-4958-4a02-926e-3b069cf218dc",
+                                "Quality": "1"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_MELEE_MODERN_HAMMER_NAME",
+                            "Id": "PROP_MELEE_MODERN_HAMMER",
+                            "Type": "weapon",
+                            "Subtype": "melee",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "97128ab7-e6ad-46f8-b32c-ba3fe17735fc"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "Targets": [
+                                "3ee70c86-8407-44bd-9927-3002d265a3a2",
+                                "02bdd2c2-4311-4d62-a699-fa4ee07fc55f",
+                                "445ef39d-ba5c-4e62-a9ca-02a2f5ade4ce",
+                                "bce38660-1554-425b-8a00-749b70b61015",
+                                "0fee1154-c66b-41e1-b504-897374cfdaff"
+                            ]
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$remove": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$inarray": {
+                                                        "in": "$.Targets",
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "$or": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "3c24c96a-557c-472a-9d71-1a235d7383a7"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "c4747fa2-4958-4a02-926e-3b069cf218dc"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Transition": "Start"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "6e649619-3923-4bfc-a8e6-4c6f6b48e605",
+                    "Name": "UI_CHALLENGES_ANCESTRAL_GREENHOUSE_POISON_NAME",
+                    "ImageName": "images/challenges/Ancestral/greenhouse_poison.jpg",
+                    "Description": "UI_CHALLENGES_ANCESTRAL_GREENHOUSE_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "4fce92ac-b4c3-4dc5-9545-742af597db7e"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "1524234b-6f85-426d-92d6-a2dc6d42cfbd",
+                    "Name": "UI_CHALLENGES_BULLDOG_ELIMINATE_ALEXA_NAME",
+                    "ImageName": "images/challenges/Ancestral/Ancestral_Bulldog_Eliminate_Alexa.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_ELIMINATE_ALEXA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "080efb03-a66a-401e-b6df-4eac496e9e2d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "647278f4-e20f-4c42-8a8b-5d2cf30591c0",
+                    "Name": "UI_CHALLENGES_BULLDOG_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "682fe23c-5d0a-414c-8b88-cb4472856a1b",
+                    "Name": "UI_CHALLENGES_BULLDOG_SILENT_ASSASSIN_SUIT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_SILENT_ASSASSIN_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "suitonly", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "8628936a-497d-4838-b5ee-a720babf440d",
+                    "Name": "UI_CHALLENGES_BULLDOG_BIG4_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_BIG4_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "c4f0976d-ecda-4ae0-80e2-ff4e074177cf",
+                                "682fe23c-5d0a-414c-8b88-cb4472856a1b",
+                                "d794359b-9537-40ec-9591-f24627766bb4",
+                                "647278f4-e20f-4c42-8a8b-5d2cf30591c0"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "c4f0976d-ecda-4ae0-80e2-ff4e074177cf",
+                    "Name": "UI_CHALLENGES_BULLDOG_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                },
+                {
+                    "Id": "d794359b-9537-40ec-9591-f24627766bb4",
+                    "Name": "UI_CHALLENGES_BULLDOG_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_BULLDOG_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "sniper", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["755984a8-fb0b-4673-8637-95cfe7d34e0f"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "eed5d4b4-f850-4c7d-8a3e-8194721a6aea",
+                    "Name": "UI_FIG_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Fig_Group.jpg",
+                    "Description": "UI_FIG_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["80cf04de-8e0b-4f38-b094-600753e2ac24"]
+                    }
+                },
+                {
+                    "Id": "d8738000-1c18-427f-b59c-c71220bafbd0",
+                    "Name": "UI_JACKFRUIT_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Jackfruit_Group.jpg",
+                    "Description": "UI_JACKFRUIT_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["85a67f31-75ce-40f5-a281-7765791f58ca"]
+                    }
+                },
+                {
+                    "Id": "9f43f915-1320-4ce9-86a2-12df8d60c35e",
+                    "Name": "UI_BANANA_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Banana_Group.jpg",
+                    "Description": "UI_BANANA_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["bfb56fe6-06db-440a-aafe-42eeeb223fa1"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/DUBAI/_DUBAI_CHALLENGES.json
+++ b/contractdata/DUBAI/_DUBAI_CHALLENGES.json
@@ -1,0 +1,4207 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_GOLDEN"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "02eed2d0-872d-4c42-a813-f7083686a8c1",
+                    "Name": "UI_CHALLENGES_GECKO_INGRAM_EAT_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Ingram_Eat_Poison.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_INGRAM_EAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EAT_POISON_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "0e6504a4-730c-4ed3-8233-fd261f1cce60",
+                    "Name": "UI_CHALLENGES_GECKO_STUYVESANT_LEDGE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Stuyvesant_Ledge.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_STUYVESANT_LEDGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9571d196-8d67-4d94-8dad-6e2d970d7a91"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_push"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "191a1382-5f12-422b-a835-0f72b461ffa4",
+                    "Name": "UI_CHALLENGES_GECKO_INGRAM_GOLF_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Ingram_Golf.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_INGRAM_GOLF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GOLF_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "231142e0-9b72-4e9d-b5cd-1cb5c0990df7",
+                    "Name": "UI_CHALLENGES_GECKO_INGRAM_OILRIG_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Ingram_Oilrig.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_INGRAM_OILRIG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "bd0689d6-07b4-4757-b8ee-cac19f1c9e16",
+                            "SetPiece": "b843321d-41cc-4c32-8799-439e6ea111d6"
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "bb06171f-1a3a-4536-ad55-eb81ef53137c",
+                    "Name": "UI_CHALLENGES_GECKO_STUYVESEANT_CHANDELIER_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Chandelier.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_STUYVESEANT_CHANDELIER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "SetPieces": [
+                                "5bd6749c-5050-4d2a-9d6c-b1fc208357f6",
+                                "afb3dabf-8a0c-44af-b8d1-c2fd4a5113ff",
+                                "3afa842d-9e19-480a-830d-726d2b28b0e6"
+                            ],
+                            "Targets": [
+                                "9571d196-8d67-4d94-8dad-6e2d970d7a91",
+                                "bd0689d6-07b4-4757-b8ee-cac19f1c9e16"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "5bd6749c-5050-4d2a-9d6c-b1fc208357f6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "afb3dabf-8a0c-44af-b8d1-c2fd4a5113ff"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "3afa842d-9e19-480a-830d-726d2b28b0e6"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.5
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "5bd6749c-5050-4d2a-9d6c-b1fc208357f6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "afb3dabf-8a0c-44af-b8d1-c2fd4a5113ff"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "3afa842d-9e19-480a-830d-726d2b28b0e6"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "e1c076ea-ea74-410d-b569-9ea2ac243a02",
+                    "Name": "UI_CHALLENGES_GECKO_DOUBLE_PARACHUTE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Double_Parachute.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_DOUBLE_PARACHUTE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DOUBLE_PARACHUTE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "ea32c9f3-b89f-46ad-a1c7-c52e2e537640",
+                    "Name": "UI_CHALLENGES_GECKO_DOUBLE_SNIPE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Double_Snipe.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_DOUBLE_SNIPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Targets": [
+                                "9571d196-8d67-4d94-8dad-6e2d970d7a91",
+                                "bd0689d6-07b4-4757-b8ee-cac19f1c9e16"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.5
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "f3b42e19-14a2-4047-b2d8-f8dadaa65dac",
+                    "Name": "UI_CHALLENGES_GECKO_INGRAM_LEDGE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Ingram_Ledge.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_INGRAM_LEDGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "bd0689d6-07b4-4757-b8ee-cac19f1c9e16"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_push"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "fb713f85-98ed-448e-ada6-5c7623f975b9",
+                    "Name": "UI_CHALLENGES_GECKO_STUYVESANT_SUN_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Stuyvesant_Sun.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_STUYVESANT_SUN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "9571d196-8d67-4d94-8dad-6e2d970d7a91",
+                            "SetPiece": "2bc99e54-d786-4ed4-8204-ca35b6e02472"
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "12707489-b886-4d73-ba44-cbe4630c87f0",
+                    "Name": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "19937e00-0633-4ca2-9b10-abc9f8c31929",
+                    "Name": "UI_CHALLENGES_GOLDEN_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "d65b6412-e2e2-4f2c-8a68-b6ff8423574e",
+                                "5779a9e0-7ce5-4a12-980c-18a72409694b",
+                                "e4b787b9-80ca-4864-957e-e432cbf9b133",
+                                "c6b5a25c-adf8-468e-a282-93135a2bcbbe",
+                                "12707489-b886-4d73-ba44-cbe4630c87f0"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "5779a9e0-7ce5-4a12-980c-18a72409694b",
+                    "Name": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "c6b5a25c-adf8-468e-a282-93135a2bcbbe",
+                    "Name": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "d65b6412-e2e2-4f2c-8a68-b6ff8423574e",
+                    "Name": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "e4b787b9-80ca-4864-957e-e432cbf9b133",
+                    "Name": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "0d160e0a-99ad-4ec3-9865-30d8da8076df",
+                    "Name": "UI_CHALLENGES_GOLDEN_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Area_Discovered_Gecko.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 33
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_GOLDEN_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "10aea755-8148-4a45-a04f-c9f87cd7b0b5",
+                    "Name": "UI_CHALLENGES_GOLDEN_WINDOWSHUTTER_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_windowshutter.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_WINDOWSHUTTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 6
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "WindowShutter_Event_01": false,
+                            "WindowShutter_Event_02": false,
+                            "WindowShutter_Event_03": false,
+                            "WindowShutter_Event_04": false,
+                            "WindowShutter_Event_05": false,
+                            "WindowShutter_Event_06": false
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "Hit",
+                        "States": {
+                            "Start": {
+                                "WindowShutter_Event_01": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.WindowShutter_Event_01",
+                                                false
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "WindowShutter_Event_01",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "WindowShutter_Event_02": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.WindowShutter_Event_02",
+                                                false
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "WindowShutter_Event_02",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "WindowShutter_Event_03": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.WindowShutter_Event_03",
+                                                false
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "WindowShutter_Event_03",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "WindowShutter_Event_04": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.WindowShutter_Event_04",
+                                                false
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "WindowShutter_Event_04",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "WindowShutter_Event_05": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.WindowShutter_Event_05",
+                                                false
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "WindowShutter_Event_05",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "WindowShutter_Event_06": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.WindowShutter_Event_06",
+                                                false
+                                            ]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "WindowShutter_Event_06",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ]
+                            },
+                            "CheckCount": {
+                                "-": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Transition": "Start"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "292b0a5d-897b-4f6e-b4f8-7160cc98aa81",
+                    "Name": "UI_CHALLENGES_GOLDEN_BECOME_PILOT_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_become_pilot.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_BECOME_PILOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "ea5b1cea-c305-4f60-9512-78b2e6cd5030"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "319d9198-336b-4739-b218-7794f4433f06",
+                    "Name": "UI_CHALLENGES_GOLDEN_LADDER_C_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_ladder_c.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_LADDER_C_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Gecko_Ladder_C_Down": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "3b579c45-4261-4b21-92f9-20b2e974aa5f",
+                    "Name": "UI_CHALLENGES_GOLDEN_BECOME_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_become_assassin.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_BECOME_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "ef9dddc5-25c7-450f-afcb-ac1b8f9569c9"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "400f3160-e140-4e62-95f7-246eac3a29ae",
+                    "Name": "UI_CHALLENGES_GOLDEN_GET_KEY_HELICOPTER_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_get_key_helicopter.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_GET_KEY_HELICOPTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "5d2ffdf1-9722-459c-9163-6b9ee3dc250f"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4a3120cc-403c-41a7-807c-767f8cfb80af",
+                    "Name": "UI_CHALLENGES_GOLDEN_LADDER_B_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_ladder_b.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_LADDER_B_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Gecko_Ladder_B_Down": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "5287dbe0-e7f7-494c-8933-37914429e3c5",
+                    "Name": "UI_CHALLENGES_GOLDEN_BECOME_GUARD_PENTHOUSE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_become_guard_penthouse.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_BECOME_GUARD_PENTHOUSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "f0a52fef-608a-4fa8-9fd6-bd5c15506188"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "576073f5-b0e6-42a6-afa8-370ba8048804",
+                    "Name": "UI_CHALLENGES_GOLDEN_BECOME_CHEF_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_become_chef.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_BECOME_CHEF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "6dcf16f6-6620-410f-b51c-179f75de938c"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "59e15298-993a-4675-ac8f-1b12192cbb52",
+                    "Name": "UI_CHALLENGES_GOLDEN_GET_SCIMITAR_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_get_scimitar.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_GET_SCIMITAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "b4d4ed1a-0687-48a9-a731-0e3b99494eb6"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "6a6d7281-d7b9-4723-a575-17048e7360c1",
+                    "Name": "UI_CHALLENGES_GOLDEN_BECOME_EVENTSTAFF_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_become_eventstaff.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_BECOME_EVENTSTAFF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "77fb4c80-0b81-4672-be65-12c16c3ac7ac"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "6c537401-4577-4b5e-b1f9-a0b3cbb645f6",
+                    "Name": "UI_CHALLENGES_GOLDEN_DOOR_A_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_door_a.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_DOOR_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Gecko_Door_A_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "7a745d38-e759-4b4d-973c-eebb0992cbb0",
+                    "Name": "UI_CHALLENGES_GOLDEN_EXIT_PARACHUTE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_exit_parachute.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_EXIT_PARACHUTE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "fc58abee-40e9-41b0-bf17-3b6caecfe5d9"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "962eb75c-3e2e-4d69-9d2a-1bf3d1e044b5",
+                    "Name": "UI_CHALLENGES_GOLDEN_EXIT_ELEVATOR_PENTHOUSE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_exit_elevator_penthouse.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_EXIT_ELEVATOR_PENTHOUSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "f00ad962-fd05-4a79-883e-f7326a249783"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "970b9ee9-760b-4479-9533-9516968f0e06",
+                    "Name": "UI_CHALLENGES_GOLDEN_GET_SKYSCRAPER_MODEL_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_get_skyscraper_model.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_GET_SKYSCRAPER_MODEL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "706cb615-e66d-49f3-86bb-899fa7117bcf"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a6a5a962-8e92-42a7-bd44-824610d7399f",
+                    "Name": "UI_CHALLENGES_GOLDEN_LADDER_A_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_ladder_a.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_LADDER_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Gecko_Ladder_A_Down": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "c02d4be1-8ec6-4201-bbc6-a8656009ac16",
+                    "Name": "UI_CHALLENGES_GOLDEN_EXIT_ELEVATOR_ATRIUM_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_exit_elevator_atrium.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_EXIT_ELEVATOR_ATRIUM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "07a71270-12ce-43a6-bd89-ff46cd196c6b"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "c4180ec8-5122-4e8f-8437-137c76094a41",
+                    "Name": "UI_CHALLENGES_GOLDEN_GET_KEY_PENTHOUSE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_get_key_penthouse.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_GET_KEY_PENTHOUSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "3e176a59-7be7-4b10-a62b-41b4206d0b19"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "edad7fec-e3d1-46a2-9104-5b6a4abd7834",
+                    "Name": "UI_CHALLENGES_GOLDEN_EXIT_ELEVATOR_STAFF_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_exit_elevator_staff.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_EXIT_ELEVATOR_STAFF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "32655e96-b404-4377-b6b5-923f33375c4a"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f99eb849-9397-41a7-bce3-6d2c8843cd75",
+                    "Name": "UI_CHALLENGES_GOLDEN_EXIT_HELICOPTER_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_exit_helicopter.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_EXIT_HELICOPTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "d3a63aaa-482a-4110-a430-366f096a8373"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "fb7a5bad-5478-46c0-ac6a-1810ad06ba37",
+                    "Name": "UI_CHALLENGES_GOLDEN_GET_KEYCARD_EVACUATION_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_get_keycard_penthouse.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_GET_KEYCARD_EVACUATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "091b69e6-be1f-461d-918c-a9ab554cfcca"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "fb827e24-c525-46b1-a9ef-fb4b503d073f",
+                    "Name": "UI_CHALLENGES_GOLDEN_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_GOLDEN_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GOLDEN_GECKO",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "ef9dddc5-25c7-450f-afcb-ac1b8f9569c9",
+                                "6dcf16f6-6620-410f-b51c-179f75de938c",
+                                "f0a52fef-608a-4fa8-9fd6-bd5c15506188",
+                                "77fb4c80-0b81-4672-be65-12c16c3ac7ac",
+                                "ea5b1cea-c305-4f60-9512-78b2e6cd5030",
+                                "a745ca17-3a7e-4c15-8219-6a5d6245ac7f",
+                                "eb12cc2b-6dcf-4831-ba4e-ef8e53180e2f",
+                                "e65f04b2-47a6-4d3d-b36c-9fb7fa08a00b",
+                                "eb15e523-713f-41ba-ad67-d33b02de43c6",
+                                "2c649c52-f85a-4b29-838a-31c2525cc862",
+                                "bdbd806d-eb11-4167-bd2d-f5f015c3fe86"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "0c668dd3-bd73-4246-adf0-87b4c8e38bda",
+                    "Name": "UI_CHALLENGES_GECKO_MISSIONSTORY_MEETTHESTUYVESANTS_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Meetthestuyvesants.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_MISSIONSTORY_MEETTHESTUYVESANTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MTS_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "5161ad7b-f2d3-4252-904e-3e890a2c782e",
+                    "Name": "UI_CHALLENGES_GECKO_EXIT_SKYDIVING_SUIT_NAME",
+                    "ImageName": "images/challenges/golden/Golden_Gecko_Exit_Skydiving_Suit.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_EXIT_SKYDIVING_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Outfit": "c4146f27-81a9-42ef-b3c7-87a9d60b87fe"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Outfit", "$Value"]
+                                    },
+                                    "Transition": "CorrectDisguise"
+                                }
+                            },
+                            "NotCorrectDisguise": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Outfit", "$Value"]
+                                    },
+                                    "Transition": "CorrectDisguise"
+                                }
+                            },
+                            "CorrectDisguise": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$eq": ["$.Outfit", "$Value"]
+                                        }
+                                    },
+                                    "Transition": "NotCorrectDisguise"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "5788a483-7e55-489d-983e-cc6dd93d840c",
+                    "Name": "UI_CHALLENGES_GECKO_PHOTO_REUNION_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Photo_Reunion.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_PHOTO_REUNION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PHOTO_REUNION_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "5c320a3c-1e6e-414d-93bc-79375bf999a8",
+                    "Name": "UI_CHALLENGES_GECKO_MISSIONSTORY_GUARD_NAME",
+                    "ImageName": "images/challenges/golden/Golden_Gecko_Guard.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_MISSIONSTORY_GUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "c52dc088-cc41-4313-a779-15b4bb3ed74a"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "69f36bdb-11f7-4f8a-a4de-aa66ea2a15eb",
+                    "Name": "UI_CHALLENGES_GECKO_MISSIONSTORY_GERONIMO_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Geronimo.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_MISSIONSTORY_GERONIMO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GERONIMO_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "816254fa-2117-4c12-b974-86da39e468cd",
+                    "Name": "UI_CHALLENGES_GECKO_HACK_SERVER_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Hack_server.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_HACK_SERVER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HACK_SERVER_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "830a9ba8-eaa9-4721-b8f3-af64873e32de",
+                    "Name": "UI_CHALLENGES_GECKO_SHEIKH_GOLDBAR_NAME",
+                    "ImageName": "images/challenges/golden/Golden_Gecko_Sheikh_Goldbar.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_SHEIKH_GOLDBAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "e1c8c0a5-a506-45b6-9567-7b6df50b8877",
+                            "Item": "4292fe64-aac6-4bbe-be73-31671640172a"
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "$.Item"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "99138591-57cf-4cae-b172-663c56608a3a",
+                    "Name": "UI_CHALLENGES_GECKO_PHOTO_SHEIKH_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Photo_Sheikh.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_PHOTO_SHEIKH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PHOTO_SHEIKH_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "a94223a3-b174-4bfc-868e-45dfbbe93b08",
+                    "Name": "UI_CHALLENGES_GECKO_MISSIONSTORY_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/golden/Golden_Gecko_Assassin.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_MISSIONSTORY_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "3e58ea63-c6f5-472d-a52f-d3875a92d196"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "aa97ac00-69b8-43a8-aa72-4e7e90fec778",
+                    "Name": "UI_CHALLENGES_GECKO_MISSIONSTORY_PEACE_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Peace.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_MISSIONSTORY_PEACE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PEACE_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "bc70c2d5-cc31-4430-a1a8-3964e76a9599",
+                    "Name": "UI_CHALLENGES_GECKO_MISSIONSTORY_GREY_NAME",
+                    "ImageName": "images/challenges/golden/Golden_Gecko_Grey.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_MISSIONSTORY_GREY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "6298d6c5-e512-4475-be6b-3ed7040b9f9d"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "c1525950-efcf-4628-a510-3675b698931d",
+                    "Name": "UI_CHALLENGES_GECKO_BANANA_FLIP_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Banana_Flip.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_BANANA_FLIP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "SetPiece": "62c0f1aa-41ba-45c0-800d-b6c34b98a544"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Ingram_In_Skydiving_Outfit_Event": {
+                                    "Transition": "Ingram_Banana_Slip"
+                                },
+                                "Marcus_In_Skydiving_Outfit_Event": {
+                                    "Transition": "Marcus_Banana_Slip"
+                                }
+                            },
+                            "Ingram_Banana_Slip": {
+                                "Marcus_In_Skydiving_Outfit_Event": {
+                                    "Transition": "Both_Banana_Slip"
+                                },
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "bd0689d6-07b4-4757-b8ee-cac19f1c9e16"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Marcus_Banana_Slip": {
+                                "Ingram_In_Skydiving_Outfit_Event": {
+                                    "Transition": "Both_Banana_Slip"
+                                },
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9571d196-8d67-4d94-8dad-6e2d970d7a91"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Both_Banana_Slip": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "df572610-9398-4a8a-9a36-093db44987f8",
+                    "Name": "UI_CHALLENGES_GECKO_MISSIONSTORY_WHISKY_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Whisky.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_MISSIONSTORY_WHISKY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "WHISKY_COMPLETE_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "ed0ca902-d722-4b4e-985e-cf41506b9230",
+                    "Name": "UI_CHALLENGES_GECKO_DUMP_ELEVATOR_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Dump_Elevator.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_DUMP_ELEVATOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DUMP_ELEVATOR_EVENT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "fa6513f3-c2e6-4452-9372-f332a7b35181",
+                    "Name": "UI_CONTRACT_ANGELICA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Golden_Angelica.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "d3ad9529-a962-4322-ab34-d890c2ce51c9"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["8885eeda-ad64-44fa-a944-1438b36c670c"]
+                    }
+                },
+                {
+                    "Id": "3ee0ad35-e6a5-4c00-85c5-dbae30a1c7fe",
+                    "Name": "UI_CONTRACT_LUNARIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Golden_Lunaria_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "39aea78e-02f7-4bd7-9dab-eb51691c7a7b",
+                                "OrderIndex": 1021,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_GREED_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_GREED_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "sins",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "2da79821-6d37-44b9-892e-1d64726c55c9"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["ae04c7a0-4028-4524-b27f-6a62f020fdca"]
+                    }
+                },
+                {
+                    "Id": "48969636-c3e0-4745-bfde-3905a6f00353",
+                    "Name": "UI_CONTRACT_LUNARIA_CASHINCHALL_03_NAME",
+                    "ImageName": "images/contracts/Escalation/ContractEscalation_Golden_Lunaria_HardChallenge.jpg",
+                    "Description": "UI_CONTRACT_LUNARIA_CASHIN_03_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "30Coins": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level3_COINS": {
+                                    "$set": ["30Coins", true]
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.30Coins"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ae04c7a0-4028-4524-b27f-6a62f020fdca"]
+                    }
+                },
+                {
+                    "Id": "67769495-e7ba-44ef-99d9-f6af5df87126",
+                    "Name": "UI_CONTRACT_LUNARIA_CASHINALL_NAME",
+                    "ImageName": "images/contracts/Escalation/ContractEscalation_Golden_Lunaria_AllChallenges.jpg",
+                    "Description": "UI_CONTRACT_LUNARIA_CASHINALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "AllCoins": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AllCoins": {
+                                    "$set": ["AllCoins", true]
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.AllCoins"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ae04c7a0-4028-4524-b27f-6a62f020fdca"]
+                    }
+                },
+                {
+                    "Id": "6853fb20-47fe-4e8d-9bf8-4caa3cf9a708",
+                    "Name": "UI_CONTRACT_LUNARIA_CASHINCHALL_02_NAME",
+                    "ImageName": "images/contracts/Escalation/ContractEscalation_Golden_Lunaria_MediumChallenge.jpg",
+                    "Description": "UI_CONTRACT_LUNARIA_CASHIN_02_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "20Coins": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level2_COINS": {
+                                    "$set": ["20Coins", true]
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.20Coins"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ae04c7a0-4028-4524-b27f-6a62f020fdca"]
+                    }
+                },
+                {
+                    "Id": "78d2c232-7997-4c0c-b802-0f76a59e9486",
+                    "Name": "UI_CONTRACT_LUNARIA_CASHINCHALL_01_NAME",
+                    "ImageName": "images/contracts/Escalation/ContractEscalation_Golden_Lunaria_EasyChallenge.jpg",
+                    "Description": "UI_CONTRACT_LUNARIA_CASHIN_01_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "10Coins": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level1_COINS": {
+                                    "$set": ["10Coins", true]
+                                },
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.10Coins"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ae04c7a0-4028-4524-b27f-6a62f020fdca"]
+                    }
+                },
+                {
+                    "Id": "9963f9fa-c31e-4341-b033-6e8f9729a401",
+                    "Name": "UI_CONTRACT_LUNARIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Golden_Lunaria.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "fecb5488-a31e-4eff-a08d-63d966ea96a2"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["ae04c7a0-4028-4524-b27f-6a62f020fdca"]
+                    }
+                },
+                {
+                    "Id": "b425b3f9-cd42-4ee8-afa8-5f77c825a924",
+                    "Name": "UI_CONTRACT_LUNARIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Golden_Lunaria_ItemReward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "AllowUpSync": true,
+                                "GameAssets": ["PROP_TOOL_GREED_COIN"],
+                                "RepositoryId": "2d5657ee-d467-4202-ada5-b00b7dc3bb76",
+                                "RepositoryAssets": [
+                                    "2d5657ee-d467-4202-ada5-b00b7dc3bb76",
+                                    "2d5657ee-d467-4202-ada5-b00b7dc3bb76",
+                                    "2d5657ee-d467-4202-ada5-b00b7dc3bb76"
+                                ]
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_TOOL_GREED_COIN_NAME",
+                            "Id": "PROP_TOOL_GREED_COIN",
+                            "Type": "gear",
+                            "Subtype": "distraction",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "bb9e2850-9b3c-43c4-9f00-b04d08825330"
+                        },
+                        {
+                            "Properties": {
+                                "LoadoutSlot": "carriedweapon",
+                                "Rarity": "common",
+                                "RepositoryId": "8f0931b1-3c3a-40e8-941b-70e85c04e580",
+                                "Quality": "2",
+                                "UnlockOrder": 5,
+                                "AllowUpSync": true,
+                                "OrderIndex": 660
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_MELEE_CANE_GREED_NAME",
+                            "Id": "PROP_MELEE_CANE_GREED",
+                            "Type": "weapon",
+                            "Subtype": "melee",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3f621aca-7f55-492e-85af-1569897d0844"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "d97d1485-e313-42c7-9d74-9efc9c1aab4e"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["ae04c7a0-4028-4524-b27f-6a62f020fdca"]
+                    }
+                },
+                {
+                    "Id": "75fe2134-b635-40a0-9d01-48e0927da93f",
+                    "Name": "UI_CONTRACT_SHEEPSSORREL_GROUP_TITLE",
+                    "ImageName": "images/contracts/Escalation/ContractEscalation_Golden_SheepsSorrel.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "65dfca6a-3e8e-434c-9ef5-817e5dc3380c"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["9448d91d-f7df-4b5a-8ea3-91f1233f644a"]
+                    }
+                },
+                {
+                    "Id": "8f4e820b-24d9-4c82-ae8a-e57984bf9de9",
+                    "Name": "UI_CONTRACT_DESERTROSE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Golden_Desert_Rose.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 3,
+                                "LoadoutSlot": "gear",
+                                "IsContainer": true,
+                                "Rarity": "common",
+                                "RepositoryId": "d5f7e973-fbd8-477e-a34e-37985bedd831",
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_CONTAINER_SUITCASE_GOLDEN_NAME",
+                            "Id": "PROP_CONTAINER_SUITCASE_GOLDEN",
+                            "Type": "gear",
+                            "Subtype": "container",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "7bafe179-89ad-478c-8197-c50492c0dca4"
+                        },
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "10f0653c-fe9c-4a43-98f1-18d20d18d9ab"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_SMG_TACTICAL_DAK_DTI_GOLD_COVERT_NAME",
+                            "Id": "FIREARMS_SMG_TACTICAL_DAK_DTI_GOLD_COVERT",
+                            "Type": "weapon",
+                            "Subtype": "smg",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "f3d166cd-c2a1-4b02-8c4a-828e4b8de0d2"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "0e05bd68-3c83-449a-9e71-542445bd46ec"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["89305766-199e-43eb-9fcb-29e6f2b6e9ab"]
+                    }
+                },
+                {
+                    "Id": "dfcca063-6e23-4e54-9bbe-53c23800c62f",
+                    "Name": "UI_CONTRACT_DESERTROSE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Golden_DesertRose_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "da1ce1bf-1d1b-4f49-9d0f-73d57f955606",
+                                "OrderIndex": 1001,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_GOLDEN_DEVIL_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_GOLDEN_DEVIL_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "deluxe",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "bd071ad9-82c4-4d5a-bcd3-2e5b17bd72e9"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["89305766-199e-43eb-9fcb-29e6f2b6e9ab"]
+                    }
+                },
+                {
+                    "Id": "768d0685-83f9-4e66-b0c8-c4a94e0c18ee",
+                    "Name": "UI_CONTRACT_VINE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Vine.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "bd6c00b1-e236-4730-a99b-3f8570e8d550"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a9dc4bf9-d277-4115-8dac-6c665cd68168"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "16b2d5e1-43a2-4cea-adf1-1d6af2fe8df6",
+                    "Name": "UI_CHALLENGES_GECKO_ELIMINATE_INGRAM_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Eliminate_Ingram.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_ELIMINATE_INGRAM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "bd0689d6-07b4-4757-b8ee-cac19f1c9e16"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "f84ab0c6-3a6b-4bea-8492-73dd00041308",
+                    "Name": "UI_CHALLENGES_GECKO_ELIMINATE_STUYVESANT_NAME",
+                    "ImageName": "images/challenges/Golden/Golden_Gecko_Eliminate_Stuyvesant.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_ELIMINATE_STUYVESANT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "9571d196-8d67-4d94-8dad-6e2d970d7a91"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "2694b2ff-224c-4bde-858d-1671a1dbc580",
+                    "Name": "UI_CHALLENGES_GECKO_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "sniper", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "40ba6b62-de82-4b94-ace9-c34917b36cc9",
+                    "Name": "UI_CHALLENGES_GECKO_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "53a17fb0-f6ef-449f-a346-ff0b52c918e7",
+                    "Name": "UI_CHALLENGES_GECKO_SILENT_ASSASSIN_SUIT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_SILENT_ASSASSIN_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "suitonly", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "b729d1b0-d5f1-4b9a-a922-d25e4c20b8aa",
+                    "Name": "UI_CHALLENGES_GECKO_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                },
+                {
+                    "Id": "df97f0ef-e91e-42b2-84ac-9d5f477ea50e",
+                    "Name": "UI_CHALLENGES_GECKO_BIG4_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_GECKO_BIG4_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GOLDEN",
+                    "ParentLocationId": "LOCATION_PARENT_GOLDEN",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "40ba6b62-de82-4b94-ace9-c34917b36cc9",
+                                "53a17fb0-f6ef-449f-a346-ff0b52c918e7",
+                                "2694b2ff-224c-4bde-858d-1671a1dbc580",
+                                "b729d1b0-d5f1-4b9a-a922-d25e4c20b8aa"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["7d85f2b0-80ca-49be-a2b7-d56f67faf252"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/FACILITY/_FACILITY_CHALLENGES.json
+++ b/contractdata/FACILITY/_FACILITY_CHALLENGES.json
@@ -1,0 +1,2782 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_ICA_FACILITY"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "0b0289de-73c9-42e5-8133-b2dbe46b454b",
+                    "Name": "UI_CHALLENGES_PROLOGUE_FIBERWIRE_KILL_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_fiberwire_kill.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_FIBERWIRE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3d25ee6c-61fa-4ba5-8f19-fedd905fd8fb"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "37f6512d-36e7-419a-a1b2-c0da87e6655f",
+                    "Name": "UI_CHALLENGES_PROLOGUE_TARGET_DROWN_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_target_drown.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_TARGET_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3d25ee6c-61fa-4ba5-8f19-fedd905fd8fb"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "228996e6-5fff-4f76-95de-484ee941c0ab",
+                    "Name": "UI_CHALLENGES_GRADUATION_DEATH_BYPROXY_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_death_byproxy.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_DEATH_BYPROXY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "IsKnightDied": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 5
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "579f2544-1970-4865-afa3-ad4566e5f98d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "0955e3c3-8b58-468f-81df-0e66ffbac677"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "KGB_Fix_Fuse"
+                                        ]
+                                    },
+                                    "Transition": "IsKnightDied"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "24806303-11f7-4c71-a3fc-412f8095726c",
+                    "Name": "UI_CHALLENGES_GRADUATION_THE_MECHANIC_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_the_mechanic.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_THE_MECHANIC_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "8f6ea4f1-32a8-4e57-a39d-90a2c2ff2bb0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "3f2bfeb7-4cb0-4a56-b37b-dd5768b04a03",
+                    "Name": "UI_CHALLENGES_GRADUATION_SEAT_EJECT_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_seat_eject.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_SEAT_EJECT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "579f2544-1970-4865-afa3-ad4566e5f98d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f41da13a-dd22-4cff-864d-0010609b8309"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "4be75ba3-4916-4660-9f5b-8f12b3250c7a",
+                    "Name": "UI_CHALLENGES_GRADUATION_DROWN_KILL_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_drown_kill.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_DROWN_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "579f2544-1970-4865-afa3-ad4566e5f98d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "5434404c-1db9-48d7-8f30-fbf0b342938a",
+                    "Name": "UI_CHALLENGES_GRADUATION_THE_SOVIET_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_the_soviet.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_THE_SOVIET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "5c419edc-203d-4736-8cd9-bed24e34171c"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "assaultrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "62f8d41c-ef58-4213-8fa7-b2d68191e092",
+                    "Name": "UI_CHALLENGES_GRADUATION_THAT_SPOT_LIGHT_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_spot_light.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_THAT_SPOT_LIGHT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "579f2544-1970-4865-afa3-ad4566e5f98d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "a43ee7ae-44ff-44d8-80fb-5f28f55ca7e5"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "77729582-ddf2-4fcc-9307-f6d6d867edb8",
+                    "Name": "UI_CHALLENGES_GRADUATION_THE_SECURITY_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_the_security.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_THE_SECURITY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "f7acaf86-205c-4ac4-98c7-2c418007299c"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "pistol"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "e20675e2-7504-4692-92ad-4e75fd7b9d64",
+                    "Name": "UI_CHALLENGES_GRADUATION_PROJECTOR_KILL_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_projector_kill.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_PROJECTOR_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "IsKnightDied": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 5
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "579f2544-1970-4865-afa3-ad4566e5f98d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "0955e3c3-8b58-468f-81df-0e66ffbac677"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "579f2544-1970-4865-afa3-ad4566e5f98d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "0955e3c3-8b58-468f-81df-0e66ffbac677"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "KGB_Fix_Fuse"
+                                        ]
+                                    },
+                                    "Transition": "IsKnightDied"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "5b630176-2d35-4328-b1b2-51df4c2c0bb3",
+                    "Name": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_KGB_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_disguise_kgb.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_KGB_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "abb1e004-7fdf-462b-96b3-074e3390c171"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "72db2871-a24c-4fa9-8f78-25c9a004ee02",
+                    "Name": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_SECUIRTYGUARD_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_disguise_securityguard.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_SECUIRTYGUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "f7acaf86-205c-4ac4-98c7-2c418007299c"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "7e8f3cf1-fff8-4dc6-9157-e87e316159b6",
+                    "Name": "UI_CHALLENGES_GRADUATION_TARGET_SICK_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_target_sick.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_TARGET_SICK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Actorsick": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.actor_R_ID",
+                                            "579f2544-1970-4865-afa3-ad4566e5f98d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "c508908e-2cef-4679-8499-2f6c9873fde8",
+                    "Name": "UI_CHALLENGES_GRADUATION_OPP_FIND_SLIDES_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_find_slides.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_OPP_FIND_SLIDES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "c9f0b076-0ade-4795-b3ae-901b58292e69"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "ccc19da4-6a05-4355-8cb2-4466ceb5b4fb",
+                    "Name": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_MECHANIC_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_disguise_mechaic.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_MECHANIC_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "8f6ea4f1-32a8-4e57-a39d-90a2c2ff2bb0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "d51d2d4a-6cf3-4643-a0c6-ed17a1f0a80a",
+                    "Name": "UI_CHALLENGES_GRADUATION_OPP_INVESTIGATE_PLANE_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_opp_investigate_plane.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_OPP_INVESTIGATE_PLANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "885d3ac3-aff7-4dca-942b-fecbc3fc688a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "eb565979-a252-4fcd-aec0-b81bf54caea4",
+                    "Name": "UI_CHALLENGES_GRADUATION_DELIVER_VODKA_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_deliver_vodka.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_DELIVER_VODKA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "195dcd6b-6663-4768-9e0a-c94e244cbea4"
+                                        ]
+                                    },
+                                    "Transition": "State_Delivery"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "State_Delivery": {
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "6edc921c-9051-4fe3-b327-117ca15728df"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "fdea3ead-783c-45da-b31a-713faa0bf07c",
+                    "Name": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_SOVIET_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_disguise_soviet.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_OPP_DISGUISE_SOVIET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "5c419edc-203d-4736-8cd9-bed24e34171c"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "9b2a753a-93e7-4044-a4fa-bc7738805578",
+                    "Name": "UI_CHALLENGES_GRADUATION_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/lat73/area_discovered_graduation.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 9
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_GRADUATION_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "18f5e1fd-736c-44de-a4e1-c3e70357ec7c",
+                    "Name": "UI_CHALLENGES_PROLOGUE_BOARD_AS_GUARD_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_board_as_guard.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_BOARD_AS_GUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Board_Yacht_asGuard"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "57e399bc-e449-4805-bbae-f7cd257925fe",
+                    "Name": "UI_CHALLENGES_PROLOGUE_LIFERAFT_KILL_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_liferaft_kill.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_LIFERAFT_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3d25ee6c-61fa-4ba5-8f19-fedd905fd8fb"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "99743df5-fef0-4c20-a1b6-deb34f094a44"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["clean", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "5c312f4a-5895-42ab-bce7-cd6c166113b1",
+                    "Name": "UI_CHALLENGES_PROLOGUE_ITEM_FOUND_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_item_found.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_ITEM_FOUND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Guard_FoundItem": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "8eca1722-68c7-4bdd-9317-f13fad851552",
+                    "Name": "UI_CHALLENGES_PROLOGUE_HIDEBODY_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_hidebody.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_HIDEBODY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyHidden": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "3d25ee6c-61fa-4ba5-8f19-fedd905fd8fb"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "a9faeb2f-a4d6-4bd6-b97d-d005e21f7db6",
+                    "Name": "UI_CHALLENGES_PROLOGUE_RAT_POISON_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_rat_poison.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_RAT_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "8b37a3a8-8a20-4262-81c5-0fcd15f4bba9"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "c70e38d8-b858-47ed-9257-c43f563e5871",
+                    "Name": "UI_CHALLENGES_PROLOGUE_DIGUISE_PICKED_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_disguise_picked.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_DIGUISE_PICKED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "InValidBox": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Out_Waiter_Disguise_Box"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "bbffa24b-fa46-4f9d-a73d-71de56ff3bfe"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "In_Waiter_Disguise_Box"
+                                        ]
+                                    },
+                                    "Transition": "InValidBox"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "c984bb30-920c-4d0e-9088-06f7c9b4629e",
+                    "Name": "UI_CHALLENGES_PROLOGUE_POISON_SICK_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_poison_sick.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_POISON_SICK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Actorsick": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.actor_R_ID",
+                                            "3d25ee6c-61fa-4ba5-8f19-fedd905fd8fb"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["clean", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "cf5a7ad8-6e45-4577-a7e9-30e3fb428ca9",
+                    "Name": "UI_CHALLENGES_PROLOGUE_GENERATOR_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_generator.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_GENERATOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "DistractionStart": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 200
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Guard_In_box"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Generator_Rigged"
+                                        ]
+                                    },
+                                    "Transition": "DistractionStart"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "df10cfd0-545e-40db-afca-cf5c178870a5",
+                    "Name": "UI_CHALLENGES_PROLOGUE_TARGET_EXPLOSION_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_target_explosion.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_TARGET_EXPLOSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3d25ee6c-61fa-4ba5-8f19-fedd905fd8fb"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "7d0c107e-4279-4fda-a7e2-77359271cb9a"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["clean", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "df35b620-ca4d-40f1-ae50-9297585ede5d",
+                    "Name": "UI_CHALLENGES_PROLOGUE_NORFOLK_MEETING_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_norfolk_meeting.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_NORFOLK_MEETING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "47_Norfolk_meeting_start"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["clean", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "eb6129de-ee3b-488a-bd02-50aa5c0a92bb",
+                    "Name": "UI_CHALLENGES_PROLOGUE_COIN_DISTRACTION_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_coin_distraction.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_COIN_DISTRACTION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "DistractionStart": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 3
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Investigate_Curious": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$eq": [
+                                                "$Value.InvestigationType",
+                                                0
+                                            ]
+                                        }
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Start": {
+                                "ItemThrown": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "dda002e9-02b1-4208-82a5-cf059f3c79cf"
+                                        ]
+                                    },
+                                    "Transition": "DistractionStart"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["b573932d-7a34-44f1-bcf4-ea8f79f75710"]
+                    }
+                },
+                {
+                    "Id": "055ad61d-04bb-4a19-a44f-6ef4db545438",
+                    "Name": "UI_CHALLENGES_GRADUATION_47_MASTER_OF_TRADE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_47_MASTER_OF_TRADE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "eed87874-5a23-4230-a5ba-220e90372721",
+                                "969f8855-6727-4cf4-bfa9-a40e4460f7ae",
+                                "24806303-11f7-4c71-a3fc-412f8095726c",
+                                "77729582-ddf2-4fcc-9307-f6d6d867edb8",
+                                "5434404c-1db9-48d7-8f30-fbf0b342938a",
+                                "3f2bfeb7-4cb0-4a56-b37b-dd5768b04a03",
+                                "e20675e2-7504-4692-92ad-4e75fd7b9d64",
+                                "4be75ba3-4916-4660-9f5b-8f12b3250c7a",
+                                "62f8d41c-ef58-4213-8fa7-b2d68191e092",
+                                "85bbb639-40e3-4aa5-87aa-388a1cad2404",
+                                "228996e6-5fff-4f76-95de-484ee941c0ab"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "1b3c8b9b-17a5-407f-ad4f-4bdca3779a8f",
+                    "Name": "UI_CHALLENGES_GRADUATION_STORY_CHALLENGE_JET_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_story_jet.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_STORY_CHALLENGE_JET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Story_Jet"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "210f75bf-8094-4a4a-90f3-da23b4e73ad9",
+                    "Name": "UI_CHALLENGES_GRADUATION_CHESS_PUZZLE_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_c_chess_puzzle.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_CHESS_PUZZLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.name_metricvalue",
+                                            "Chess_GoodMove"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "294ad6dc-829d-4f29-8721-f86735603009",
+                    "Name": "UI_CHALLENGES_GRADUATION_STORY_CHALLENGE_RADIO_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_story_radio.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_STORY_CHALLENGE_RADIO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Story_Radio"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "3168e255-aeef-4b40-8d28-9800e4521d47",
+                    "Name": "UI_CHALLENGES_PROLOGUE_MISSION_COMPLETED_NAME",
+                    "ImageName": "images/challenges/lat73/prologue_c_mission_completed.jpg",
+                    "Description": "UI_CHALLENGES_PROLOGUE_MISSION_COMPLETED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Name": "054f443b-824f-4913-8b29-64dfcd82b089_greenland_hero_trainingsuit_m_hpa745_name_",
+                                "Description": "054f443b-824f-4913-8b29-64dfcd82b089_greenland_hero_trainingsuit_m_hpa745_description_",
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "IsConsumable": false,
+                                "RepositoryId": "054f443b-824f-4913-8b29-64dfcd82b089",
+                                "OrderIndex": 753
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_GREENLAND_HERO_TRAININGSUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_GREENLAND_HERO_TRAININGSUIT",
+                            "Type": "disguise",
+                            "Subtype": "tactical",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3af7dc77-f7f0-4ed0-a31b-b42f6327d4b9"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "71b47237-cbf0-4b18-be34-81226026a4c9",
+                    "Name": "UI_CHALLENGES_POLARBEAR_HAMMER_TIME_NAME",
+                    "ImageName": "images/challenges/lat73/polarbear_hammer_time.jpg",
+                    "Description": "UI_CHALLENGES_POLARBEAR_HAMMER_TIME_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Distraction_State": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 2
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Investigate_Curious": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$eq": [
+                                                "$Value.InvestigationType",
+                                                0
+                                            ]
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$eq": [
+                                                "$Value.KillItemRepositoryId",
+                                                "3c24c96a-557c-472a-9d71-1a235d7383a7"
+                                            ]
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Pacify": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$eq": [
+                                                "$Value.KillItemRepositoryId",
+                                                "3c24c96a-557c-472a-9d71-1a235d7383a7"
+                                            ]
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                },
+                                "ItemDropped": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "3c24c96a-557c-472a-9d71-1a235d7383a7"
+                                            ]
+                                        }
+                                    },
+                                    "Transition": "Distraction_State"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$any": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$Value.DamageEvents"
+                                                    }
+                                                },
+                                                "in": ["Subdue", "CoupDeGrace"]
+                                            }
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Pacify": {
+                                    "Condition": {
+                                        "$not": {
+                                            "$eq": [
+                                                "$Value.KillItemRepositoryId",
+                                                "3c24c96a-557c-472a-9d71-1a235d7383a7"
+                                            ]
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "bab13148-ca59-4214-b332-e7060429fff4",
+                    "Name": "UI_CHALLENGES_GRADUATION_STORY_CHALLENGE_PROJECTOR_NAME",
+                    "ImageName": "images/challenges/lat73/graduation_story_projector.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_STORY_CHALLENGE_PROJECTOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Story_Projector"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "c00464a6-19e5-49fa-8b83-fe32e8278741",
+                    "Name": "UI_CHALLENGES_GRADUATION_47_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_47_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "8f6ea4f1-32a8-4e57-a39d-90a2c2ff2bb0",
+                                "f7acaf86-205c-4ac4-98c7-2c418007299c",
+                                "abb1e004-7fdf-462b-96b3-074e3390c171",
+                                "5c419edc-203d-4736-8cd9-bed24e34171c"
+                            ]
+                        },
+                        "Context": {
+                            "Disguises": []
+                        },
+                        "ContextListeners": {
+                            "Disguises": {
+                                "count": "($.Disguises).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Disguises",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.Disguises"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "ec46536e-f632-47aa-ab92-7041d9728640",
+                    "Name": "UI_CONTRACT_SNOWDROP_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Snowdrop.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "e71bb57e-cba6-4b47-bdb1-2c89319d7e45"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats"],
+                    "InclusionData": {
+                        "ContractIds": ["aee6a16f-6525-4d63-a37f-225e293c6118"]
+                    }
+                },
+                {
+                    "Id": "f6a2aae0-6c20-47a1-b647-74263476db69",
+                    "Name": "UI_CONTRACT_WOLFSBANE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Wolfsbane.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "dac764bf-d07f-461b-8f51-a511ed64a20a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats"],
+                    "InclusionData": {
+                        "ContractIds": ["c469d91d-01fc-4314-b22c-71cb804e92c0"]
+                    }
+                },
+                {
+                    "Id": "5fea8bbc-66cc-407c-b6fc-00036a418891",
+                    "Name": "UI_CHALLENGES_GRADUATION_BIG3_STORY_NAME",
+                    "ImageName": "images/challenges/lat73/all_graduation_story_bjective.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_BIG3_STORY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 5,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "b39d7a0d-e839-417b-880c-cf9b165d4e11"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_TOOL_LOCK_PICK_NAME",
+                            "Id": "PROP_TOOL_LOCK_PICK",
+                            "Type": "gear",
+                            "Subtype": "tool",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "7850fd23-3a73-44b9-89f6-2ce634e003b9"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "1b3c8b9b-17a5-407f-ad4f-4bdca3779a8f",
+                                "294ad6dc-829d-4f29-8721-f86735603009",
+                                "bab13148-ca59-4214-b332-e7060429fff4",
+                                "210f75bf-8094-4a4a-90f3-da23b4e73ad9"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "85bbb639-40e3-4aa5-87aa-388a1cad2404",
+                    "Name": "UI_CHALLENGES_GRADUATION_47_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_47_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Collection": [
+                                "4fc9396e-2619-4e66-a51e-2bd366230da7",
+                                "28d1aef1-45ba-4e8d-9bca-7cd8b4e5b4f8",
+                                "feef1171-9faa-4c95-b80e-22ae3c9bbec1",
+                                "989928f2-06d6-42f3-871a-353f07def969",
+                                "5e292dfb-646c-4a5b-9233-f4fbe5d5c033",
+                                "08f9f972-9229-432f-9092-2787883774e6",
+                                "054f443b-824f-4913-8b29-64dfcd82b089",
+                                "75759271-e236-4b33-8dd5-7e502c958d05",
+                                "58161492-10c8-4fce-860c-89e9b0a764fb",
+                                "00000000-0000-0000-0000-000000000000"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                },
+                                "ContractStart": {
+                                    "Condition": {
+                                        "$all": {
+                                            "?": {
+                                                "$not": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.Disguise"
+                                                    ]
+                                                }
+                                            },
+                                            "in": "$.Collection"
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "969f8855-6727-4cf4-bfa9-a40e4460f7ae",
+                    "Name": "UI_CHALLENGES_GRADUATION_SILENT_ASSASSIN_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_SILENT_ASSASSIN_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "classic", "hard", "suitonly"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                },
+                {
+                    "Id": "eed87874-5a23-4230-a5ba-220e90372721",
+                    "Name": "UI_CHALLENGES_GRADUATION_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_GRADUATION_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "ParentLocationId": "LOCATION_PARENT_ICA_FACILITY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["ada5f2b1-8529-48bb-a596-717f75f5eacb"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/HAVEN/_HAVEN_CHALLENGES.json
+++ b/contractdata/HAVEN/_HAVEN_CHALLENGES.json
@@ -1,0 +1,4170 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_OPULENT"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "037d9ea9-8353-4cc4-a8fc-9f5a6063d43e",
+                    "Name": "UI_CHALLENGES_STINGRAY_LJUDMILA_MASSAGE_NAME",
+                    "ImageName": "images/challenges/Opulent/ljudmila_massage.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_LJUDMILA_MASSAGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "5bc06fb1-bfb3-48ef-94ae-6f18c16c1eee"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f78aa894-b174-4996-8af3-fe104888a1c8"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "0b058fd0-52c7-4e34-a2d7-b113cce23fab",
+                    "Name": "UI_CHALLENGES_STINGRAY_TYSON_PROJECTOR_NAME",
+                    "ImageName": "images/challenges/Opulent/tyson_projector.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TYSON_PROJECTOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "In_Position": "false"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Contract_Name_metricvalue",
+                                            "Projector_In_Position_Event"
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": [
+                                            "In_Position",
+                                            "$Value.Event_metricvalue"
+                                        ]
+                                    }
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$.In_Position", "true"]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "7504b78e-e766-42fe-930c-c5640f5f507b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "ballistic"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "25b7f705-763e-4290-ae17-f1de5afeb6d4",
+                    "Name": "UI_CHALLENGES_STINGRAY_TYSON_CHANDELIER_NAME",
+                    "ImageName": "images/challenges/Opulent/tyson_chandelier.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TYSON_CHANDELIER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "7504b78e-e766-42fe-930c-c5640f5f507b"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "edfbe698-4679-43a6-b2bd-a353016fa88f"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "2c897a74-d474-4edc-ae2b-ad2ac81e7c71"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "2839efae-218b-4462-959a-4420207e7f8f",
+                    "Name": "UI_CHALLENGES_STINGRAY_LJUDMILA_TRAP_DOOR_NAME",
+                    "ImageName": "images/challenges/Opulent/ljudmila_trap_door.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_LJUDMILA_TRAP_DOOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "5bc06fb1-bfb3-48ef-94ae-6f18c16c1eee"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f3c29525-f63b-4b23-919d-428bce2b3d73"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "2d4c7b50-9c01-4a8a-ab51-7f92b4d124ab",
+                    "Name": "UI_CHALLENGES_STINGRAY_STEVE_BENCH_PRESS_NAME",
+                    "ImageName": "images/challenges/Opulent/steve_bench_press.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_STEVE_BENCH_PRESS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0afcc59e-6d6e-433f-8404-7699df872c9d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "9e62e881-cecc-4739-804c-26d2822c47fe"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "4b545a9d-9a7c-4b3f-b38f-49fa6e7d6779",
+                    "Name": "UI_CHALLENGES_STINGRAY_STEVE_SCOOTER_EXPLODE_NAME",
+                    "ImageName": "images/challenges/Opulent/steve_scooter_explode.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_STEVE_SCOOTER_EXPLODE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "In_Position": "false"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Contract_Name_metricvalue",
+                                            "Scooter_In_Position_Event"
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": [
+                                            "In_Position",
+                                            "$Value.Event_metricvalue"
+                                        ]
+                                    }
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$.In_Position", "true"]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0afcc59e-6d6e-433f-8404-7699df872c9d"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "unknown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "52032a34-513d-4337-9ed0-357a326fb4eb",
+                    "Name": "UI_CHALLENGES_STINGRAY_LJUDMILA_EXPLODE_KITCHEN_NAME",
+                    "ImageName": "images/challenges/Opulent/ljudmila_explode_kitchen.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_LJUDMILA_EXPLODE_KITCHEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "5bc06fb1-bfb3-48ef-94ae-6f18c16c1eee"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "8898adff-9cac-4705-9c28-05533067227d"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "74ebc46d-c394-4295-8062-b7ce69abef62",
+                    "Name": "UI_CHALLENGES_STINGRAY_GAS_UNDERGROUND_NAME",
+                    "ImageName": "images/challenges/Opulent/gas_underground.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_GAS_UNDERGROUND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "20c13b62-cb5f-4be7-8efa-74a010b38c0a"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", 3]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "7d460f62-2670-439a-82c5-050c7d073703",
+                    "Name": "UI_CHALLENGES_STINGRAY_TOWER_SNIPER_NAME",
+                    "ImageName": "images/challenges/Opulent/tower_sniper.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TOWER_SNIPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "InSniperTowerChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "InSniperTower"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": ["$Value.IsTarget", true]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "InSniperTower": {
+                                "InSniperTowerChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$contains": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "a708f321-9a38-448c-95d7-bf80fdd4a0d6",
+                    "Name": "UI_CHALLENGES_STINGRAY_STEVE_SCOOTER_SNIPE_NAME",
+                    "ImageName": "images/challenges/Opulent/steve_scooter_snipe.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_STEVE_SCOOTER_SNIPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "In_Position": "false"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Contract_Name_metricvalue",
+                                            "Scooter_In_Position_Event"
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": [
+                                            "In_Position",
+                                            "$Value.Event_metricvalue"
+                                        ]
+                                    }
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$.In_Position", "true"]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0afcc59e-6d6e-433f-8404-7699df872c9d"
+                                                ]
+                                            },
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "b47eae96-cb8f-4fb3-9e1d-90bdfdf1a96c",
+                    "Name": "UI_CHALLENGES_STINGRAY_POISON_ALL_NAME",
+                    "ImageName": "images/challenges/Opulent/poison_all.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_POISON_ALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillClass",
+                                                        "poison"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "c2a64941-a06f-418e-973f-a651000cf7bc",
+                    "Name": "UI_CHALLENGES_STINGRAY_TYSON_STETHOSCOPE_NAME",
+                    "ImageName": "images/challenges/Opulent/tyson_stethoscope.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TYSON_STETHOSCOPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "7504b78e-e766-42fe-930c-c5640f5f507b",
+                            "KillItem": "280739c7-9d93-48b9-840e-694883e76700"
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "$.KillItem"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "c50c3cb5-66ec-4741-ba10-421dc69d2e74",
+                    "Name": "UI_CHALLENGES_STINGRAY_DOUBLE_DROWN_NAME",
+                    "ImageName": "images/challenges/Opulent/double_drown.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_DOUBLE_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "263ac148-0798-4f68-a74f-5e57eb03dcc1"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "cf363d72-ceb7-4757-9ee4-db9f3eca5d38",
+                    "Name": "UI_CHALLENGES_STINGRAY_TYSON_MEDICINE_NAME",
+                    "ImageName": "images/challenges/Opulent/tyson_medicine.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TYSON_MEDICINE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "7504b78e-e766-42fe-930c-c5640f5f507b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "acd1ab5e-b91d-47ac-a704-aab9560d6b9d"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "2f1d41be-5000-4d6d-b038-38280c7e53b3",
+                    "Name": "UI_CHALLENGES_OPULENT_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "a58eebea-cbaa-40fe-ae21-79d0f8c3ca3f",
+                    "Name": "UI_CHALLENGES_OPULENT_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "c03f8887-91e3-4799-a843-792fb173667d",
+                    "Name": "UI_CHALLENGES_OPULENT_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "d425b21e-24c6-4202-b318-f90a6b74d280",
+                    "Name": "UI_CHALLENGES_OPULENT_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "c03f8887-91e3-4799-a843-792fb173667d",
+                                "2f1d41be-5000-4d6d-b038-38280c7e53b3",
+                                "a58eebea-cbaa-40fe-ae21-79d0f8c3ca3f",
+                                "fd93938c-8951-433b-9577-92445318d12f",
+                                "ddcbcbeb-6ab1-4ead-a3d6-5a02e89823e7"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "ddcbcbeb-6ab1-4ead-a3d6-5a02e89823e7",
+                    "Name": "UI_CHALLENGES_OPULENT_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "fd93938c-8951-433b-9577-92445318d12f",
+                    "Name": "UI_CHALLENGES_OPULENT_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "0f1abe2d-b598-43d0-b9bf-49fad8718659",
+                    "Name": "UI_CHALLENGES_STINGRAY_GET_ALL_INTEL_NAME",
+                    "ImageName": "images/challenges/Opulent/get_all_intel.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_GET_ALL_INTEL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Targets": [
+                                "afdd059f-648d-4734-bcd5-9b9ca194ac4e",
+                                "b4040a95-bc37-4602-a883-7e22de4f6410",
+                                "47592b6d-6a2d-4668-9fb3-c8704e1ba2e1",
+                                "e99d4c2d-e668-46c3-a8e0-bd7be8d30681",
+                                "ca823f24-efab-4818-9456-a1fc319c9662",
+                                "542ea1a3-dd43-4a3a-839b-66f65bd4a880",
+                                "7ad545d9-b63f-4246-a529-d7432b6be939",
+                                "38efe99b-db11-436e-9698-2fa5dc065f06"
+                            ]
+                        },
+                        "Context": {
+                            "Collection": []
+                        },
+                        "ContextListeners": {
+                            "Collection": {
+                                "type": "challengecounter",
+                                "count": "($.Collection).Count",
+                                "total": "($.Targets).Count"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.Targets"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Collection",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.Collection).Count",
+                                                "($.Targets).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "28771738-c487-4249-93c6-a9e69408383b",
+                    "Name": "UI_CHALLENGES_OPULENT_EXIT_SPEEDBOAT_NAME",
+                    "ImageName": "images/challenges/Opulent/exit_speedboat.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_EXIT_SPEEDBOAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "ffaeaed8-64fb-4631-b3e6-583525aaec4a"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "329560bc-5251-40f1-9b66-5a44dba1e206",
+                    "Name": "UI_CHALLENGES_OPULENT_COLLECT_PHAMLET_NAME",
+                    "ImageName": "images/challenges/Opulent/collect_phamlet.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_COLLECT_PHAMLET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 11
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PhampletCollected": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "332bcb62-534a-48c7-9bf9-f26f85ad7c03",
+                    "Name": "UI_CHALLENGES_OPULENT_GET_BANANA_NAME",
+                    "ImageName": "images/challenges/Opulent/get_banana.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_GET_BANANA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "903d273c-c750-441d-916a-31557fea3382"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "33d65e4c-580d-4741-b095-1486ea2e7f38",
+                    "Name": "UI_CHALLENGES_OPULENT_EXIT_PLANE_NAME",
+                    "ImageName": "images/challenges/Opulent/exit_plane.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_EXIT_PLANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "f24a2f08-7103-4ae7-b6da-0251294ae2db"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "3d2ddc19-2080-47f4-908e-aaade0786695",
+                    "Name": "UI_CHALLENGES_OPULENT_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "2817afb5-6dff-4496-bf56-4cd59b9abc9b",
+                                "30164cfe-a26b-4a72-8bc2-5bc99c0283c1",
+                                "33e3a400-0bbc-4edd-b07f-056135329802",
+                                "49e70108-2c8d-4418-8e42-8f63d6ed43af",
+                                "53415cf7-8d62-45b9-943f-d1a50c7c6024",
+                                "95f2f02f-205b-422f-a315-875568f911da",
+                                "a260d9d6-a33c-499e-a6c5-698cfcc3de8f",
+                                "cfc19dda-bff1-4bd1-9b0c-b1a799ee011f",
+                                "cbcfe485-f706-46a1-a14a-316f6dedf398",
+                                "cda86b1b-63a4-4e3a-975e-d716685335a7",
+                                "d4c9507a-b297-46ce-8e9c-4ec479da22a4",
+                                "dec42c4a-3ff0-451f-80b0-a01e68310286",
+                                "e9fa4892-fa2a-40a1-a51c-78d8561034f3",
+                                "ea4230f3-03f7-46f1-a3f4-be2ff383b417",
+                                "f108122d-5b31-487a-857b-d5f1badf2220",
+                                "fd4c537a-226f-448d-9635-941c6f09d388",
+                                "f6e37038-98c1-4e58-bd85-c895f5c19d56"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "426b00f9-5b91-4390-b0c6-778e13db15b0",
+                    "Name": "UI_CHALLENGES_OPULENT_PERSONAL_TRAINER_NAME",
+                    "ImageName": "images/challenges/Opulent/personal_trainer.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_PERSONAL_TRAINER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PersonalTrainer_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4cacb4c4-dbe3-4396-bece-119b550bf0cf",
+                    "Name": "UI_CHALLENGES_OPULENT_EXIT_DINGY_NAME",
+                    "ImageName": "images/challenges/Opulent/exit_dingy.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_EXIT_DINGY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "922fc9a0-d0a5-4eb9-b0e2-39856ff62e59"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4da41b61-e22f-482d-9815-7a1f70dd653d",
+                    "Name": "UI_CHALLENGES_OPULENT_HAVEN_REPORT_NAME",
+                    "ImageName": "images/challenges/Opulent/haven_report.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_HAVEN_REPORT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "542ea1a3-dd43-4a3a-839b-66f65bd4a880"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "581493b4-0e25-466f-94b8-1407ba88df50",
+                    "Name": "UI_CHALLENGES_OPULENT_BECOME_TECH_CREW_NAME",
+                    "ImageName": "images/challenges/Opulent/become_tech_crew.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BECOME_TECH_CREW_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "f6e37038-98c1-4e58-bd85-c895f5c19d56"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "5b099248-e209-4f12-9145-a23a27565dbd",
+                    "Name": "UI_CHALLENGES_OPULENT_BECOME_MASSEUR_NAME",
+                    "ImageName": "images/challenges/Opulent/become_masseur.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BECOME_MASSEUR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "dec42c4a-3ff0-451f-80b0-a01e68310286"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "621b4015-02a2-420b-8ddd-ede6b39c4ca4",
+                    "Name": "UI_CHALLENGES_OPULENT_BECOME_SNORKEL_INSTRUCTOR_NAME",
+                    "ImageName": "images/challenges/Opulent/become_snorkel_instructor.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BECOME_SNORKEL_INSTRUCTOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "30164cfe-a26b-4a72-8bc2-5bc99c0283c1"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "8be74072-d8a1-4c6b-bc87-d1e6142d1670",
+                    "Name": "UI_CHALLENGES_OPULENT_BREAK_SERVERRACKS_NAME",
+                    "ImageName": "images/challenges/Opulent/break_serverracks.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BREAK_SERVERRACKS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Constants": {
+                            "Goal": 4
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "trigger-always": true
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "RackDestroyed"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "RackReset"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$dec": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "8e79df7a-4412-487b-91a3-c36e7a47da45",
+                    "Name": "UI_CHALLENGES_OPULENT_EXIT_WATERSCOOTER_NAME",
+                    "ImageName": "images/challenges/Opulent/exit_waterscooter.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_EXIT_WATERSCOOTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "c32574d3-f611-434f-8379-7665638b5d32"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a096baa0-5c34-4a5e-995b-9fad5dbe9902",
+                    "Name": "UI_CHALLENGES_OPULENT_BECOME_CHEF_NAME",
+                    "ImageName": "images/challenges/Opulent/become_chef.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BECOME_CHEF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "cfc19dda-bff1-4bd1-9b0c-b1a799ee011f"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a40a4f8f-f4b2-4a82-99e5-d94eb841ce6f",
+                    "Name": "UI_CHALLENGES_OPULENT_SERVE_COCKTAIL_NAME",
+                    "ImageName": "images/challenges/Opulent/serve_cocktail.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_SERVE_COCKTAIL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SomeoneServed": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "afdb4abc-6a98-4e3c-9586-d216ccb76765",
+                    "Name": "UI_CHALLENGES_OPULENT_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Opulent/opulent_locationdiscovery.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 41
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_STINGRAY_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "b48c9f81-4152-404e-b021-f75e39061916",
+                    "Name": "UI_CHALLENGES_OPULENT_FIND_TREASURE_NAME",
+                    "ImageName": "images/challenges/Opulent/find_treasure.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_FIND_TREASURE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "cdc5b394-c7e5-4ec0-84fe-1fa556a82f63"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "c3405325-38ae-43b5-bc52-6a071743c01c",
+                    "Name": "UI_CHALLENGES_OPULENT_GRAB_FISH_NAME",
+                    "ImageName": "images/challenges/Opulent/grab_fish.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_GRAB_FISH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GrabFish_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "c4195ed0-182b-48d2-8d11-000f24981f1c",
+                    "Name": "UI_CHALLENGES_OPULENT_BECOME_HAZMAT_NAME",
+                    "ImageName": "images/challenges/Opulent/become_hazmat.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BECOME_HAZMAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "cbcfe485-f706-46a1-a14a-316f6dedf398"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "dd762645-786a-4b2e-bfb5-0a7ab47ea891",
+                    "Name": "UI_CHALLENGES_OPULENT_COLLECT_KEY_NAME",
+                    "ImageName": "images/challenges/Opulent/collect_key.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_COLLECT_KEY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 4
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CollectOneKey": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "f50a2357-5302-40ed-baa3-9184a4086e0a",
+                    "Name": "UI_CHALLENGES_OPULENT_BECOME_CAPTAIN_NAME",
+                    "ImageName": "images/challenges/Opulent/become_captain.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BECOME_CAPTAIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "2817afb5-6dff-4496-bf56-4cd59b9abc9b"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "0cbe3dbf-c113-4b0a-9b64-c1ad2478c01a",
+                    "Name": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_GUN_HIRE_NAME",
+                    "ImageName": "images/challenges/opulent/missionstory_gun_hire.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_GUN_HIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "57095852-d261-4365-acbf-af5d0d17a2a3"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "294a4a22-fdaf-4c81-a86d-14eadf18dad3",
+                    "Name": "UI_CHALLENGES_STINGRAY_TRAMPOLIN_JUMP_NAME",
+                    "ImageName": "images/challenges/Opulent/trampolin_jump.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TRAMPOLIN_JUMP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ManJumps": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "2d076326-47df-4880-b090-426461c43ac4",
+                    "Name": "UI_CHALLENGES_STINGRAY_STEVE_MEDITATE_NAME",
+                    "ImageName": "images/challenges/Opulent/steve_meditate.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_STEVE_MEDITATE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SteveMeditate_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "4383a151-8f25-4298-b64c-966fde4d374e",
+                    "Name": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_WATERSCOOTER_STEP_NAME",
+                    "ImageName": "images/challenges/Opulent/missionstory_waterscooter_step.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_WATERSCOOTER_STEP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "38efe99b-db11-436e-9698-2fa5dc065f06"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "4a0b2021-67d0-424d-b091-e523bb0949a0",
+                    "Name": "UI_CHALLENGES_STINGRAY_TYSON_BODYGUARD_NAME",
+                    "ImageName": "images/challenges/Opulent/tyson_bodyguard.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TYSON_BODYGUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "9b91d8b7-e9b5-4dd0-bc4d-6807f584a6af"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "4b7e72e7-208e-4763-bdd9-3c1f5f411cc0",
+                    "Name": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_DOCTOR_STEP_NAME",
+                    "ImageName": "images/challenges/Opulent/missionstory_doctor_step.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_DOCTOR_STEP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "f108122d-5b31-487a-857b-d5f1badf2220"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "56b92182-066d-4d48-b358-22339393ae3d",
+                    "Name": "UI_CHALLENGES_STINGRAY_LJUDMILA_FOOD_NAME",
+                    "ImageName": "images/challenges/Opulent/ljudmila_food.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_LJUDMILA_FOOD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "f79053b2-cafa-4084-8412-78e79f153bac"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "64706eb9-7e25-4517-923d-1e43bebdc2f8",
+                    "Name": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_DOCTOR_NAME",
+                    "ImageName": "images/challenges/opulent/missionstory_doctor.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_DOCTOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "44623041-18e8-4f1f-8fc2-b30ce1e8ad9d"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "88533d72-6212-47e9-9411-5f7c8b3e627f",
+                    "Name": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_GUN_HIRE_STEP_NAME",
+                    "ImageName": "images/challenges/Opulent/missionstory_gun_hire_step.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_GUN_HIRE_STEP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "afdd059f-648d-4734-bcd5-9b9ca194ac4e"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "925f4239-402e-42ac-9c2e-a8f2cbc7df56",
+                    "Name": "UI_CHALLENGES_STINGRAY_STEVE_MEET_LJUDMILA_NAME",
+                    "ImageName": "images/challenges/Opulent/steve_meet_ljudmila.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_STEVE_MEET_LJUDMILA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SteveMeetLjudmila_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "9acf5011-75cf-455d-b3e0-9a8d444d19cf",
+                    "Name": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_WATERSCOOTER_NAME",
+                    "ImageName": "images/challenges/opulent/missionstory_waterscooter.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_MISSIONSTORY_WATERSCOOTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "07e1bbc5-47ee-4894-85a3-cd2140bd2553"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "e1106963-df41-40e0-bebe-0d34b6866872",
+                    "Name": "UI_CHALLENGES_STINGRAY_DOUBLE_USB_NAME",
+                    "ImageName": "images/challenges/Opulent/double_usb.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_DOUBLE_USB_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "LjudmilaHasUSB": "false",
+                            "TysonHasUSB": "false"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TysonUsbGiven": [
+                                    {
+                                        "$set": ["TysonHasUSB", "true"]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$.TysonHasUSB",
+                                                        "true"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$.LjudmilaHasUSB",
+                                                        "true"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "LjudmilaUsbGiven": [
+                                    {
+                                        "$set": ["LjudmilaHasUSB", "true"]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$.TysonHasUSB",
+                                                        "true"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$.LjudmilaHasUSB",
+                                                        "true"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "ec2f8410-f81e-4e3f-ab49-824c770e1c81",
+                    "Name": "UI_CHALLENGES_STINGRAY_DITCH_PORTMAN_NAME",
+                    "ImageName": "images/challenges/Opulent/ditch_portman.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_DITCH_PORTMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "77d46c8c-83f2-4668-b4f4-3b6243242152"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "66c8bca6-b8f2-4f87-8467-4b54af6c2815",
+                    "Name": "UI_CONTRACT_ArcticThyme_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Opulent_ArcticThyme.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "052cbf5d-e268-479a-a705-17609d528182",
+                                "OrderIndex": 955,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_PIRATE_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_PIRATE_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "themed",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "7ff5b943-eede-4415-adb2-61e6e7258c60"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "c5ef7b7a-3cfb-4b99-a566-8b3ab4b36436"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["83d4e87e-2f47-4c81-b831-30bd13a29b05"]
+                    }
+                },
+                {
+                    "Id": "0486c68b-776d-4406-9d68-01ac86abdf7b",
+                    "Name": "UI_CHALLENGES_OPULENT_BANANA_SLIP_NAME",
+                    "ImageName": "images/challenges/Opulent/banana_slip.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_BANANA_SLIP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.SetPieceId",
+                                            "62c0f1aa-41ba-45c0-800d-b6c34b98a544"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "3f387992-8241-4b6c-a012-72c474aef792",
+                    "Name": "UI_CHALLENGES_OPULENT_ELECTROCUTED_NAME",
+                    "ImageName": "images/challenges/Opulent/electrocuted.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_ELECTROCUTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "accident_electric"
+                                                    ]
+                                                },
+                                                "in": [
+                                                    "$Value.KillMethodBroad",
+                                                    "$Value.KillMethodStrict"
+                                                ]
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "cba99292-d377-4edc-813a-4522d9bc5d7c",
+                    "Name": "UI_CHALLENGES_OPULENT_SPEAKERS_KILL_NAME",
+                    "ImageName": "images/challenges/Opulent/speakers_kill.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_SPEAKERS_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.SetPieceType",
+                                                "a43ee7ae-44ff-44d8-80fb-5f28f55ca7e5"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"]
+                },
+                {
+                    "Id": "f6342c4e-ac61-4843-827b-d0ccac50e268",
+                    "Name": "UI_CHALLENGES_OPULENT_COCONUT_KILL_NAME",
+                    "ImageName": "images/challenges/Opulent/coconut_kill.jpg",
+                    "Description": "UI_CHALLENGES_OPULENT_COCONUT_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_OPULENT_STINGRAY",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.SetPieceType",
+                                                "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "1959278c-1a0c-48d8-8de4-2d73aa42f520",
+                    "Name": "UI_CHALLENGES_STINGRAY_STEVE_KILLED_NAME",
+                    "ImageName": "images/challenges/Opulent/steve_killed.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_STEVE_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "0afcc59e-6d6e-433f-8404-7699df872c9d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "43db463e-8de5-4d9f-8ded-8b1bfbedfe17",
+                    "Name": "UI_CHALLENGES_STINGRAY_TYSON_KILLED_NAME",
+                    "ImageName": "images/challenges/Opulent/tyson_killed.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_TYSON_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "7504b78e-e766-42fe-930c-c5640f5f507b"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "bf836d82-9915-4e64-bbe2-af18365d5f59",
+                    "Name": "UI_CHALLENGES_STINGRAY_LJUDMILA_KILLED_NAME",
+                    "ImageName": "images/challenges/Opulent/ljudmila_killed.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_LJUDMILA_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "5bc06fb1-bfb3-48ef-94ae-6f18c16c1eee"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "0d02acc0-badc-41d0-a60a-b9376a0949bb",
+                    "Name": "UI_CHALLENGES_STINGRAY_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "11c8167e-d159-463e-b828-2715888928eb",
+                    "Name": "UI_CHALLENGES_STINGRAY_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "7d3eb67f-395d-4d96-85a3-0cfb8cda162a",
+                    "Name": "UI_CHALLENGES_STINGRAY_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "bdcfb22c-51de-4c63-9f9a-a55c8ee3841c",
+                    "Name": "UI_CHALLENGES_STINGRAY_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                },
+                {
+                    "Id": "c92ff63c-b559-44ac-8d81-808e4138b01a",
+                    "Name": "UI_CHALLENGES_STINGRAY_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_STINGRAY_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_OPULENT",
+                    "ParentLocationId": "LOCATION_PARENT_OPULENT",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "7d3eb67f-395d-4d96-85a3-0cfb8cda162a",
+                                "0d02acc0-badc-41d0-a60a-b9376a0949bb",
+                                "11c8167e-d159-463e-b828-2715888928eb",
+                                "bdcfb22c-51de-4c63-9f9a-a55c8ee3841c"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["095261b5-e15b-4ca1-9bb7-001fb85c5aaa"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/HAWKESBAY/_HAWKESBAY_CHALLENGES.json
+++ b/contractdata/HAWKESBAY/_HAWKESBAY_CHALLENGES.json
@@ -1,0 +1,2957 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_NEWZEALAND"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "21ba022b-968f-4a75-a69d-e016bc481e1f",
+                    "Name": "UI_CHALLENGES_SHEEP_FISH_IN_BARREL_NAME",
+                    "ImageName": "images/challenges/NewZealand/Fish_in_barrel.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_FISH_IN_BARREL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "FishInABarrelEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "44061dee-3eaf-41d1-8d1f-27d99e214849",
+                    "Name": "UI_CHALLENGES_SHEEP_VENTILATION_KILL_NAME",
+                    "ImageName": "images/challenges/NewZealand/Ventilation_kill.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_VENTILATION_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9e85c891-9eb7-4f3c-8115-896bf54d979b"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "2e4163e0-c93a-4e57-9f3d-dabb035cd6d1"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "279bbda5-9d27-4029-aa4f-c33125acecda"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "60a6cffe-d7aa-4e51-94d6-43f76f814fee",
+                    "Name": "UI_CHALLENGES_SHEEP_SHOWER_KILL_NAME",
+                    "ImageName": "images/challenges/NewZealand/Shower_kill.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_SHOWER_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ShowerKillEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "a1ab1b3b-c0b6-4f1a-95f6-188203dd6543",
+                    "Name": "UI_CHALLENGES_SHEEP_TEA_KILL_NAME",
+                    "ImageName": "images/challenges/NewZealand/Tea_kill.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_TEA_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9e85c891-9eb7-4f3c-8115-896bf54d979b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "2af583dc-c85d-45ad-b1bb-67dc5e6e4573"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "c9553b2e-d4d9-4cd8-8faf-03aa290ed297",
+                    "Name": "UI_CHALLENGES_SHEEP_BED_SMOTHER_NAME",
+                    "ImageName": "images/challenges/NewZealand/Bed_smother.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_BED_SMOTHER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9e85c891-9eb7-4f3c-8115-896bf54d979b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "cc785fd5-8a76-42d2-b036-9ba8396c2078"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "0f5f5a0f-fc01-4b10-9c15-e4089c431fd2",
+                    "Name": "CHALLENGEPACK_NITROGEN_NINJA_NAME",
+                    "ImageName": "images/challenges/Categories/PackNitrogen/Nitrogen_Ninja.jpg",
+                    "Description": "CHALLENGEPACK_NITROGEN_NINJA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "RequiredWeapons": [
+                                "e55eb9a4-e79c-43c7-970b-79e94e7683b7",
+                                "33c16292-7f60-4f0b-8ea0-bae80bc31d1a",
+                                "92330cd4-1bb1-419e-98d3-ef26631504bf",
+                                "5631dace-7f4a-4df8-8e97-b47373b815ff",
+                                "d439fb64-8713-4c54-a3f3-90730dbdf370",
+                                "cdab8f33-0491-497c-91c2-316c77d59e55",
+                                "c03498c1-db54-402a-9923-63ada447a4b8",
+                                "fecf585b-4bdb-4a9b-9ab0-2bc44c6bd84a",
+                                "af2b1a36-a7f0-4003-aae4-a6076402542d"
+                            ],
+                            "RequiredTargetCount": 10
+                        },
+                        "Context": {
+                            "KilledTargetCount": 0
+                        },
+                        "ContextListeners": {
+                            "KilledTargetCount": {
+                                "type": "challengecounter",
+                                "count": "$.KilledTargetCount",
+                                "total": "$.RequiredTargetCount"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.KillItemRepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": "$.RequiredWeapons"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "KilledTargetCount"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.KilledTargetCount",
+                                                "$.RequiredTargetCount"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "easy", "assassination"]
+                },
+                {
+                    "Id": "2164504e-1ee8-44bf-ba0c-7ed131f10c38",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_47_MASTER_OF_TRADE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_47_MASTER_OF_TRADE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "360ddd68-287d-4a88-a8b4-41aecf9fb665",
+                                "f36e833b-e16f-4c9d-81ea-204197755a0c",
+                                "6ff769a9-0e91-40b9-9348-21ee58d897d8",
+                                "4b4210ba-a537-43e7-9828-af780c36030b",
+                                "c1bb7891-8c9c-499c-ba1c-95eabfcb6c9b"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "360ddd68-287d-4a88-a8b4-41aecf9fb665",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "37a8c51a-c125-4865-896a-abba80b88cf3",
+                    "Name": "CHALLENGEPACK_NITROGEN_KNIFEKILL_NAME",
+                    "ImageName": "images/challenges/Categories/PackNitrogen/Nitrogen_KnifeKill.jpg",
+                    "Description": "CHALLENGEPACK_NITROGEN_KNIFEKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "TargetKilled": false
+                        },
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": ["$.TargetKilled", true]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.OutfitIsHitmanSuit",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$or": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "5631dace-7f4a-4df8-8e97-b47373b815ff"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "d439fb64-8713-4c54-a3f3-90730dbdf370"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "cdab8f33-0491-497c-91c2-316c77d59e55"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "c03498c1-db54-402a-9923-63ada447a4b8"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "fecf585b-4bdb-4a9b-9ab0-2bc44c6bd84a"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.KillItemRepositoryId",
+                                                                "af2b1a36-a7f0-4003-aae4-a6076402542d"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "$set": ["TargetKilled", true]
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "medium", "assassination"]
+                },
+                {
+                    "Id": "3be7a0d1-359a-4b42-86d2-c42a6169bc34",
+                    "Name": "CHALLENGEPACK_NITROGEN_EXPLOSIVEKILL_NAME",
+                    "ImageName": "images/challenges/Categories/PackNitrogen/Nitrogen_ExplosiveKill.jpg",
+                    "Description": "CHALLENGEPACK_NITROGEN_EXPLOSIVEKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillClass",
+                                                        "explosion"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckDeath"
+                                    }
+                                ]
+                            },
+                            "CheckDeath": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 1
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$not": {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            }
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$not": {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            }
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "medium", "assassination"]
+                },
+                {
+                    "Id": "4b4210ba-a537-43e7-9828-af780c36030b",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "5012d3aa-5d28-4b7b-83aa-d388862bc3b9",
+                    "Name": "CHALLENGEPACK_OXYGEN_SHOTGUN_NAME",
+                    "ImageName": "images/challenges/Categories/PackOxygen/Oxygen_Shotgun.jpg",
+                    "Description": "CHALLENGEPACK_OXYGEN_SHOTGUN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "GuardsRequired": 5,
+                            "EligibleGuards": [
+                                "edf64cae-98b1-496e-8b13-31b8e65ccb7e",
+                                "77fea61d-7993-486c-a5d5-71a6e55d414c",
+                                "6024f334-d840-4418-b3b0-12a2870150c4",
+                                "7762eb11-138c-4d5b-bf3c-f28921cfa0e0",
+                                "020cded4-84d2-48f8-a593-a13b60574cf0",
+                                "dbebec2f-5a75-4713-bb08-c32f141bc9a5",
+                                "2458ad3d-1131-4dc8-a52b-101065b55f2c",
+                                "c8c6979e-2b8b-48cc-b405-7f1138b88e8c",
+                                "afbfb9f3-e629-44f4-bb6d-3537fb94898a",
+                                "a58ae30e-00ad-42ec-949d-1d6c5fe1bb47",
+                                "4e98437d-49e2-4cbd-a081-6c3f34c7797d",
+                                "8c5143d6-ac75-44a5-a67c-cd4cd4304e4a",
+                                "d0c2aa29-763e-45dc-a8fb-41d05322de9e",
+                                "1e6be31a-a6f6-4b61-b7fa-6e37d4b69a2c",
+                                "f0db3e8b-cf65-4c65-b607-f77284a0f644",
+                                "e77866f1-f51e-4be8-948d-2ce53289f588",
+                                "dddfaa8a-b4bc-42b4-a0ce-c44b1d1af75a",
+                                "e82f3d7f-4e8c-452f-97ae-b0a413cd0d14",
+                                "b8936aed-f498-403f-9167-d39ab02419b4",
+                                "77853169-4a3f-40de-90c3-e7b8fc09cc70",
+                                "c04e1fe2-9227-4c86-9068-8ef098d89b57",
+                                "9a469cd6-0689-49af-86ea-1a2d7022a1e5",
+                                "0ec76339-0fd9-4c83-9368-f235b66b3fa0",
+                                "e2196d59-c5fe-43e0-b7e8-508bde38cb67",
+                                "47c00c25-953a-45da-86e0-3fcdadea3487",
+                                "71d833e8-5f8d-4cd5-8dc8-48d5097f71e9",
+                                "6d64c21b-1ae4-47a8-aceb-120cb68ae362",
+                                "3b1bffed-bbcf-446e-8824-5855f9df7714",
+                                "0037cdef-80c5-40aa-85f8-1a28588ae954",
+                                "f1408061-856f-4017-a922-b297d72d1fb0",
+                                "e1363159-b0aa-40b5-bf01-a3ad41a5230d",
+                                "0b6e8324-8118-40b4-b0b8-4d75d03ff37f",
+                                "d37dbe48-0cd8-480d-9d61-28fe8057d3e1"
+                            ]
+                        },
+                        "Context": {
+                            "GuardsEliminated": 0
+                        },
+                        "ContextListeners": {
+                            "GuardsEliminated": {
+                                "count": "$.GuardsEliminated",
+                                "total": "$.GuardsRequired",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "901a3b51-51a0-4236-bdf2-23d20696b358"
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": "$.EligibleGuards"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "GuardsEliminated"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.GuardsEliminated",
+                                                "$.GuardsRequired"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Actions": {
+                                        "$set": ["GuardsEliminated", 0]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "medium", "assassination"]
+                },
+                {
+                    "Id": "6ff769a9-0e91-40b9-9348-21ee58d897d8",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "93899956-ce09-400c-b3c8-49da63f1f333",
+                    "Name": "CHALLENGEPACK_NITROGEN_NINJASNIPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackNitrogen/Nitrogen_NinjaSniper.jpg",
+                    "Description": "CHALLENGEPACK_NITROGEN_NINJASNIPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.name_metricvalue",
+                                            "ActorPacifiedByAquarium"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "easy", "assassination"]
+                },
+                {
+                    "Id": "c1bb7891-8c9c-499c-ba1c-95eabfcb6c9b",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "d260587d-fa93-48c3-bfe2-f71c588a7fbe",
+                    "Name": "CHALLENGEPACK_OXYGEN_LEDGE_NAME",
+                    "ImageName": "images/challenges/Categories/PackOxygen/Oxygen_Ledge.jpg",
+                    "Description": "CHALLENGEPACK_OXYGEN_LEDGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillMethodStrict",
+                                                        "accident_push"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "TargetDumped"
+                                    }
+                                ],
+                                "DumpInOcean": {
+                                    "Transition": "ActorInPool"
+                                }
+                            },
+                            "TargetDumped": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 2
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "DumpInOcean": {
+                                    "Transition": "Start"
+                                }
+                            },
+                            "ActorInPool": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 2
+                                    },
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "easy", "assassination"]
+                },
+                {
+                    "Id": "db2c3ede-a272-4c92-beab-504007dbb855",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_POOL_PUSH_NAME",
+                    "ImageName": "images/challenges/NewZealand/Pool_push.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_POOL_PUSH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "PoolPushEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "easy"]
+                },
+                {
+                    "Id": "e605092c-6ce9-4e4d-8acb-316e8552868d",
+                    "Name": "CHALLENGEPACK_OXYGEN_SCISSORS_NAME",
+                    "ImageName": "images/challenges/Categories/PackOxygen/Oxygen_Scissors.jpg",
+                    "Description": "CHALLENGEPACK_OXYGEN_SCISSORS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "6ecf1f15-453c-4783-9c70-8777c83934d7"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "easy", "assassination"]
+                },
+                {
+                    "Id": "f36e833b-e16f-4c9d-81ea-204197755a0c",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "8d72168f-539b-4e98-b4ba-fb75bc7214a5",
+                    "Name": "UI_CHALLENGES_SHEEP_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/NewZealand/area_discovered_sheep.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 6
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_SHEEP_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a8f290f5-faa2-4684-8291-d936ecb8627d",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_DRIFTWOOD_NAME",
+                    "ImageName": "images/challenges/NewZealand/Driftwood.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_DRIFTWOOD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "DriftwoodEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["discovery", "medium"]
+                },
+                {
+                    "Id": "abfb1b4d-1247-452a-ad80-890820d3b796",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_KIWI_NAME",
+                    "ImageName": "images/challenges/NewZealand/Kiwi.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_KIWI_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "KiwiEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["discovery", "easy"]
+                },
+                {
+                    "Id": "e25983a3-3e4d-48ef-a632-6fa386333b2b",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_47_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_47_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "d4dd18b3-2dbe-4ad2-8bfa-db5fdb9a6568"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f3cf1887-023f-4e5f-9a76-6d0b52aaa19a",
+                    "Name": "UI_CHALLENGES_NEWZEALAND_HOUSE_KEY_NAME",
+                    "ImageName": "images/challenges/NewZealand/House_key.jpg",
+                    "Description": "UI_CHALLENGES_NEWZEALAND_HOUSE_KEY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "HouseKeyEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["discovery", "easy"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "3400b27a-2380-4e92-bbfd-fb3d1deeed28",
+                    "Name": "UI_CHALLENGES_SHEEP_SANDMAN_NAME",
+                    "ImageName": "images/challenges/NewZealand/Sandman.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_SANDMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "InVolume": "false"
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "SandmanInsideVolumeEvent": {
+                                    "$set": ["InVolume", "true"]
+                                },
+                                "SandmanOutsideVolumeEvent": {
+                                    "$set": ["InVolume", "false"]
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9e85c891-9eb7-4f3c-8115-896bf54d979b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "ballistic"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$.InVolume", "true"]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "41443d3f-ad70-4657-9716-b6397ca46364",
+                    "Name": "UI_CHALLENGES_SHEEP_POOL_WHISKEY_POISON_NAME",
+                    "ImageName": "images/challenges/NewZealand/Pool_whiskey_poison.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_POOL_WHISKEY_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "293579a3-b1d9-415a-ad3f-9f876892d9b1"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "cd0769a7-ff21-450c-8fcc-91ac5982b036"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "95a1afc7-6b1c-44f6-a376-081c71e5d60d",
+                    "Name": "UI_CHALLENGES_SHEEP_ORSON_BATHES_NAME",
+                    "ImageName": "images/challenges/NewZealand/Orson_bathes.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_ORSON_BATHES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "InShower": "false"
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "EnteredShowerEvent": {
+                                    "$set": ["InShower", "true"]
+                                },
+                                "LeftShowerEvent": {
+                                    "$set": ["InShower", "false"]
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "293579a3-b1d9-415a-ad3f-9f876892d9b1"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "e17172cc-bf70-4df6-9828-d9856b1a24fd"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$.InShower", "true"]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "760597a5-1ff9-4f23-be1d-73ba6211b561",
+                    "Name": "UI_CONTRACT_OPUNTIA_SCARECROW_NAME",
+                    "ImageName": "images/contracts/Escalation/ContractEscalation_NewZealand_Opuntia_Scarecrow.jpg",
+                    "Description": "UI_CONTRACT_OPUNTIA_SCARECROW_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "2afecc9a-4fe9-411f-a34f-b038ef91ee98",
+                                "OrderIndex": 960,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_REWARD_HERO_HALLOWEENSANSPUMPKIN_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_REWARD_HERO_HALLOWEENSANSPUMPKIN_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "themed",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3184c551-4577-45fe-818d-02282ede9db9"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0,
+                            "Count": 0,
+                            "HalloweenGuards": [
+                                "c04e1fe2-9227-4c86-9068-8ef098d89b57",
+                                "d37dbe48-0cd8-480d-9d61-28fe8057d3e1",
+                                "47c00c25-953a-45da-86e0-3fcdadea3487",
+                                "0ec76339-0fd9-4c83-9368-f235b66b3fa0",
+                                "6024f334-d840-4418-b3b0-12a2870150c4",
+                                "71d833e8-5f8d-4cd5-8dc8-48d5097f71e9",
+                                "7762eb11-138c-4d5b-bf3c-f28921cfa0e0",
+                                "3663ff4d-c47d-4a5c-9de7-5d748449a6fd",
+                                "9a469cd6-0689-49af-86ea-1a2d7022a1e5",
+                                "77fea61d-7993-486c-a5d5-71a6e55d414c",
+                                "6d64c21b-1ae4-47a8-aceb-120cb68ae362",
+                                "dddfaa8a-b4bc-42b4-a0ce-c44b1d1af75a",
+                                "e2196d59-c5fe-43e0-b7e8-508bde38cb67",
+                                "4e98437d-49e2-4cbd-a081-6c3f34c7797d",
+                                "020cded4-84d2-48f8-a593-a13b60574cf0",
+                                "a58ae30e-00ad-42ec-949d-1d6c5fe1bb47",
+                                "c8c6979e-2b8b-48cc-b405-7f1138b88e8c",
+                                "51a33b0d-8262-4efe-a62e-1e0f798535da",
+                                "a358c870-516f-4158-890d-63014b962455",
+                                "0b6e8324-8118-40b4-b0b8-4d75d03ff37f",
+                                "0037cdef-80c5-40aa-85f8-1a28588ae954",
+                                "3b1bffed-bbcf-446e-8824-5855f9df7714",
+                                "afbfb9f3-e629-44f4-bb6d-3537fb94898a",
+                                "dbebec2f-5a75-4713-bb08-c32f141bc9a5"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$inarray": {
+                                                        "in": "$.HalloweenGuards",
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "8e445d94-9294-4087-af0d-178ef1f8c8f7"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$remove": [
+                                                "HalloweenGuards",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        true,
+                                                        "$.RecordingDestroyed"
+                                                    ]
+                                                },
+                                                {
+                                                    "$all": {
+                                                        "in": "$.Witnesses",
+                                                        "?": {
+                                                            "$any": {
+                                                                "in": "$.KilledTargets",
+                                                                "?": {
+                                                                    "$eq": [
+                                                                        "$.#",
+                                                                        "$.##"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": ["$.Count", "$.Goal"]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "DisguiseBlown": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["3efc73f9-33f0-4af6-9508-7208e6851394"]
+                    }
+                },
+                {
+                    "Id": "8bdce1b3-1508-472b-b0d3-ac674724835d",
+                    "Name": "UI_CONTRACT_OPUNTIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_NewZealand_Opuntia_Pacify_All.jpg",
+                    "Description": "UI_CONTRACT_OPUNTIA_CHALLENGE_BRIEFING",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "08022e2c-4954-4b63-b632-3ac50d018292",
+                                "OrderIndex": 702,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_WET_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_WET_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "tactical",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c2834cc6-0c71-4785-a976-c93aceb4c528"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats"],
+                    "InclusionData": {
+                        "ContractIds": ["3efc73f9-33f0-4af6-9508-7208e6851394"]
+                    }
+                },
+                {
+                    "Id": "9e999107-0d08-49eb-92e3-177e20d01a31",
+                    "Name": "UI_CONTRACT_OPUNTIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_NewZealand_Opuntia.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "GameAssets": [
+                                    "PROP_MELEE_SHURIKEN_BAT",
+                                    "PROP_MELEE_SHURIKEN_BAT"
+                                ],
+                                "RepositoryId": "92330cd4-1bb1-419e-98d3-ef26631504bf",
+                                "RepositoryAssets": [
+                                    "92330cd4-1bb1-419e-98d3-ef26631504bf",
+                                    "92330cd4-1bb1-419e-98d3-ef26631504bf",
+                                    "92330cd4-1bb1-419e-98d3-ef26631504bf"
+                                ],
+                                "Quality": "2",
+                                "UnlockOrder": 7
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_MELEE_SHURIKEN_BAT_NAME",
+                            "Id": "PROP_MELEE_SHURIKEN_BAT",
+                            "Type": "weapon",
+                            "Subtype": "melee",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "7ec875a3-a299-48db-bbf8-35975258f509"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "97c4148b-ecea-4735-87cd-563e9a4ad343"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3efc73f9-33f0-4af6-9508-7208e6851394"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "8383982b-9a99-407f-a5b0-f6757e40ae6f",
+                    "Name": "UI_CHALLENGES_SHEEP_ALMA_KILLED_NAME",
+                    "ImageName": "images/challenges/NewZealand/Alma_killed.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_ALMA_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "9e85c891-9eb7-4f3c-8115-896bf54d979b"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "17fdac23-9554-4714-9853-bc8c0ff905fc",
+                    "Name": "UI_CHALLENGES_SHEEP_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "2d17c8fc-bf8e-4d00-aaf8-2ecd065374f3",
+                    "Name": "UI_CHALLENGES_SHEEP_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "92d45a4c-e62c-4277-b6d8-25bc77040aea",
+                    "Name": "UI_CHALLENGES_SHEEP_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "f620c1ba-4ae4-4aea-b96a-f684557f0836",
+                                "2d17c8fc-bf8e-4d00-aaf8-2ecd065374f3",
+                                "17fdac23-9554-4714-9853-bc8c0ff905fc",
+                                "f88447e7-f947-466c-a8e7-4b245bf77194"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "f620c1ba-4ae4-4aea-b96a-f684557f0836",
+                    "Name": "UI_CHALLENGES_SHEEP_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                },
+                {
+                    "Id": "f88447e7-f947-466c-a8e7-4b245bf77194",
+                    "Name": "UI_CHALLENGES_SHEEP_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_SHEEP_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c65019e5-43a8-4a33-8a2a-84c750a5eeb3"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "2e2417f3-4829-48fb-866a-260a24b793e4",
+                    "Name": "UI_PEACH_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Peach_Group.jpg",
+                    "Description": "UI_PEACH_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "ParentLocationId": "LOCATION_PARENT_NEWZEALAND",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["39cc0603-4348-4dbf-9bd3-733cadf2913c"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/HOKKAIDO/_HOKKAIDO_CHALLENGES.json
+++ b/contractdata/HOKKAIDO/_HOKKAIDO_CHALLENGES.json
@@ -3231,6 +3231,126 @@
                     }
                 },
                 {
+                    "Id": "259f1e66-e454-4489-8fb6-cc92d37524e2",
+                    "Name": "CHALLENGEPACK_SILICON_SNOWBALLER_NAME",
+                    "ImageName": "images/challenges/Categories/PackSilicon/Silicon_Snowballer.jpg",
+                    "Description": "CHALLENGEPACK_SILICON_SNOWBALLER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Gameplay": {
+                                    "range": 0.5,
+                                    "damage": 0.6,
+                                    "clipsize": 0.2,
+                                    "rateoffire": 0.6
+                                },
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "concealedweapon",
+                                "RepositoryId": "77f644ef-6dbb-4f30-afef-5c3a6a26a665",
+                                "UnlockOrder": 10
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_HERO_PISTOL_ICEBALLER_NAME",
+                            "Id": "FIREARMS_HERO_PISTOL_ICEBALLER",
+                            "Type": "weapon",
+                            "Subtype": "pistol",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "276c8916-83d0-4367-b4b8-7574658e7a06"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "RequiredTargets": [
+                                "9bebb40a-3746-4ba2-8bfc-a1fcabaec72c",
+                                "b13314ab-ea25-48b7-9e51-8ebb87788e20",
+                                "a1f7ac80-7fe3-4df1-b332-539c78a72a87"
+                            ]
+                        },
+                        "Context": {
+                            "PacifiedTargets": []
+                        },
+                        "ContextListeners": {
+                            "PacifiedTargets": {
+                                "type": "challengecounter",
+                                "count": "($.PacifiedTargets).Count",
+                                "total": "($.RequiredTargets).Count"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "a6706101-3aaf-4797-a0f8-a5b6aac9cdfe"
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": "$.RequiredTargets"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "PacifiedTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.PacifiedTargets).Count",
+                                                "($.RequiredTargets).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "live", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c414a084-a7b9-43ce-b6ca-590620acd87e"]
+                    }
+                },
+                {
                     "Id": "49dbcfaa-d54f-4d16-8a5d-a7da434a3248",
                     "Name": "CHALLENGEPACK_SILICON_WRAPPER_NAME",
                     "ImageName": "images/challenges/Categories/PackSilicon/Silicon_Wrapper.jpg",

--- a/contractdata/MENDOZA/_MENDOZA_CHALLENGES.json
+++ b/contractdata/MENDOZA/_MENDOZA_CHALLENGES.json
@@ -1,0 +1,5263 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_ELEGANT"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "09e8d272-f1cf-426f-93cf-9a670607eaaf",
+                    "Name": "UI_CHALLENGES_LLAMA_PINOTNOIR_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_pinotnoir.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_PINOTNOIR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PinotNoir": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "3bec3eb0-5701-496a-b076-298f0dc30289",
+                    "Name": "UI_CHALLENGES_LLAMA_AGENT17_NAME",
+                    "ImageName": "images/challenges/Elegant/BrotherFromAnotherBrother.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_AGENT17_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "a54b89f2-4d3b-4801-a202-1b95a98d7ced",
+                                "OrderIndex": 160,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_REWARD_HERO_AGENT17_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_REWARD_HERO_AGENT17_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "classic",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "94347f56-9158-496d-b459-53d10e25449e"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 2
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SniperTeamDealtWith": {
+                                    "Transition": "InPosition"
+                                }
+                            },
+                            "NotInPosition": {
+                                "EnterVolume": {
+                                    "Transition": "InPosition"
+                                }
+                            },
+                            "InPosition": {
+                                "Exit_Volume": {
+                                    "Transition": "NotInPosition"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "7d64d9df-5d30-4e98-9af0-7562ee145d5c"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "6effe91f-688c-4501-a8df-f8c62147be40",
+                    "Name": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_MARITICIDE_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_mariticide_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_MARITICIDE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "YatesEliminateMariticide": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "87fe1e5b-6b9b-428f-aaa2-199f35f9ef8c",
+                    "Name": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_BRANSON_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_branson_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_BRANSON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "YatesEliminateBranson": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "8fac0a9f-79fc-4716-bbd3-d1102989e3f7",
+                    "Name": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_LAWYER_PEN_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_Lawyer_Pen_Kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_LAWYER_PEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "YatesPenKill": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "9445c035-8780-4dba-8bfd-6866f09ade08",
+                    "Name": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_GARDENSHREDDER_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_gardenshredder_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_GARDENSHREDDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "YatesEliminateShredder": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "a15e3f78-9edc-478d-b33a-3c35970753aa",
+                    "Name": "UI_CHALLENGES_LLAMA_VIDAL_ELIMINATE_ELECTROCUTION_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_electrocution_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_VIDAL_ELIMINATE_ELECTROCUTION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "651ceb9a-117f-4f8d-89dd-9b6bd2a38b5a"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "accident_electric"
+                                                        ]
+                                                    },
+                                                    "in": [
+                                                        "$Value.KillMethodBroad",
+                                                        "$Value.KillMethodStrict"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "b1a98673-a834-4c65-b9f3-29ed3164b109",
+                    "Name": "UI_CHALLENGES_LLAMA_VIDAL_ELIMINATE_CRUSHERPRESSER_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_crusherpresser_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_VIDAL_ELIMINATE_CRUSHERPRESSER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VidalEliminateCrusherPresser": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "b1c12d6d-debd-459b-a598-14d3cd6b7a5d",
+                    "Name": "UI_CHALLENGES_LLAMA_BOTH_ELIMINATE_PROXY_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_proxy_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_BOTH_ELIMINATE_PROXY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 2
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EliminateProxy": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "ce4bd143-90f4-4765-a813-844cc50f8d25",
+                    "Name": "UI_CHALLENGES_LLAMA_VIDAL_ELIMINATE_HYPOTHERMIA_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_hypothermia_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_VIDAL_ELIMINATE_HYPOTHERMIA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VidalEliminateHypothermia": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "dd07e325-54ce-4a18-ab36-8636e5677050",
+                    "Name": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_GRANDPALADIN_NAME",
+                    "ImageName": "images/challenges/Elegant/LLama_grandpaladin_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_YATES_ELIMINATE_GRANDPALADIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "YatesEliminateGrandpaladin": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "34e75f03-7b37-4e51-8cee-e86f170f6b94",
+                    "Name": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "53ac8d63-b32d-4d65-a933-201b8e20f6c9",
+                    "Name": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "693630fc-ba5c-4e33-89bd-6136d37044b9",
+                    "Name": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "8d5a414e-f752-41ad-aab9-a9ec80d8ad66",
+                    "Name": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "9d9581ab-b795-4d9b-9c01-e8e00ec80704",
+                    "Name": "UI_CHALLENGES_ELEGANT_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "34e75f03-7b37-4e51-8cee-e86f170f6b94",
+                                "53ac8d63-b32d-4d65-a933-201b8e20f6c9",
+                                "693630fc-ba5c-4e33-89bd-6136d37044b9",
+                                "8d5a414e-f752-41ad-aab9-a9ec80d8ad66",
+                                "d2a3ceaf-cfe6-4353-9297-2d532b54ab33"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "d2a3ceaf-cfe6-4353-9297-2d532b54ab33",
+                    "Name": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "0929e97a-befe-416b-bdae-4e06ca581b9c",
+                    "Name": "UI_CHALLENGES_ELEGANT_BECOME_HERALD_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_disguise_herald.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_BECOME_HERALD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "f5b24132-7a6b-4a3f-868d-193b8692a52b"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "0cf3ec7c-345f-4a31-b4a6-a8916ff1a7f2",
+                    "Name": "UI_CHALLENGES_ELEGANT_EXIT_BOAT_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_exit_boat.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_EXIT_BOAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "4c70c22c-1a69-432a-8ae0-1742606dcc0a"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "1131c30d-cf02-4444-aafa-694cea2ce124",
+                    "Name": "UI_CHALLENGES_ELEGANT_DOOR_B_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_Door_B.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_DOOR_B_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Elegant_Door_B_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "14355177-f245-458d-9b1a-e112d6d8412f",
+                    "Name": "UI_CHALLENGES_ELEGANT_OBTAIN_SNIPER_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_obtain_sniper.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_OBTAIN_SNIPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Elegant_Obtain_Sniper": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "143c5b0a-966b-4094-b173-ae07351acb68",
+                    "Name": "UI_CHALLENGES_ELEGANT_OBTAIN_GRANDPALADIN_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_obtain_grandpaladin.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_OBTAIN_GRANDPALADIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "2d960bf0-217c-400d-a1ee-f721e18f2926"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "1e31a92b-c8b6-481f-98a2-5211edfdb633",
+                    "Name": "UI_CHALLENGES_ELEGANT_EXIT_CAVE_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_exit_cave.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_EXIT_CAVE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "32c0f28a-d76f-4cfe-9c08-30bc99ac5993"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "22013398-2e85-4556-b244-4068220f745d",
+                    "Name": "UI_CHALLENGES_ELEGANT_EXIT_CAR_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_exit_car.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_EXIT_CAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "bcdd0e1c-11fc-434f-97d2-a1f20d56b2dd"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "2766eca6-ef13-4d18-82be-71a230b99091",
+                    "Name": "UI_CHALLENGES_ELEGANT_BECOME_WAITER_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_disguise_waiter.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_BECOME_WAITER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "cac0081e-9eb0-4fbf-ba23-70c2815f0874"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "2bf3c46f-05d1-4b9c-aa4c-cbff70195420",
+                    "Name": "UI_CHALLENGES_ELEGANT_BECOME_WORKER_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_disguise_worker.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_BECOME_WORKER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "bbdfca80-abef-4b43-953e-9a46c3eee2eb"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "398ecf71-d404-4085-94a2-8e82156c8140",
+                    "Name": "UI_CHALLENGES_ELEGANT_OBTAIN_GRRAPEVINE_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_obtain_grapevine.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_OBTAIN_GRAPEVINE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "3fbd6da4-c61c-40d6-9494-8277d2e172e4"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4a75fb3f-b8a5-4f0e-b64c-044f48246c99",
+                    "Name": "UI_CHALLENGES_ELEGANT_DOOR_C_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_Door_C.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_DOOR_C_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Elegant_Door_C_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                },
+                {
+                    "Id": "55833bfc-1344-4767-a2c1-b49ac2a474e6",
+                    "Name": "UI_CHALLENGES_ELEGANT_EXIT_TANGO_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_exit_tango.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_EXIT_TANGO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ExitTango": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "8b861f50-694e-4174-b5bb-18d528ad08ac",
+                    "Name": "UI_CHALLENGES_ELEGANT_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "e887e53a-6b02-455d-88be-284af6d88e94",
+                                "69d4d32b-0fc9-4fde-8817-fafd98c13365",
+                                "aa7dc754-702a-401b-8f84-e806e958869c",
+                                "f5b24132-7a6b-4a3f-868d-193b8692a52b",
+                                "6ab03e04-9e88-4237-a596-96e3135420ab",
+                                "8d105591-dfbe-46aa-8520-f00f986b57e2",
+                                "cac0081e-9eb0-4fbf-ba23-70c2815f0874",
+                                "7fed7c24-08b2-468b-8e49-22b5ad59b56b",
+                                "bbdfca80-abef-4b43-953e-9a46c3eee2eb",
+                                "521ed265-2115-4977-8db0-45404b067102",
+                                "16df6808-97ac-4c3a-8d4b-7ddacfc8a7ea",
+                                "af56d687-ba1b-44c8-8061-fd4a4a1222a3",
+                                "08022e2c-4954-4b63-b632-3ac50d018292",
+                                "6c129ec5-41cb-43f1-837d-ebff54f260c6",
+                                "214b2143-3277-44cd-b20f-344747fc23d9"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "a41fa35f-8617-407e-b576-4ae82a9952bc",
+                    "Name": "UI_CHALLENGES_ELEGANT_EXIT_GRAPEFIELD_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_exit_grapefield.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_EXIT_GRAPEFIELD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "9fb145d0-37ab-4346-a0ca-839100d05a28"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "b7d3f2f2-be0d-43b8-8cde-50cc13b0f069",
+                    "Name": "UI_CHALLENGES_ELEGANT_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_AreaDiscovered.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 45
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_ELEGANT_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "cf5a72d4-e773-414b-84f0-70f3c71d5201",
+                    "Name": "UI_CHALLENGES_ELEGANT_OBTAIN_WINES_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_Wines.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_OBTAIN_WINES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CollectedWine": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "d4259efc-4e01-44ad-97af-073e2d007d09",
+                    "Name": "UI_CHALLENGES_ELEGANT_OBTAIN_SCANDAL_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_obtain_scandal.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_OBTAIN_SCANDAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "773e7624-307e-418e-b6cf-f9bc6dc6b295"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "ee4bd134-4e8d-4e60-9d9a-ac705e28e1ce",
+                    "Name": "UI_CHALLENGES_ELEGANT_BECOME_GAUCHO_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_disguise_gaucho.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_BECOME_GAUCHO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "e887e53a-6b02-455d-88be-284af6d88e94"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f5c2f1f9-98aa-43f7-a71f-c19f72dea85d",
+                    "Name": "UI_CHALLENGES_ELEGANT_BECOME_CHEF_NAME",
+                    "ImageName": "images/challenges/Elegant/elegant_disguise_chef.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_BECOME_CHEF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "8d105591-dfbe-46aa-8520-f00f986b57e2"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "fe368941-ba7a-419d-b870-abbf45fdf899",
+                    "Name": "UI_CHALLENGES_ELEGANT_DOOR_A_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_Door_a.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_DOOR_A_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Elegant_Door_A_Open": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery", "shortcut"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "11794549-46cb-40ec-b4ef-c9e20633bc8e",
+                    "Name": "UI_CHALLENGES_LLAMA_GRAPEPACIFY_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_GrapePacify.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_GRAPEPACIFY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.SetPieceId",
+                                            "90922481-cf35-455b-9321-8baceb51ed62"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "37b44bfe-5fd5-4ebb-a8fd-84bf700fa667",
+                    "Name": "UI_CHALLENGES_LLAMA_MISSIONSTORY_PRIVATETOUR_NAME",
+                    "ImageName": "images/challenges/elegant/llama_ms_privatetour.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_MISSIONSTORY_PRIVATETOUR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "ad88d89a-3bda-401e-9e57-fc66264f239c"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "3a9a8883-6c0b-45f4-b9fb-3a3c5b039700",
+                    "Name": "UI_CHALLENGES_LLAMA_WINERUN_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_winerun.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_WINERUN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Winerun": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "3ce2b1d6-6492-43c2-b19f-5883c7c91588",
+                    "Name": "UI_CHALLENGES_LLAMA_MISSIONSTORY_CLOSINGSTATEMENT_NAME",
+                    "ImageName": "images/challenges/elegant/llama_ms_closingstatement.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_MISSIONSTORY_CLOSINGSTATEMENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "8be0a94b-9663-491f-b6f8-a06d7a0342db"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "4dabc50b-4b6e-40b9-82e5-68aa9e4ae31c",
+                    "Name": "UI_CHALLENGES_LLAMA_FERMENTATION_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_fermentation.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_FERMENTATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Fermentation": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "56f9c697-7b54-49a5-abe1-ef27339ebe9b",
+                    "Name": "UI_CHALLENGES_LLAMA_MISSIONSTORY_EYESONTARGET_NAME",
+                    "ImageName": "images/challenges/elegant/llama_ms_eyesontarget.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_MISSIONSTORY_EYESONTARGET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "0854c929-4291-42fa-ba73-f2b7a2659d83"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "5dda1391-0a5e-4dfa-8e31-108c3d5192ec",
+                    "Name": "UI_CHALLENGES_LLAMA_ASADO_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_asado.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_ASADO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AsadoServed": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "704534c9-5ae6-4017-a33f-d8816a22e4e5",
+                    "Name": "UI_CHALLENGES_LLAMA_BOTH_ELIMINATE_GAS_NAME",
+                    "ImageName": "images/challenges/Elegant/LLama_gas_kill.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_BOTH_ELIMINATE_GAS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BothEliminateGas": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "8eefbfdc-6209-43c9-8b7b-a1f1e5fadfde",
+                    "Name": "UI_CHALLENGES_LLAMA_MELONMAN_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_melonman.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_MELONMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MelonMan": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "a7c3a32b-0290-4370-8c1e-930dba82bd50",
+                    "Name": "UI_CHALLENGES_LLAMA_TOURGUIDE_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_tourguide.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_TOURGUIDE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Tourguide": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "c53f269f-91cc-4239-ac64-0e4301ba674b",
+                    "Name": "UI_CHALLENGES_LLAMA_WINEFRIDGEVENT_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_winefridgevent.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_WINEFRIDGEVENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Winefridgevent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "d4a2bb03-fa76-44be-b43f-3889f22fb4d7",
+                    "Name": "UI_CHALLENGES_LLAMA_MRRIEPER_NAME",
+                    "ImageName": "images/challenges/Elegant/Llama_mrrieper.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_MRRIEPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MrRieper": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "e5da0285-7cda-4131-a9ad-4a9b5a0ee6d8",
+                    "Name": "UI_CHALLENGES_LLAMA_MISSIONSTORY_OVERTHETOP_NAME",
+                    "ImageName": "images/challenges/elegant/llama_ms_overflow.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_MISSIONSTORY_OVERTHETOP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "53f38ab3-bbdf-4a73-97e1-697c5695519a"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "1a3a2fd4-55f1-4da4-a2ef-7890f2104d1f",
+                    "Name": "UI_CHALLENGE_FRANGIPANI_SA_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani_Challenge_SA.jpg",
+                    "Description": "UI_CHALLENGE_FRANGIPANI_SA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "Objectives": [
+                                "9ed268c6-5b1c-4f62-84cf-26bac737e40a",
+                                "ad257c8e-33d3-4c97-bf3c-5f101b88ca0f",
+                                "d9bbd8af-cb85-47d9-84ab-c3e94b9970ce",
+                                "b4617c68-6eb9-4db8-a9c0-2ae3829d0003",
+                                "00b17ae8-8afb-4f69-9cb8-dd8e22a706ae",
+                                "099b3c29-1056-4002-a775-76291e598f5f",
+                                "f7598298-30c4-46f8-81f8-e43b8abc58ec"
+                            ],
+                            "Contract1": "b7c1de70-6bbc-4a9b-9f89-8ec00ba6b8b2",
+                            "Contract2": "25fb11e4-9cd5-4deb-a583-4982b9803298",
+                            "Contract3": "615beb4f-ba37-4e95-bead-3638cd240976",
+                            "KillGoal1": 1,
+                            "KillGoal2": 3,
+                            "KillGoal3": 3,
+                            "WinGoal": 3
+                        },
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0,
+                            "KillCount": 0,
+                            "WinCount": 0,
+                            "LastContractWon": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "ContextListeners": {
+                            "WinCount": {
+                                "type": "challengecounter",
+                                "count": "$.WinCount",
+                                "total": "$.WinGoal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Actions": [
+                                            {
+                                                "$set": ["Witnesses", []]
+                                            },
+                                            {
+                                                "$set": ["KilledTargets", []]
+                                            },
+                                            {
+                                                "$set": [
+                                                    "RecordingDestroyed",
+                                                    true
+                                                ]
+                                            },
+                                            {
+                                                "$set": ["LastAccidentTime", 0]
+                                            },
+                                            {
+                                                "$set": ["KillCount", 0]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.LastContractWon"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$dec": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "00000000-0000-0000-0000-000000000000"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.Contract1"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$set": ["WinCount", 0]
+                                        }
+                                    }
+                                ],
+                                "ObjectiveCompleted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": ["$.#", "$Value.Id"]
+                                            },
+                                            "in": "$.Objectives"
+                                        }
+                                    },
+                                    "Actions": {
+                                        "$inc": "KillCount"
+                                    }
+                                },
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        true,
+                                                        "$.RecordingDestroyed"
+                                                    ]
+                                                },
+                                                {
+                                                    "$all": {
+                                                        "in": "$.Witnesses",
+                                                        "?": {
+                                                            "$any": {
+                                                                "in": "$.KilledTargets",
+                                                                "?": {
+                                                                    "$eq": [
+                                                                        "$.#",
+                                                                        "$.##"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "$or": [
+                                                        {
+                                                            "$and": [
+                                                                {
+                                                                    "$eq": [
+                                                                        "$ContractId",
+                                                                        "$.Contract1"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "$ge": [
+                                                                        "$.KillCount",
+                                                                        "$.KillGoal1"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$and": [
+                                                                {
+                                                                    "$eq": [
+                                                                        "$ContractId",
+                                                                        "$.Contract2"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "$ge": [
+                                                                        "$.KillCount",
+                                                                        "$.KillGoal2"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$and": [
+                                                                {
+                                                                    "$eq": [
+                                                                        "$ContractId",
+                                                                        "$.Contract3"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "$ge": [
+                                                                        "$.KillCount",
+                                                                        "$.KillGoal3"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "$ContractId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$ge": ["$.WinCount", "$.WinGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "Failure": {
+                                "ContractEnd": {
+                                    "Transition": "Start"
+                                },
+                                "ContractFailed": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "33098e9c-b39b-478f-9cfb-01ab7c3ca566",
+                    "Name": "UI_CONTRACT_FRANGIPANI_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani_ItemReward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Gameplay": {},
+                                "Quality": 4,
+                                "Rarity": "common",
+                                "LoadoutSlot": "carriedweapon",
+                                "RepositoryId": "f4e92f7a-c13e-4f7f-8406-137dfd3f8378"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_FIREARMS_SNIPER_JAEGER_7_TUATARA_ENVY_NAME",
+                            "Id": "FIREARMS_SNIPER_JAEGER_7_TUATARA_ENVY",
+                            "Type": "weapon",
+                            "Subtype": "sniperrifle",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3393062e-621f-4069-9a33-acdf7fb4e53c"
+                        },
+                        {
+                            "Properties": {
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "ac2b7cf1-523a-4aee-a73b-5b2ccfd6079f",
+                                "Quality": 4
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_MELEE_DAGGER_ENVY_NAME",
+                            "Id": "PROP_MELEE_DAGGER_ENVY",
+                            "Type": "weapon",
+                            "Subtype": "melee",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": true,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "6b9af417-9ebf-4be6-8ed9-67dc5529766b"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "b7c1de70-6bbc-4a9b-9f89-8ec00ba6b8b2"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "3f67f64a-60cf-4583-ae97-7a000ff75aaa",
+                    "Name": "UI_CHALLENGE_FRANGIPANI_ALLTARGETS_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani_Challenge_AllTargets.jpg",
+                    "Description": "UI_CHALLENGE_FRANGIPANI_ALLTARGETS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "Objectives": [
+                                "4c4db429-db93-4f87-8d68-7ea20959fb7e",
+                                "961e85d3-adda-4693-b506-c852adffef8a",
+                                "4f0b769c-1259-4079-af55-d4645dd5234d",
+                                "ff275165-04bf-4b3b-87e0-85b73db15b40",
+                                "15385cb1-fd6f-4357-adad-60020fd2a599",
+                                "6e9a3efe-1ccf-4899-948b-3450c74efe87",
+                                "0961ff91-7e3b-48ad-a63b-33a144fcb53b"
+                            ],
+                            "Contract1": "b7c1de70-6bbc-4a9b-9f89-8ec00ba6b8b2",
+                            "Contract2": "25fb11e4-9cd5-4deb-a583-4982b9803298",
+                            "Contract3": "615beb4f-ba37-4e95-bead-3638cd240976",
+                            "KillGoal1": 1,
+                            "KillGoal2": 3,
+                            "KillGoal3": 3,
+                            "WinGoal": 3
+                        },
+                        "Context": {
+                            "KillCount": 0,
+                            "WinCount": 0,
+                            "LastContractWon": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "ContextListeners": {
+                            "WinCount": {
+                                "type": "challengecounter",
+                                "count": "$.WinCount",
+                                "total": "$.WinGoal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["KillCount", 0]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.LastContractWon"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$dec": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "00000000-0000-0000-0000-000000000000"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.Contract1"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$set": ["WinCount", 0]
+                                        }
+                                    }
+                                ],
+                                "ObjectiveCompleted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": ["$.#", "$Value.Id"]
+                                            },
+                                            "in": "$.Objectives"
+                                        }
+                                    },
+                                    "Actions": {
+                                        "$inc": "KillCount"
+                                    }
+                                },
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract1"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal1"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract2"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal2"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract3"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal3"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "$ContractId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$ge": ["$.WinCount", "$.WinGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "647bf978-f7dd-4c45-b05c-fc216cd1adf2",
+                    "Name": "UI_CHALLENGE_FRANGIPANI_WIN_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani_Challenge_Win.jpg",
+                    "Description": "UI_CHALLENGE_FRANGIPANI_WIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "Objectives": [
+                                "4c4db429-db93-4f87-8d68-7ea20959fb7e",
+                                "961e85d3-adda-4693-b506-c852adffef8a",
+                                "4f0b769c-1259-4079-af55-d4645dd5234d",
+                                "ff275165-04bf-4b3b-87e0-85b73db15b40",
+                                "15385cb1-fd6f-4357-adad-60020fd2a599",
+                                "6e9a3efe-1ccf-4899-948b-3450c74efe87",
+                                "0961ff91-7e3b-48ad-a63b-33a144fcb53b"
+                            ],
+                            "Contract1": "b7c1de70-6bbc-4a9b-9f89-8ec00ba6b8b2",
+                            "Contract2": "25fb11e4-9cd5-4deb-a583-4982b9803298",
+                            "Contract3": "615beb4f-ba37-4e95-bead-3638cd240976",
+                            "KillGoal1": 1,
+                            "KillGoal2": 2,
+                            "KillGoal3": 2,
+                            "WinGoal": 3
+                        },
+                        "Context": {
+                            "KillCount": 0,
+                            "WinCount": 0,
+                            "LastContractWon": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "ContextListeners": {
+                            "WinCount": {
+                                "type": "challengecounter",
+                                "count": "$.WinCount",
+                                "total": "$.WinGoal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["KillCount", 0]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.LastContractWon"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$dec": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "00000000-0000-0000-0000-000000000000"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.Contract1"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$set": ["WinCount", 0]
+                                        }
+                                    }
+                                ],
+                                "ObjectiveCompleted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": ["$.#", "$Value.Id"]
+                                            },
+                                            "in": "$.Objectives"
+                                        }
+                                    },
+                                    "Actions": {
+                                        "$inc": "KillCount"
+                                    }
+                                },
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract1"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal1"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract2"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal2"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract3"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal3"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "$ContractId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$ge": ["$.WinCount", "$.WinGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "9b429345-e67a-478f-9957-15a2a24c6519",
+                    "Name": "UI_CHALLENGE_FRANGIPANI_ALLCONDITIONS_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani_Challenge_AllConditions.jpg",
+                    "Description": "UI_CHALLENGE_FRANGIPANI_ALLCONDITIONS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "Objectives": [
+                                "9ed268c6-5b1c-4f62-84cf-26bac737e40a",
+                                "ad257c8e-33d3-4c97-bf3c-5f101b88ca0f",
+                                "d9bbd8af-cb85-47d9-84ab-c3e94b9970ce",
+                                "b4617c68-6eb9-4db8-a9c0-2ae3829d0003",
+                                "00b17ae8-8afb-4f69-9cb8-dd8e22a706ae",
+                                "099b3c29-1056-4002-a775-76291e598f5f",
+                                "f7598298-30c4-46f8-81f8-e43b8abc58ec"
+                            ],
+                            "Contract1": "b7c1de70-6bbc-4a9b-9f89-8ec00ba6b8b2",
+                            "Contract2": "25fb11e4-9cd5-4deb-a583-4982b9803298",
+                            "Contract3": "615beb4f-ba37-4e95-bead-3638cd240976",
+                            "KillGoal1": 1,
+                            "KillGoal2": 3,
+                            "KillGoal3": 3,
+                            "WinGoal": 3
+                        },
+                        "Context": {
+                            "KillCount": 0,
+                            "WinCount": 0,
+                            "LastContractWon": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "ContextListeners": {
+                            "WinCount": {
+                                "type": "challengecounter",
+                                "count": "$.WinCount",
+                                "total": "$.WinGoal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["KillCount", 0]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.LastContractWon"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$dec": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "00000000-0000-0000-0000-000000000000"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.Contract1"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$set": ["WinCount", 0]
+                                        }
+                                    }
+                                ],
+                                "ObjectiveCompleted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": ["$.#", "$Value.Id"]
+                                            },
+                                            "in": "$.Objectives"
+                                        }
+                                    },
+                                    "Actions": {
+                                        "$inc": "KillCount"
+                                    }
+                                },
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract1"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal1"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract2"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal2"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$ContractId",
+                                                                "$.Contract3"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$ge": [
+                                                                "$.KillCount",
+                                                                "$.KillGoal3"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "$ContractId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$ge": ["$.WinCount", "$.WinGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "bd289d15-f398-4ff6-a033-1b399cb8e2bf",
+                    "Name": "UI_CHALLENGE_FRANGIPANI_SASO_NAME",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani_Challenge_SASO.jpg",
+                    "Description": "UI_CHALLENGE_FRANGIPANI_SASO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "Objectives": [
+                                "9ed268c6-5b1c-4f62-84cf-26bac737e40a",
+                                "ad257c8e-33d3-4c97-bf3c-5f101b88ca0f",
+                                "d9bbd8af-cb85-47d9-84ab-c3e94b9970ce",
+                                "b4617c68-6eb9-4db8-a9c0-2ae3829d0003",
+                                "00b17ae8-8afb-4f69-9cb8-dd8e22a706ae",
+                                "099b3c29-1056-4002-a775-76291e598f5f",
+                                "f7598298-30c4-46f8-81f8-e43b8abc58ec"
+                            ],
+                            "Contract1": "b7c1de70-6bbc-4a9b-9f89-8ec00ba6b8b2",
+                            "Contract2": "25fb11e4-9cd5-4deb-a583-4982b9803298",
+                            "Contract3": "615beb4f-ba37-4e95-bead-3638cd240976",
+                            "KillGoal1": 1,
+                            "KillGoal2": 3,
+                            "KillGoal3": 3,
+                            "WinGoal": 3
+                        },
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0,
+                            "KillCount": 0,
+                            "WinCount": 0,
+                            "LastContractWon": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "ContextListeners": {
+                            "WinCount": {
+                                "type": "challengecounter",
+                                "count": "$.WinCount",
+                                "total": "$.WinGoal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Actions": [
+                                            {
+                                                "$set": ["Witnesses", []]
+                                            },
+                                            {
+                                                "$set": ["KilledTargets", []]
+                                            },
+                                            {
+                                                "$set": [
+                                                    "RecordingDestroyed",
+                                                    true
+                                                ]
+                                            },
+                                            {
+                                                "$set": ["LastAccidentTime", 0]
+                                            },
+                                            {
+                                                "$set": ["KillCount", 0]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.LastContractWon"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$dec": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "00000000-0000-0000-0000-000000000000"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$ContractId",
+                                                "$.Contract1"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$set": ["WinCount", 0]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "ObjectiveCompleted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": ["$.#", "$Value.Id"]
+                                            },
+                                            "in": "$.Objectives"
+                                        }
+                                    },
+                                    "Actions": {
+                                        "$inc": "KillCount"
+                                    }
+                                },
+                                "ContractEnd": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        true,
+                                                        "$.RecordingDestroyed"
+                                                    ]
+                                                },
+                                                {
+                                                    "$all": {
+                                                        "in": "$.Witnesses",
+                                                        "?": {
+                                                            "$any": {
+                                                                "in": "$.Targets",
+                                                                "?": {
+                                                                    "$eq": [
+                                                                        "$.#",
+                                                                        "$.##"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "$or": [
+                                                        {
+                                                            "$and": [
+                                                                {
+                                                                    "$eq": [
+                                                                        "$ContractId",
+                                                                        "$.Contract1"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "$ge": [
+                                                                        "$.KillCount",
+                                                                        "$.KillGoal1"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$and": [
+                                                                {
+                                                                    "$eq": [
+                                                                        "$ContractId",
+                                                                        "$.Contract2"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "$ge": [
+                                                                        "$.KillCount",
+                                                                        "$.KillGoal2"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$and": [
+                                                                {
+                                                                    "$eq": [
+                                                                        "$ContractId",
+                                                                        "$.Contract3"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "$ge": [
+                                                                        "$.KillCount",
+                                                                        "$.KillGoal3"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "WinCount",
+                                            "$set": [
+                                                "LastContractWon",
+                                                "$ContractId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$ge": ["$.WinCount", "$.WinGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "Failure": {
+                                "ContractEnd": {
+                                    "Transition": "Start"
+                                },
+                                "ContractFailed": {
+                                    "Transition": "Start"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "d3072b5e-381a-4699-999e-653283bb6495",
+                    "Name": "UI_CONTRACT_FRANGIPANI_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani_Reward.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "8ae5d394-49d1-4aaa-a51d-85d0bbe6bca9",
+                                "OrderIndex": 1026,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_ENVY_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_ENVY_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "sins",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "95ad82bb-c602-439b-8b8e-c8306121aeb9"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "f54bae9b-080f-444c-814e-4249f8fe299f",
+                    "Name": "UI_CONTRACT_FRANGIPANI_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Frangipani.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "615beb4f-ba37-4e95-bead-3638cd240976"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["8c8ed496-948f-4672-879b-4d9575406577"]
+                    }
+                },
+                {
+                    "Id": "1a93f31d-8c1f-4f13-aa63-b6019962f28d",
+                    "Name": "UI_CONTRACT_JACARANDA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_Jacaranda.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "b6d195ed-218f-4027-b789-4db9d5553a17"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["14a21819-f81f-453d-8734-a3aab528fa62"]
+                    }
+                },
+                {
+                    "Id": "1401aa3e-bc59-4432-b9a5-015b7b62530c",
+                    "Name": "UI_CONTRACT_WHITEDRYAS_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_WhiteDryas_Reward_Items.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_LEVEL1_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 4,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "83930544-d8db-4020-901f-ea6017764aaa",
+                                "UnlockOrder": 10
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_EMETIC_POISON_PEN_SYRINGE_GURU_NAME",
+                            "Id": "PROP_EMETIC_POISON_PEN_SYRINGE_GURU",
+                            "Type": "gear",
+                            "Subtype": "poison",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "5db59ddc-98c5-46ed-8823-0a91fda6ee04"
+                        },
+                        {
+                            "Properties": {
+                                "Quality": 3,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "a49fe9f6-aa5a-4000-8aec-2902ab57b4b7"
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_GAS_GRENADE_EMETIC_GURU_NAME",
+                            "Id": "PROP_GAS_GRENADE_EMETIC_GURU",
+                            "Type": "gear",
+                            "Subtype": "tool",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "8a914db9-9df7-4756-8616-b38168fb0db9"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "e14bbb5d-bd8a-4b6b-9749-4f147db0ebe0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["72aaaa7b-4386-4ee7-9e9e-73fb8ff8e416"]
+                    }
+                },
+                {
+                    "Id": "625470a9-69b6-4da5-b5df-d180a1940525",
+                    "Name": "UI_CONTRACT_WHITEDRYAS_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_WhiteDryas.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "3849e8d5-3876-48ef-b4e1-9b3a4489589a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["72aaaa7b-4386-4ee7-9e9e-73fb8ff8e416"]
+                    }
+                },
+                {
+                    "Id": "b530360e-3141-469e-9a48-072225906629",
+                    "Name": "UI_CONTRACT_WHITEDRYAS_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Elegant_WhiteDryas_Reward_Suit.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 1,
+                                "Rarity": "common",
+                                "LoadoutSlot": "disguise",
+                                "RepositoryId": "a4ef8071-8931-4179-abec-11a2b9ceba36",
+                                "OrderIndex": 1004,
+                                "AllowUpSync": true
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_TOKEN_OUTFIT_HERO_GURU_SUIT_NAME",
+                            "Id": "TOKEN_OUTFIT_HERO_GURU_SUIT",
+                            "Type": "disguise",
+                            "Subtype": "deluxe",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 99,
+                            "GamePrice": 99,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "2df3c803-8729-4bd1-b10f-4e2afc439c9c"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractStart": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["72aaaa7b-4386-4ee7-9e9e-73fb8ff8e416"]
+                    }
+                },
+                {
+                    "Id": "62e7cd73-7691-4c88-a329-69887bd6efd3",
+                    "Name": "UI_CHALLENGES_LLAMA_QRCODES_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_qrcodes.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_QRCODES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 7
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "QRCODE_Event_01": false,
+                            "QRCODE_Event_02": false,
+                            "QRCODE_Event_03": false,
+                            "QRCODE_Event_04": false,
+                            "QRCODE_Event_05": false,
+                            "QRCODE_Event_06": false,
+                            "QRCODE_Event_07": false
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "QRCODE_01": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.QRCODE_Event_01", false]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "QRCODE_Event_01",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "QRCODE_02": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.QRCODE_Event_02", false]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "QRCODE_Event_02",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "QRCODE_03": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.QRCODE_Event_03", false]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "QRCODE_Event_03",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "QRCODE_04": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.QRCODE_Event_04", false]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "QRCODE_Event_04",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "QRCODE_05": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.QRCODE_Event_05", false]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "QRCODE_Event_05",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "QRCODE_06": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.QRCODE_Event_06", false]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "QRCODE_Event_06",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ],
+                                "QRCODE_07": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.QRCODE_Event_07", false]
+                                        },
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$set": [
+                                                    "QRCODE_Event_07",
+                                                    true
+                                                ]
+                                            }
+                                        ],
+                                        "Transition": "CheckCount"
+                                    }
+                                ]
+                            },
+                            "CheckCount": {
+                                "-": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Transition": "Start"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                },
+                {
+                    "Id": "630234f5-a203-49db-af74-775ef2c41d30",
+                    "Name": "UI_CHALLENGES_ELEGANT_PRESSER_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_presser_feat.jpg",
+                    "Description": "UI_CHALLENGES_ELEGANT_PRESSER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_ELEGANT_LLAMA",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Presser": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "4107e3fd-6bb0-4b55-833a-6a4456fd3718",
+                    "Name": "UI_CHALLENGES_LLAMA_ELIMINATE_VIDAL_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_Llama_Vidal.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_ELIMINATE_VIDAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "651ceb9a-117f-4f8d-89dd-9b6bd2a38b5a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "cbfafaab-8c10-4fc0-a71f-e9e918e93ac2",
+                    "Name": "UI_CHALLENGES_LLAMA_ELIMINATE_YATES_NAME",
+                    "ImageName": "images/challenges/Elegant/Elegant_Llama_Yates.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_ELIMINATE_YATES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "57907f04-329e-4faf-b753-7e95d5c2e085"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "246f098c-3e1d-428e-bcf5-5fce86e2a5b8",
+                    "Name": "UI_CHALLENGES_LLAMA_SILENT_ASSASSIN_SUIT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_SILENT_ASSASSIN_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "suitonly", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "2e70c347-83a7-4cfb-9af8-2fc511e8c8ac",
+                    "Name": "UI_CHALLENGES_LLAMA_BIG4_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_BIG4_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "e5931ee2-09b0-4690-b1d1-854b4e94c955",
+                                "246f098c-3e1d-428e-bcf5-5fce86e2a5b8",
+                                "7e1efe31-5212-4be9-b9e9-0775c44ebde0",
+                                "b98f09a2-63ed-4e28-b27b-588df4e0b533"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "7e1efe31-5212-4be9-b9e9-0775c44ebde0",
+                    "Name": "UI_CHALLENGES_LLAMA_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "sniper", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "b98f09a2-63ed-4e28-b27b-588df4e0b533",
+                    "Name": "UI_CHALLENGES_LLAMA_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                },
+                {
+                    "Id": "e5931ee2-09b0-4690-b1d1-854b4e94c955",
+                    "Name": "UI_CHALLENGES_LLAMA_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_LLAMA_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["d42f850f-ca55-4fc9-9766-8c6a2b5c3129"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "ef6614ba-a480-4e35-8d40-66e195b28ee6",
+                    "Name": "UI_LYCHEE_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Lychee_Group.jpg",
+                    "Description": "UI_LYCHEE_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["a79640cb-331a-41af-abaf-58e629fe0a04"]
+                    }
+                },
+                {
+                    "Id": "0869c961-1637-42f3-a30e-ad53955d2714",
+                    "Name": "UI_SOURSOP_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Soursop_Group.jpg",
+                    "Description": "UI_SOURSOP_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["afb4ce18-bf9d-443d-85a8-207df9011792"]
+                    }
+                },
+                {
+                    "Id": "640fe414-3f60-4d12-ba7b-31b058b8faad",
+                    "Name": "UI_CHERIMOYA_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Cherimoya_Group.jpg",
+                    "Description": "UI_CHERIMOYA_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["17027c6f-7010-43b8-bb42-1a6846fc0b7b"]
+                    }
+                },
+                {
+                    "Id": "f3413b04-e274-4100-a4dc-e7083a5b3002",
+                    "Name": "UI_MELON_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Melon_Group.jpg",
+                    "Description": "UI_MELON_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_ELEGANT",
+                    "ParentLocationId": "LOCATION_PARENT_ELEGANT",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["2c2afdfe-d396-451a-a6a3-52aca4ea4f1f"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/MIAMI/_MIAMI_CHALLENGES.json
+++ b/contractdata/MIAMI/_MIAMI_CHALLENGES.json
@@ -1,0 +1,6185 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_MIAMI"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "033e0565-15a3-46eb-acbf-6b4f8f0792a8",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_RACE_CAR_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_RaceCar.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_RACE_CAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "d756bbae-26cf-4b8d-9792-86b37629403f"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "29031b19-5229-4747-8baa-e8c934005d6f",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "2abeb6a7-c7eb-47bb-8ab2-456e1fa3a9d9",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "2f16bbde-9e17-4ee8-9b5a-6a6edb2ccfa8",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "32d489e8-ca06-41be-8b6a-13d7b419d4e9",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_DROWNING_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Drowning.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_DROWNING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "4612a8fc-24f3-4ce0-9f2b-379e74497f86",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "516590c4-6840-40f2-aad4-d267ab2612e4",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_ELECTRICITY_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Electricity.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_ELECTRICITY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_electric"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "70e7b08a-82e0-444a-8386-578b28712c74",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_POISON_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Poison.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "consumed_poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "72387cc4-c2d2-4d95-92fb-824a4a7f4b8f",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_EXPLOSION_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Explosion.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_EXPLOSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "7f7cfd01-d085-4255-8398-bbb73500d65f",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_FIRE_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Fire.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_FIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_burn"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "8b1bb1c0-145a-40e6-8a9d-b7a1317ee17c",
+                    "Name": "UI_CHALLENGES_MIAMI_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "2abeb6a7-c7eb-47bb-8ab2-456e1fa3a9d9",
+                                "2f16bbde-9e17-4ee8-9b5a-6a6edb2ccfa8",
+                                "fb8c7378-c030-48a3-aec6-187279159490",
+                                "29031b19-5229-4747-8baa-e8c934005d6f",
+                                "4612a8fc-24f3-4ce0-9f2b-379e74497f86"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "b9561d87-9af2-4af3-8502-b65ee843bf7f",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_COCONUT_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Coconut.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_COCONUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "fb8c7378-c030-48a3-aec6-187279159490",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "06194934-e0fe-4fb3-9d53-cf86bec397ca",
+                    "Name": "UI_CHALLENGES_FLAMINGO_WHEEL_OF_MISFORTUNE_NAME",
+                    "ImageName": "images/challenges/Miami/Wheel_of_misfortune.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_WHEEL_OF_MISFORTUNE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "WheelOfMisfortuneEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "17f24f74-915d-4ae7-859e-0a3db77a319b",
+                    "Name": "UI_CHALLENGES_FLAMINGO_THE_MAN_AND_THE_SEA_NAME",
+                    "ImageName": "images/challenges/Miami/The_man_and_the_sea.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_THE_MAN_AND_THE_SEA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee454990-0c4b-49e5-9572-a67887325283"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f39a1df6-b57c-4020-9dad-5df2f411e6f5"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "2dbda297-b042-4913-8209-5d9145392076",
+                    "Name": "UI_CHALLENGES_FLAMINGO_DONT_DRIVE_AND_DRINK_NAME",
+                    "ImageName": "images/challenges/Miami/Dont_drive_and_drink.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_DONT_DRIVE_AND_DRINK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "94b4ee95-5a7e-4544-ac2e-f0ab9bcbc017"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "32e9f728-e5ba-4c3a-b95c-d04dce963f7b",
+                    "Name": "UI_CHALLENGES_FLAMINGO_VITAMIN_OVERDOSE_NAME",
+                    "ImageName": "images/challenges/Miami/Vitamin_overdose.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_VITAMIN_OVERDOSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VitamineOverdoseEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "468c5bdf-e58a-4ddf-9d30-f7951aa5bac3",
+                    "Name": "UI_CHALLENGES_FLAMINGO_DOUBLE_WHAMMY_NAME",
+                    "ImageName": "images/challenges/Miami/Double_whammy.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_DOUBLE_WHAMMY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DoubleWhammyEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "54c7ecf7-f587-4066-98d4-fb6fa8f23352",
+                    "Name": "UI_CHALLENGES_FLAMINGO_ANDROID_NAME",
+                    "ImageName": "images/challenges/Miami/Android.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_ANDROID_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee454990-0c4b-49e5-9572-a67887325283"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "824497cf-0c96-4826-a00e-5fb3ccf1140b"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "57dd78e6-de7e-4823-a9cc-f31cad82f750",
+                    "Name": "UI_CHALLENGES_FLAMINGO_DAYS_OF_THUNDER_NAME",
+                    "ImageName": "images/challenges/Miami/Days_of_thunder.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_DAYS_OF_THUNDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DaysOfThunderEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "6f49af69-4697-4004-b85d-c711d25f7714",
+                    "Name": "UI_CHALLENGES_FLAMINGO_EYEDROPS_NAME",
+                    "ImageName": "images/challenges/Miami/Eyedrops.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_EYEDROPS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee454990-0c4b-49e5-9572-a67887325283"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f8aa1446-d64b-4843-bfd7-62cbdf08a336"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "7818ee8f-7b27-4528-b064-3ef10a3993ad",
+                    "Name": "UI_CHALLENGES_FLAMINGO_HOT_SHOT_NAME",
+                    "ImageName": "images/challenges/Miami/Hot_shot.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_HOT_SHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "4bee9f68-8c1d-4455-bd39-da844bcfdf7e"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_burn"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "7b7e34ac-91f9-4b99-bc4c-a57e9d44ff33",
+                    "Name": "UI_CHALLENGES_FLAMINGO_WHOS_YOUR_DADDY_NAME",
+                    "ImageName": "images/challenges/Miami/Whos_your_daddy.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_WHOS_YOUR_DADDY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "WhosYourDaddyEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "8344bdd2-0926-40c9-9ab3-0c17e17d9f65",
+                    "Name": "UI_CHALLENGES_FLAMINGO_BETTER_BURN_UP_THAN_FADE_AWAY_NAME",
+                    "ImageName": "images/challenges/Miami/Better_burn_up_than_fade_away.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_BETTER_BURN_UP_THAN_FADE_AWAY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "b2e95d0f-3370-42d7-8b83-ff767374b9fa"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "96368a6c-7b48-42d0-8f0f-f98b06d0037b",
+                    "Name": "UI_CHALLENGES_FLAMINGO_HELPING_HAND_NAME",
+                    "ImageName": "images/challenges/Miami/Helping_hand.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_HELPING_HAND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SniperKillSierraCar": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "a9ebf452-e03f-4685-a947-378748d4a200",
+                    "Name": "UI_CHALLENGES_FLAMINGO_UNDER_THE_SEA_NAME",
+                    "ImageName": "images/challenges/Miami/Under_the_sea.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_UNDER_THE_SEA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee454990-0c4b-49e5-9572-a67887325283"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "b91b6766-233c-43c0-96dc-d64a588207fd"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "d3968ab9-8d01-4760-81fb-114f14700988",
+                    "Name": "UI_CHALLENGES_FLAMINGO_THE_MESSAGE_NAME",
+                    "ImageName": "images/challenges/Miami/The_message.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_THE_MESSAGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TheMessageEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "eb71159f-72a6-4686-9adf-38a0a1c6804d",
+                    "Name": "UI_CHALLENGES_FLAMINGO_PINK_MENACE_NAME",
+                    "ImageName": "images/challenges/Miami/Pink_menace.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_PINK_MENACE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PinkMenaceEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "f45b427f-052e-459c-b414-523f0c1b078f",
+                    "Name": "UI_CHALLENGES_FLAMINGO_THE_FLORIDA_DIET_NAME",
+                    "ImageName": "images/challenges/Miami/The_florida_diet.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_THE_FLORIDA_DIET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee454990-0c4b-49e5-9572-a67887325283"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "0a5e41e0-e74e-4f37-89b1-764d8cb40adf"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "f6bd5bda-5bad-48a3-abec-a662e41e608e",
+                    "Name": "UI_CHALLENGES_FLAMINGO_DEMOCAR_NAME",
+                    "ImageName": "images/challenges/Miami/Democar.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_DEMOCAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee454990-0c4b-49e5-9572-a67887325283"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "fa3b0cbc-cd05-4ef6-a900-a5094ec35ae0"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "fb864488-483d-4250-87b5-e4acc5dbbe40",
+                    "Name": "UI_CHALLENGES_FLAMINGO_DOCTOR_47_NAME",
+                    "ImageName": "images/challenges/Miami/Doctor_47.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_DOCTOR_47_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Doctor47Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "15b90a65-d9fc-428b-a72a-4b4416c22858",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "37f8bc5d-c415-49f6-ac0d-3f4fa4691d9e",
+                    "Name": "UI_CHALLENGES_MIAMI_SHAFTED_NAME",
+                    "ImageName": "images/challenges/Miami/Shafted.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_SHAFTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShaftedEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"]
+                },
+                {
+                    "Id": "6efa86e9-26a8-4e73-8ba5-1b777fcbd641",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "81895777-9fcb-4338-9c42-5b10236bce40",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "83d063c6-eb27-45aa-837a-56cffcf657a7",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "a28f1cb4-1e99-425e-bd47-89b5173bf2ac",
+                    "Name": "UI_CHALLENGES_MIAMI_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "bfdab5fe-d7a4-4455-ae33-9b4c3dec80c6",
+                    "Name": "UI_CHALLENGES_MIAMI_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "83d063c6-eb27-45aa-837a-56cffcf657a7",
+                                "a28f1cb4-1e99-425e-bd47-89b5173bf2ac",
+                                "81895777-9fcb-4338-9c42-5b10236bce40",
+                                "6efa86e9-26a8-4e73-8ba5-1b777fcbd641",
+                                "15b90a65-d9fc-428b-a72a-4b4416c22858"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "d227d468-5ec0-474a-b9cd-fc68f078f055",
+                    "Name": "CHALLENGEPACK_HELIUM_BIGGERFISH_NAME",
+                    "ImageName": "images/challenges/Categories/PackHelium/Helium_BiggerFish.jpg",
+                    "Description": "CHALLENGEPACK_HELIUM_BIGGERFISH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "f3e796af-bc6f-41db-8694-1424235250e7"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "f39a1df6-b57c-4020-9dad-5df2f411e6f5"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "easy", "assassination"]
+                },
+                {
+                    "Id": "d37743b8-b22c-4061-9fca-838aa98a949c",
+                    "Name": "UI_CHALLENGES_MIAMI_FISH_SLAPPING_DANCE_NAME",
+                    "ImageName": "images/challenges/Miami/Fish_slapping_dance.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_FISH_SLAPPING_DANCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "PacifiedActorID": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.KillItemRepositoryId",
+                                            "4d0d6b2a-dd81-474c-a412-3bf19af8233d"
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": [
+                                            "PacifiedActorID",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "PacifiedByFish"
+                                }
+                            },
+                            "PacifiedByFish": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 5
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.PacifiedActorID"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"]
+                },
+                {
+                    "Id": "e2835c6d-088a-4f88-987e-c4b9c9f9baaa",
+                    "Name": "CHALLENGEPACK_CHLORINE_SHREDDER_NAME",
+                    "ImageName": "images/challenges/Categories/PackChlorine/Chlorine_Shredder.jpg",
+                    "Description": "CHALLENGEPACK_CHLORINE_SHREDDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "58c3b7bc-8d89-48f8-927a-d9b4b7fdd8e4"
+                                        ]
+                                    },
+                                    "Transition": "Shredder"
+                                }
+                            },
+                            "Shredder": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 2
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "hard", "assassination"]
+                },
+                {
+                    "Id": "f53c1671-9d85-42c6-bb5d-2ce6610ad184",
+                    "Name": "UI_CHALLENGES_MIAMI_THOROUGH_DEMONSTRATION_NAME",
+                    "ImageName": "images/challenges/Miami/Thorough_demonstration.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_THOROUGH_DEMONSTRATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$not": {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "ee454990-0c4b-49e5-9572-a67887325283"
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "824497cf-0c96-4826-a00e-5fb3ccf1140b"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "4e12b107-7674-4207-b648-19a518a7d832",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_BOTTLES_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Bottles.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_BOTTLES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "RequiredBottleCount": 3
+                        },
+                        "Context": {
+                            "CurrentBottleCount": 0
+                        },
+                        "States": {
+                            "Start": {
+                                "BottleDestroyed": {
+                                    "Actions": {
+                                        "$inc": "CurrentBottleCount"
+                                    }
+                                },
+                                "RocketLaunched": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "4e7ed137-f3dc-4bb7-98f0-08b23c530f93",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_SERVER_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Server.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_SERVER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "e9ed2969-146a-472d-8e87-39c77bd1757d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "533ea2e7-6587-439a-ab32-3ae0090a16d1",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_WATER_TAP_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_WaterTap.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_WATER_TAP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "TapOpened": {
+                                    "Transition": "Success"
+                                },
+                                "TapBottleDestroyed": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "9d1661d0-2781-4987-8c07-3c606445bbe5",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_CAR_DESTROYED_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_CarDestroyed.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_CAR_DESTROYED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "CarDestroyed": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "bb0a0995-c10b-4e28-a59f-991e1a054ae2",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_DRIVER_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Driver.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_DRIVER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "bac37ceb-6f72-406f-bfa3-e49413436525"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "3952760a-2e6a-4b93-bc65-471ebba6eaf1",
+                    "Name": "UI_CHALLENGES_FLAMINGO_ITEM_FIND_BLACKMAIL_NAME",
+                    "ImageName": "images/challenges/Miami/Item_find_blackmail.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_ITEM_FIND_BLACKMAIL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "303ecf9a-50ad-4a90-a705-324ef225c0ac"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "04c88da5-c23b-433b-829d-d861c8c8fadd",
+                    "Name": "UI_CHALLENGES_MIAMI_SEWER_BEYOND_NAME",
+                    "ImageName": "images/challenges/Miami/SewerBeyond.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_SEWER_BEYOND_TITLE",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "22b03af7-f4a6-4a27-8c50-21da6c615e3e"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "16550145-0702-4d0f-b6c1-8188e74b127f",
+                    "Name": "UI_CHALLENGES_MIAMI_ITEM_FIND_VIP_INVITE_NAME",
+                    "ImageName": "images/challenges/Miami/Item_find_vip_invite.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_ITEM_FIND_VIP_INVITE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "5f9481cf-3cbf-4f9c-9394-c60d23753681"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "3e540f97-d352-4977-b619-47dfa8bc31f1",
+                    "Name": "UI_CHALLENGES_MIAMI_ITEM_FIND_COCAINE_NAME",
+                    "ImageName": "images/challenges/Miami/Item_find_cocaine.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_ITEM_FIND_COCAINE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "c6e9414e-e2ce-470a-95bd-14cd25225878"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "4c111c2b-0e64-47e1-b628-5034079a690a",
+                    "Name": "UI_CHALLENGES_MIAMI_YOU_GOT_A_FAST_CAR_NAME",
+                    "ImageName": "images/challenges/Miami/You_got_a_fast_car.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_YOU_GOT_A_FAST_CAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "YouGotAFastCarEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "546e0164-9ce6-4d89-82ff-44c344bddb3d",
+                    "Name": "UI_CHALLENGES_MIAMI_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "be9dd1c4-af52-43db-b8f7-37c3c054c90f",
+                                "085e639e-2cf4-4e9b-bd9b-f9fd5b899676",
+                                "fc829fad-5afc-4236-8662-65ab8698ef44",
+                                "da951ccc-1d8b-4d84-b30a-72e74ac2a312",
+                                "4376850a-3a37-4ad3-a886-168d0e24aa20",
+                                "981b7a3b-5548-4a6f-b568-f767784e6d91",
+                                "12181b2f-8c74-4761-8d78-3bedfbf9281d",
+                                "6fca97a0-cb80-4bd7-9a8f-106fa20a5d04",
+                                "46dedef3-bbcf-438c-af2b-c97dd853aac1",
+                                "bac37ceb-6f72-406f-bfa3-e49413436525",
+                                "124d145e-469e-485d-a628-ced82ddf1b75",
+                                "d7d8d5e8-070c-4d6c-9a67-f1165a7bb29d",
+                                "d37ae121-69b4-4a9c-ab57-972063505e2f",
+                                "dc5b1ccd-0997-4834-93a0-db7543e729cc",
+                                "d86e4379-4aad-42cf-a7cf-38d0fa7e727b",
+                                "2a5a3dba-bafd-4a1f-8bbf-204668b32fe1",
+                                "a166a37e-a3f8-42d2-99d6-e0dd2cf5c090",
+                                "c7bbd142-7873-4a91-98c8-76a6900bea60",
+                                "ade47a03-a3ec-4d78-aefa-6057abceea28",
+                                "9bd53a5a-a152-488f-be20-7394b083d99a",
+                                "a45555d8-d68c-4cd7-8006-7d7f61b36c72",
+                                "9df94442-ed1b-436c-942f-3195b1ef7e0e",
+                                "b838226d-5fbf-4b5d-8e5f-98e5c8ddc1f2",
+                                "e9ed2969-146a-472d-8e87-39c77bd1757d",
+                                "723e73f3-9fa4-40d8-bb11-b66184c9a795",
+                                "2018be7c-5f79-497e-a7e1-0e64f31e71f5",
+                                "a68b2030-d52f-4e52-907f-8657b867dd50",
+                                "8980597c-1559-46a7-ba8d-bc5d95d5936a",
+                                "f8ef3523-2500-410c-98fb-b6926a832df4"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "55a61776-58f0-4abe-8adc-a6fd79ed2130",
+                    "Name": "UI_CHALLENGES_MIAMI_ITEM_FIND_EXPO_KEYCARD_NAME",
+                    "ImageName": "images/challenges/Miami/Item_find_expo_keycard.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_ITEM_FIND_EXPO_KEYCARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "3882a95e-99a0-409e-87b1-74d320463347"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "5954f5a0-2897-4505-b0be-35c1ebc937ca",
+                    "Name": "UI_CHALLENGES_FLAMINGO_BECOME_TED_MENDEZ_NAME",
+                    "ImageName": "images/challenges/Miami/Become_ted_mendez.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_BECOME_TED_MENDEZ_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "d7d8d5e8-070c-4d6c-9a67-f1165a7bb29d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "5b47ea71-479a-4d0f-b795-4b828d793ccf",
+                    "Name": "UI_CHALLENGES_MIAMI_FRUTTI_DI_MARE_NAME",
+                    "ImageName": "images/challenges/Miami/Frutti_di_mare.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_FRUTTI_DI_MARE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "AquaticWeapons": [
+                                "4d0d6b2a-dd81-474c-a412-3bf19af8233d",
+                                "cad726d7-331d-4601-9723-6b8a17e5f91b"
+                            ]
+                        },
+                        "Context": {
+                            "UsedAquaticWeapons": []
+                        },
+                        "ContextListeners": {
+                            "UsedAquaticWeapons": {
+                                "count": "($.UsedAquaticWeapons).Count",
+                                "total": "($.AquaticWeapons).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.AquaticWeapons"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "UsedAquaticWeapons",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.UsedAquaticWeapons"
+                                                    }
+                                                },
+                                                "in": "$.AquaticWeapons"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "715b90ae-433a-4586-bb67-0c8a86e2c5cc",
+                    "Name": "UI_CHALLENGES_MIAMI_TINTAMARRESQUE_NAME",
+                    "ImageName": "images/challenges/Miami/Tintamarresque.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_TINTAMARRESQUE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TintamarresqueEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "85293d33-73cf-40eb-9192-eca8a185b1ba",
+                    "Name": "UI_CHALLENGES_FLAMINGO_BECOME_MOSES_NAME",
+                    "ImageName": "images/challenges/Miami/Become_moses.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_BECOME_MOSES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "a45555d8-d68c-4cd7-8006-7d7f61b36c72"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "bcfd6a2a-8f54-4f47-97eb-baa996f7a4af",
+                    "Name": "UI_CHALLENGES_MIAMI_ITEM_FIND_EVENT_KEY_NAME",
+                    "ImageName": "images/challenges/Miami/Item_find_event_key.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_ITEM_FIND_EVENT_KEY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "45213c3c-2d0f-49f2-8cea-311597cce70a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "c0c7fe9a-4558-4f8b-a8ad-699b4a434d1e",
+                    "Name": "UI_CHALLENGES_MIAMI_FREE_FISHIE_NAME",
+                    "ImageName": "images/challenges/Miami/Free_fishie.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_FREE_FISHIE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FreeFishieEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "ccaaa229-5901-4471-8c80-664ab3c39e7a",
+                    "Name": "UI_CHALLENGES_MIAMI_BOATEXIT_NAME",
+                    "ImageName": "images/challenges/Miami/BoatExit.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_BOATEXIT_TITLE",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "70d167c7-1a75-4c80-8cc9-416425a828c0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "ceefc17a-e84e-47e3-83e9-f1e24429cc89",
+                    "Name": "UI_CHALLENGES_FLAMINGO_BECOME_SHEIK_NAME",
+                    "ImageName": "images/challenges/Miami/Become_sheik.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_BECOME_SHEIK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "a68b2030-d52f-4e52-907f-8657b867dd50"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "d87bb853-2501-4867-886d-1dbb635791f1",
+                    "Name": "UI_CHALLENGES_FLAMINGO_BECOME_MASCOT_NAME",
+                    "ImageName": "images/challenges/Miami/Become_mascot.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_BECOME_MASCOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "124d145e-469e-485d-a628-ced82ddf1b75"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "de7be2cc-d0d6-44f4-9428-4b87852b4050",
+                    "Name": "UI_CHALLENGES_MIAMI_WHATS_IN_THIS_THING_NAME",
+                    "ImageName": "images/challenges/Miami/Whats_in_this_thing.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_WHATS_IN_THIS_THING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "WhatsInThisThingEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "e0ae80c9-7a88-4844-bec9-9a1404e4ef15",
+                    "Name": "UI_CHALLENGES_MIAMI_MR_TAMBOURINE_MAN_NAME",
+                    "ImageName": "images/challenges/Miami/Mr_tambourine_man.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_MR_TAMBOURINE_MAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MrTambourineManEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "e82fa147-38c5-4866-9403-d36847bcdc35",
+                    "Name": "UI_CHALLENGES_FLAMINGO_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/miami/area_discovered_flamingo.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 48
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_FLAMINGO_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f51fceb1-b5b2-4753-b073-8141f9fdfe5e",
+                    "Name": "UI_CHALLENGES_FLAMINGO_BECOME_FLORIDA_MAN_NAME",
+                    "ImageName": "images/challenges/Miami/Become_florida_man.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_BECOME_FLORIDA_MAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "f8ef3523-2500-410c-98fb-b6926a832df4"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "3341d698-496a-4953-8973-dc58b148a56d",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_STAND_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Stand.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_STAND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "StandManned": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "bbfdd4f0-374d-44d5-81db-380ea83d7348",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_MEETING_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_Meeting.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_MEETING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "MeetingStarted": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "09edfa81-ab07-4fed-8451-87ac330d9810",
+                    "Name": "UI_CHALLENGES_FLAMINGO_INTRAVENEUS_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/miami/miami_opp_intravenous.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_INTRAVENEUS_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "0be63e06-94ad-42b2-841a-a79664c45bc9"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "2651d6e9-f4a8-4f17-a455-776fd9f3fb53",
+                    "Name": "UI_CHALLENGES_FLAMINGO_MUNCHIES_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/miami/miami_opp_themunchies.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_MUNCHIES_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "97568c11-92bc-47d1-af0d-531fc138b1e4"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "394c430e-34f2-4ebe-825e-27e53f63644b",
+                    "Name": "UI_CHALLENGES_FLAMINGO_SYMPATHY_FOR_THE_BIRD_NAME",
+                    "ImageName": "images/challenges/Miami/Sympathy_for_the_bird.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_SYMPATHY_FOR_THE_BIRD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SympathyForTheBirdEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "3b2da5fd-8b79-4aeb-bcad-dfaff7c5ce2f",
+                    "Name": "UI_CHALLENGES_FLAMINGO_STORY_CHALLENGE_PITSTOP_NAME",
+                    "ImageName": "images/challenges/miami/story_pitstop_flamingo.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_STORY_CHALLENGE_PITSTOP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Story_PitStop": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "455f10d0-daf8-4db0-aae8-3e8cff12466d",
+                    "Name": "UI_CHALLENGES_FLAMINGO_THE_ODD_ONE_OUT_NAME",
+                    "ImageName": "images/challenges/Miami/The_odd_one_out.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_THE_ODD_ONE_OUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TheOddOneOutEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "5b1bf57c-aabf-4f62-8fb3-788cce2aa079",
+                    "Name": "UI_CHALLENGES_FLAMINGO_ACTIVATE_SATELLITE_NAME",
+                    "ImageName": "images/challenges/Miami/Activate_satellite.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_ACTIVATE_SATELLITE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EnableSatelite": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "849cd4ee-242d-4e47-8a91-dccc2d27bc86",
+                    "Name": "UI_CHALLENGES_FLAMINGO_TURBO_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/miami/miami_opp_carexpo.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_TURBO_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "604e9a0c-db5c-4468-a7cd-fd0db2cab902"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "8ae190d6-c846-4221-afcf-5e9bc554ca2d",
+                    "Name": "UI_CHALLENGES_FLAMINGO_LAST_WORDS_NAME",
+                    "ImageName": "images/challenges/Miami/Last_words.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_LAST_WORDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "LastWordsEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "94e35a62-cb32-4021-a4d8-3376ddf92610",
+                    "Name": "UI_CHALLENGES_FLAMINGO_THUNDER_THIEF_NAME",
+                    "ImageName": "images/challenges/Miami/Thunder_thief.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_THUNDER_THIEF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ThunderThiefEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "a100d61d-5da0-4b2c-ac90-c88281a15f9d",
+                    "Name": "UI_CHALLENGES_FLAMINGO_47_SCOVILLE_NAME",
+                    "ImageName": "images/challenges/Miami/47_scoville.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_47_SCOVILLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "47ScovilleEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "a764a6aa-176c-45ac-95b0-205b45097776",
+                    "Name": "UI_CHALLENGES_FLAMINGO_PIGEON_NAME",
+                    "ImageName": "images/challenges/Miami/Pigeon.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_PIGEON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PigeonEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "b5730f82-bc29-415a-8ce1-78040ff5bc39",
+                    "Name": "UI_CHALLENGES_FLAMINGO_POTTY_TRAINING_NAME",
+                    "ImageName": "images/challenges/Miami/Potty_training.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_POTTY_TRAINING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PottyTrainingEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "b5d602d8-4124-4faa-bd80-954eaad666fa",
+                    "Name": "UI_CHALLENGES_FLAMINGO_SWEET_VICTORY_NAME",
+                    "ImageName": "images/challenges/Miami/Sweet_victory.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_SWEET_VICTORY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SweetVictoryEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "bbbf65c6-72d8-48b0-aa89-8e0eb11a5379",
+                    "Name": "UI_CHALLENGES_FLAMINGO_STORY_CHALLENGE_ANDROID_NAME",
+                    "ImageName": "images/challenges/miami/story_android_flamingo.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_STORY_CHALLENGE_ANDROID_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Story_Android": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "c4d7a8e9-3838-48d4-8051-34ed52ecf5c3",
+                    "Name": "UI_CHALLENGES_FLAMINGO_STORY_CHALLENGE_BLACKMAILER_NAME",
+                    "ImageName": "images/challenges/miami/story_blackmailer_flamingo.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_STORY_CHALLENGE_BLACKMAILER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Story_Blackmailer": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "c512a6f0-0ad8-4061-a920-e64f137bc774",
+                    "Name": "UI_CHALLENGES_FLAMINGO_MILKY_WAY_NAME",
+                    "ImageName": "images/challenges/Miami/Milky_way.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_MILKY_WAY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MilkyWayEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "6d4ae31d-dffc-43ab-a2de-9189e28f3d46",
+                    "Name": "UI_CONTRACT_CRINUM_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Crinum.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "e5b6ccf4-1f29-4ec6-bfb8-2e9b78882c85"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["719ee044-4b05-4bd9-b2bb-75029f6d2a35"]
+                    }
+                },
+                {
+                    "Id": "7b6792eb-935b-4520-a19d-a2ca00134f0c",
+                    "Name": "UI_CONTRACT_LAMIUM_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Miami_Lamium.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "dcc17268-84e5-4f49-badf-f0c631ab28cd"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["5284cb9f-9bdd-4b00-99c3-0b5939b01818"]
+                    }
+                },
+                {
+                    "Id": "b9b6cde4-eb5e-4c67-9963-3b925ad82822",
+                    "Name": "UI_CONTRACT_PLUMBAGO_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Plumbago.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "4a0a66d4-0a53-4cfd-8122-978226b4e072"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["d0f44e71-6eab-4af4-9484-78d61dbe376a"]
+                    }
+                },
+                {
+                    "Id": "4d599e75-8cf7-4fea-a939-a27b2b2da53d",
+                    "Name": "UI_CONTRACT_CARDINAL_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Cardinal.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f88cda79-c07c-4487-ac23-1b8b824b3497"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["fca539ff-1b1a-4c04-93e0-03b9b902f86c"]
+                    }
+                },
+                {
+                    "Id": "0f56c0a9-2b3d-4d1a-8247-ed2086f87c4f",
+                    "Name": "UI_CONTRACT_PENTAS_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Flamingo_Pentas.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "c89d7f7c-eb2f-4530-9e06-1d6ad5187d8e"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["782a2849-14a2-4cd4-99fc-ddacaeaba2dd"]
+                    }
+                },
+                {
+                    "Id": "22b33fba-a56d-4897-868f-06c2d125f2af",
+                    "Name": "UI_CONTRACT_BAKERIAN_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Miami_Bakerian.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "c28beef7-e223-4057-9701-db855c05744f"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["be3ea01f-ec56-4fcb-95ec-164a1d9980f3"]
+                    }
+                },
+                {
+                    "Id": "ce4ad358-2c0c-4819-bf36-e4cef5a16a44",
+                    "Name": "UI_CONTRACT_CATCHFLY_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Miami_Catchfly.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f57fd6a8-cf49-499c-b560-bd377a00ffcf"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["066ce378-0418-452a-b02e-a5e4ee711096"]
+                    }
+                },
+                {
+                    "Id": "6897650f-0748-4cf6-b131-473fde80eab6",
+                    "Name": "UI_CHALLENGES_MIAMI_SAFETY_FIRST_NAME",
+                    "ImageName": "images/challenges/Miami/Safety_first.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_SAFETY_FIRST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SafetyFirstEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                },
+                {
+                    "Id": "71947ba4-7628-4c1b-ba0c-09fb09f7b095",
+                    "Name": "UI_CHALLENGES_MIAMI_ARMS_DEALER_NAME",
+                    "ImageName": "images/challenges/Miami/Arms_dealer.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_ARMS_DEALER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleTargets": [
+                                "f412903b-4f2d-4680-8b66-d1e7f004a314",
+                                "bc7edd5f-fb78-4272-bb76-52fbf2bced13",
+                                "63ce19e1-3956-46d1-8979-62f939ffefa6",
+                                "98d71e20-2c0e-4d67-bfb8-474b41b70666",
+                                "89620533-89a3-4045-ac02-df3c8f78f28d",
+                                "59cbe5e4-eebe-4d2e-8519-6b1e5dcc1bf8",
+                                "02ec00db-dc54-4ce6-8d87-3657ff59440a",
+                                "6176a31b-3cdd-433f-b1fb-ac60f5748fe5"
+                            ]
+                        },
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.EligibleTargets"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "d1f29c76-5751-4e06-b534-e6eb7522b128"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "9c53020f-5f05-4431-a405-a5a34e4be62e",
+                    "Name": "UI_CHALLENGES_MIAMI_TANKED_NAME",
+                    "ImageName": "images/challenges/Miami/Tanked.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_TANKED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.name_metricvalue",
+                                            "ActorPacifiedByAquarium"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "c114991f-0119-472f-841b-b4459e961105",
+                    "Name": "UI_CHALLENGES_MIAMI_RED_FLAG_NAME",
+                    "ImageName": "images/challenges/Miami/Red_flag.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_RED_FLAG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RedFlagEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                },
+                {
+                    "Id": "e907276c-3829-410a-9429-acb5139aae9f",
+                    "Name": "UI_CHALLENGES_MIAMI_AQUARIUM_DUMP_NAME",
+                    "ImageName": "images/challenges/Miami/Aquarium_dump.jpg",
+                    "Description": "UI_CHALLENGES_MIAMI_AQUARIUM_DUMP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AquariumUsedAsContainer": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "71e573a2-a5c5-4e6c-b469-2a8086c12b5a",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_KRISH_KILLED_NAME",
+                    "ImageName": "images/challenges/Miami/Cottonmouth_KillKrish.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_KRISH_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "466b652d-cea0-47eb-823a-2aba9f67b5ad"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "329d8623-3fab-42dd-99b5-b69ba2af68e9",
+                    "Name": "UI_CHALLENGES_FLAMINGO_ROBERT_KILLED_NAME",
+                    "ImageName": "images/challenges/Miami/Robert_killed.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_ROBERT_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "ee454990-0c4b-49e5-9572-a67887325283"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "92047095-c614-47ba-9dd0-b7fc4e0b4c3c",
+                    "Name": "UI_CHALLENGES_FLAMINGO_SIERRA_KILLED_NAME",
+                    "ImageName": "images/challenges/Miami/Sierra_killed.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_SIERRA_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "22455fef-0fec-4e83-a9c6-65a0f44633e2",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "6fa492cb-7dc5-46ac-989c-6819cd3c98ec",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "c66e9212-b53f-452b-af99-14fed11b6e6a",
+                                "cda55c37-7605-4239-9aad-8c162d0cdaa9",
+                                "96e0a1cb-cf2d-45bf-ad36-6c889860304c",
+                                "22455fef-0fec-4e83-a9c6-65a0f44633e2"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "96e0a1cb-cf2d-45bf-ad36-6c889860304c",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "c66e9212-b53f-452b-af99-14fed11b6e6a",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "cda55c37-7605-4239-9aad-8c162d0cdaa9",
+                    "Name": "UI_CHALLENGES_COTTONMOUTH_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_COTTONMOUTH_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["f1ba328f-e3dd-4ef8-bb26-0363499fdd95"]
+                    }
+                },
+                {
+                    "Id": "08457a95-ab19-4d46-b825-4150f310f217",
+                    "Name": "UI_CHALLENGES_FLAMINGO_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "25a17321-b065-4d4e-9a73-6fcc97940dcd",
+                    "Name": "UI_CHALLENGES_FLAMINGO_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "38df4127-57ab-4ac6-9205-06986132bc7f",
+                    "Name": "UI_CHALLENGES_FLAMINGO_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "797bf431-6b84-4a1f-bf3e-40164c757e48",
+                    "Name": "UI_CHALLENGES_FLAMINGO_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                },
+                {
+                    "Id": "a3a6fb3f-05ab-4dca-a816-52ee97dcfa25",
+                    "Name": "UI_CHALLENGES_FLAMINGO_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_FLAMINGO_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MIAMI",
+                    "ParentLocationId": "LOCATION_PARENT_MIAMI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "38df4127-57ab-4ac6-9205-06986132bc7f",
+                                "08457a95-ab19-4d46-b825-4150f310f217",
+                                "25a17321-b065-4d4e-9a73-6fcc97940dcd",
+                                "797bf431-6b84-4a1f-bf3e-40164c757e48"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["c1d015b4-be08-4e44-808e-ada0f387656f"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/MUMBAI/_MUMBAI_CHALLENGES.json
+++ b/contractdata/MUMBAI/_MUMBAI_CHALLENGES.json
@@ -1,0 +1,6387 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_MUMBAI"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "116b74fa-6aa5-424f-af2c-18c19ae11df2",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_FALL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Kingcobra_Fall.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_FALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "07ccfa5d-6dd3-4d2b-9f79-75b300524857"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillMethodStrict",
+                                                        "accident_push"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "42df4e0d-4857-4479-95dd-f1b34896c86b",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "4b001058-bdda-4fb2-a1e6-426a734f04af",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "74e6caf5-0bee-4ff3-afab-09eb07ea7430",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "9c88d3f1-0005-43f1-9cb8-a5a5f182946d",
+                                "95a88152-4017-4b9d-a001-4504ab7eb94b",
+                                "4b001058-bdda-4fb2-a1e6-426a734f04af",
+                                "42df4e0d-4857-4479-95dd-f1b34896c86b"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "8ef550a3-1a2f-4216-85bb-3b09dd83a5b9",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_ELECTRICITY_NAME",
+                    "ImageName": "images/challenges/Mumbai/Kingcobra_ElectricityKill.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_ELECTRICITY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "07ccfa5d-6dd3-4d2b-9f79-75b300524857"
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "accident_electric"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "$Value.KillMethodBroad",
+                                                            "$Value.KillMethodStrict"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "95a88152-4017-4b9d-a001-4504ab7eb94b",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "9b3688f7-3716-4362-986d-036f1932d182",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_POISON_NAME",
+                    "ImageName": "images/challenges/Mumbai/Kingcobra_Poison.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {},
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "07ccfa5d-6dd3-4d2b-9f79-75b300524857"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillClass",
+                                                        "poison"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "9c88d3f1-0005-43f1-9cb8-a5a5f182946d",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "f375cfd1-f52d-4e00-a789-3e169ce03655",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_EXPLOSION_NAME",
+                    "ImageName": "images/challenges/Mumbai/Kingcobra_Explosion.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_EXPLOSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "144299f6-5a37-404a-825f-988d95f7e989",
+                    "Name": "UI_CHALLENGES_MONGOOSE_WAITING_FOR_A_SIGN_NAME",
+                    "ImageName": "images/challenges/Mumbai/Waiting_For_A_Sign.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_WAITING_FOR_A_SIGN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "c7c9e213-16f9-4215-bf07-dd8f801ce3e0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "14e64ca8-4d45-4d62-9181-9c2c64961306"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "1895e589-715c-47f9-b7b9-2ec309a82200",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BOAT_NAME",
+                    "ImageName": "images/challenges/Mumbai/Boat_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BOAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "78f98c70-b7be-4578-9b6a-1c96a3e1ff1a"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "44d5d249-b8e0-4dcf-812c-288936d36616"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "44d5d249-b8e0-4dcf-812c-288936d36616"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "44d5d249-b8e0-4dcf-812c-288936d36616"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "78f98c70-b7be-4578-9b6a-1c96a3e1ff1a"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "44d5d249-b8e0-4dcf-812c-288936d36616"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "1edb317f-628b-4337-8c60-3bae76622b33",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BARBER_KILL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Barber_Kill_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BARBER_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BarberKillEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "325c3154-6ad5-4757-9f5c-eaeb76fda970",
+                    "Name": "UI_CHALLENGES_MONGOOSE_WHATS_YOUR_FLAVA_NAME",
+                    "ImageName": "images/challenges/Mumbai/Whats_Your_Flava.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_WHATS_YOUR_FLAVA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "MaelstromKillzoneIn"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "MaelstromKillzoneOut"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "c7c9e213-16f9-4215-bf07-dd8f801ce3e0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "e80d5a59-2d51-405c-aaca-20155bbf5290"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "5ec3b218-2195-48cf-946e-0f723fae0b5e",
+                    "Name": "UI_CHALLENGES_MONGOOSE_TEA_TIME_NAME",
+                    "ImageName": "images/challenges/Mumbai/Tea_Time_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_TEA_TIME_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "e80d5a59-2d51-405c-aaca-20155bbf5290"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "614291d4-94c2-4dff-8b77-b32d9ec6f336",
+                    "Name": "UI_CHALLENGES_MONGOOSE_POOL_KILL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Pool_Kill_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_POOL_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "36744d6c-77e9-429a-98d6-8cfc1b93454f"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "8b45b9b8-ccdf-4640-b663-06ad1adc8750",
+                    "Name": "UI_CHALLENGES_MONGOOSE_ELECTRICITYKILLALL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_electricitykillall.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_ELECTRICITYKILLALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "TargetKilled": []
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_MONGOOSE_ELECTRICITYKILLALL_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetKilled",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$not": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$Value.RepositoryId"
+                                                                ]
+                                                            },
+                                                            "in": "$.TargetKilled"
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "accident_electric"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "$Value.KillMethodBroad",
+                                                            "$Value.KillMethodStrict"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "9ab4a1b4-a224-417e-bb0b-9bc7744d4bff",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BIGGEST_FAN_NAME",
+                    "ImageName": "images/challenges/Mumbai/BiggestFan_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BIGGEST_FAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "78f98c70-b7be-4578-9b6a-1c96a3e1ff1a"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "962d9b73-1fc9-4553-9842-1134048bae0a"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "9becb1f0-ea09-4d45-93d0-cb99a91be7a0",
+                    "Name": "UI_CHALLENGES_MONGOOSE_PROXY_KILLER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Proxy_Killer_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_PROXY_KILLER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0e7bf5ca-60ec-45f5-b3c2-e2e5b80940cb",
+                                "a1403283-a635-4be0-bae6-82dcd967d22b"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "a3e5f83b-cb82-4ac8-ad30-aabac3d621af",
+                    "Name": "UI_CHALLENGES_MONGOOSE_ELECTRICITYKILL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_electricitykill.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_ELECTRICITYKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "accident_electric"
+                                                        ]
+                                                    },
+                                                    "in": [
+                                                        "$Value.KillMethodBroad",
+                                                        "$Value.KillMethodStrict"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "ab36f677-1dc3-4bc6-82c7-f749bb9b936e",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BIRDCAGE_NAME",
+                    "ImageName": "images/challenges/Mumbai/Birdcage_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BIRDCAGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "BirdCageIDs": [
+                                "a4b97901-f7e8-47a1-9566-f8a3d0bfdb86",
+                                "17091514-75b2-43d6-9aa1-596e1abaa8b5"
+                            ]
+                        },
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceId"
+                                                        ]
+                                                    },
+                                                    "in": "$.BirdCageIDs"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "ac596598-4713-4f87-8ecc-191da0c91eea",
+                    "Name": "UI_CHALLENGES_MONGOOSE_TAILOR_KILL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Tailor_Kill_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_TAILOR_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "b384ff35-9c38-4b08-ab0b-e333cfd7bc6a"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "a804e004-7d45-42c8-87bd-b7cbcffa56cc"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "ae18738e-0745-4a4e-9d62-0f776ea8aaf4",
+                    "Name": "UI_CHALLENGES_MONGOOSE_TRAIN_KILL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Train_Kill_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_TRAIN_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 3
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "c7c9e213-16f9-4215-bf07-dd8f801ce3e0"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "56af0d2f-d73e-4883-bdeb-b47fb116bc2d"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "56af0d2f-d73e-4883-bdeb-b47fb116bc2d"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "56af0d2f-d73e-4883-bdeb-b47fb116bc2d"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "c7c9e213-16f9-4215-bf07-dd8f801ce3e0"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "56af0d2f-d73e-4883-bdeb-b47fb116bc2d"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "be501d77-94da-4ce7-96bf-f44adbe9f3c2",
+                    "Name": "UI_CHALLENGES_MONGOOSE_SNIPEKILLALL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_snipekillall.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_SNIPEKILLALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_MONGOOSE_SNIPEKILLALL_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "InSniperTowerChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "InSniperTower"
+                                }
+                            },
+                            "InSniperTower": {
+                                "InSniperTowerChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$contains": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "c6756e3b-879d-42e0-b37d-f9b8382e51e1",
+                    "Name": "UI_CHALLENGES_MONGOOSE_CONCRETE_PIPE_NAME",
+                    "ImageName": "images/challenges/Mumbai/Concrete_Pipe_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_CONCRETE_PIPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.5
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_suspended_object"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "78f98c70-b7be-4578-9b6a-1c96a3e1ff1a"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "c7c9e213-16f9-4215-bf07-dd8f801ce3e0"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_suspended_object"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "78f98c70-b7be-4578-9b6a-1c96a3e1ff1a"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "c7c9e213-16f9-4215-bf07-dd8f801ce3e0"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "f44ec3bc-cfee-46d4-b17a-91838558c6ca",
+                    "Name": "UI_CHALLENGES_MONGOOSE_SNIPEKILL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_snipekill.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_SNIPEKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "InSniperTowerChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "InSniperTower"
+                                }
+                            },
+                            "InSniperTower": {
+                                "InSniperTowerChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "22774d58-6a60-4dc1-aa06-55c4748a3324",
+                    "Name": "CHALLENGEPACK_CARBON_BEAKSTAFFKILL_NAME",
+                    "ImageName": "images/challenges/Categories/PackCarbon/Carbon_BeakStaffKill.jpg",
+                    "Description": "CHALLENGEPACK_CARBON_BEAKSTAFFKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "b153112f-9cd1-4a49-a9c6-ba1a34f443ab"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "e4581e1a-a45a-4c42-ba25-3527bd75c0f7"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "medium", "assassination"]
+                },
+                {
+                    "Id": "2ff03db0-0288-4f83-9f4f-58fa8de278a8",
+                    "Name": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "3586da1f-56e5-417d-8000-253466cba06b",
+                    "Name": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "4bc10a4c-7e47-43ac-ae84-209c466f365d",
+                    "Name": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "58e13a5f-0e3a-4073-b623-ef0a1578149c",
+                    "Name": "CHALLENGEPACK_CARBON_SNIPEKASHMIRIAN_NAME",
+                    "ImageName": "images/challenges/Categories/PackCarbon/Carbon_SnipeKashmirian.jpg",
+                    "Description": "CHALLENGEPACK_CARBON_SNIPEKASHMIRIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "HitmanIsInside": false
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "80051c02-e026-40fe-970a-7b7aaa62302c"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.OutfitRepositoryId",
+                                                        "e4581e1a-a45a-4c42-ba25-3527bd75c0f7"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$.HitmanIsInside",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "HitmanInside"
+                                            ]
+                                        },
+                                        "$set": ["HitmanIsInside", true]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "HitmanOutside"
+                                            ]
+                                        },
+                                        "$set": ["HitmanIsInside", false]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "medium", "assassination"]
+                },
+                {
+                    "Id": "78b2930e-aed6-48b3-94be-ef45b7e2e05f",
+                    "Name": "UI_CHALLENGES_MUMBAI_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "4bc10a4c-7e47-43ac-ae84-209c466f365d",
+                                "bca30d6d-dc79-4155-b8af-3eb2ef991448",
+                                "c6a40324-6962-4e16-90a3-4ae182a330cc",
+                                "2ff03db0-0288-4f83-9f4f-58fa8de278a8",
+                                "3586da1f-56e5-417d-8000-253466cba06b"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "bca30d6d-dc79-4155-b8af-3eb2ef991448",
+                    "Name": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "c6a40324-6962-4e16-90a3-4ae182a330cc",
+                    "Name": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "53af1c1f-08e4-47cb-a502-20780ef0d257",
+                    "Name": "UI_CHALLENGES_MONGOOSE_DIARY_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_diary.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_DIARY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ReadVanyasDiaryEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "be9077e7-3862-485b-b58b-be4840950513",
+                    "Name": "UI_CHALLENGES_MONGOOSE_DRESSCLOTH_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_dresscloth.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_DRESSCLOTH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GetCeruleanClothEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "0161210f-7d8a-4f84-8015-3b5363249e60",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_FOREMAN_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_Foreman.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_FOREMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "eeefa90a-6665-4eb1-8bc9-3e08c222abae"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "09522da2-68e6-43a5-bbad-c79eaf76d8e7",
+                    "Name": "UI_CHALLENGES_MUMBAI_TAXI_EXIT_NAME",
+                    "ImageName": "images/challenges/Mumbai/Taxi_Exit.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_TAXI_EXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": [
+                                                        "b2a015ad-2148-4a28-9c84-c8b9a76e2772",
+                                                        "97ea177d-93d4-45b8-b147-d4601d6f6126",
+                                                        "ad70a60c-dbf6-4579-a6a9-d82cd1648b52",
+                                                        "306c2870-04d3-4441-bacd-40ca6deff5b7",
+                                                        "8ad74656-027d-4b47-a8e2-1927aa2fcc51"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "0c0ba241-c2dc-4d17-b6ee-4c75cc425fa9",
+                    "Name": "UI_CHALLENGES_MUMBAI_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "6d3d59b4-571c-4dbb-9737-205fb34a1ffa",
+                                "ae320bab-bb37-42a5-86a1-df283ada49c0",
+                                "88adef78-2a19-45fb-9c95-988e82c056f1",
+                                "48afc44d-cf8a-44ba-9436-663a6979c908",
+                                "e9dffefc-e896-46e4-b158-1b401b015764",
+                                "c5c8e251-bb30-4e9e-b146-74ed96c7048f",
+                                "a2cef12c-77d6-4062-9596-cf9d1a47d1b5",
+                                "b36075a1-b352-4e0f-9d84-84f2bdac6a86",
+                                "6edb224d-0970-4d1d-8740-5e86d1e7af59",
+                                "e9e143e1-f5a6-40a5-af56-947cbf32e20a",
+                                "d136699a-a244-4789-b332-9a3afc4e3f48",
+                                "06fb2890-e820-45f2-aef3-0cb7d0528ee1",
+                                "b384ff35-9c38-4b08-ab0b-e333cfd7bc6a",
+                                "81f55bbc-a120-4757-a778-b73fd775d1a4",
+                                "6f875d32-869e-437a-8935-368e0c2cc8bc",
+                                "e4581e1a-a45a-4c42-ba25-3527bd75c0f7",
+                                "446ace07-c9c6-49fc-b157-fa58e812fcef",
+                                "c4011c75-39ff-4bff-aff5-fe902ae4b83b",
+                                "eeefa90a-6665-4eb1-8bc9-3e08c222abae"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "2f88fb9b-2934-43f4-8c87-795c91b3676b",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_PAINTER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_Painter.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_PAINTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "81f55bbc-a120-4757-a778-b73fd775d1a4"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "30b067a9-4c58-4ab9-ae70-4acce4466f26",
+                    "Name": "UI_CHALLENGES_MUMBAI_RED_FLAG_SPOTTER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Red_Flag_Spotter.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_RED_FLAG_SPOTTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RedFlagSpotter": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "3731a4bc-68a1-4f4c-aa24-63238342b8be",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_TAILOR_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_Tailor.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_TAILOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "b384ff35-9c38-4b08-ab0b-e333cfd7bc6a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "3c29b0f7-747d-4e96-8322-602ab7b88ccc",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_FAKE_MAELSTROM_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_Fake_Maelstrom.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_FAKE_MAELSTROM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "e4581e1a-a45a-4c42-ba25-3527bd75c0f7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "85224cb9-7363-42c1-9199-34db126ba71c",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_KASHMIRIAN_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_kashmirian.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_KASHMIRIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "6f875d32-869e-437a-8935-368e0c2cc8bc"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "87cad9dd-2c05-4f3b-ad02-14df72cd9a85",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_BARBER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_Barber.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_BARBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "c4011c75-39ff-4bff-aff5-fe902ae4b83b"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "8d572c83-3b69-4db8-8ff7-d80b8b658018",
+                    "Name": "UI_CHALLENGES_MUMBAI_HIDEOUT_EXIT_NAME",
+                    "ImageName": "images/challenges/Mumbai/Hideout_Exit.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_HIDEOUT_EXIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "1aa8a4a5-1c8f-4145-a87b-16b13817f6e5"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "b4440684-96c2-48e5-8528-cb1f59c02112",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_METALWORKER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_Metalworker.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_METALWORKER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "48afc44d-cf8a-44ba-9436-663a6979c908"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "bae5a73b-4eb1-4e05-9d71-ed642c2ad437",
+                    "Name": "UI_CHALLENGES_MUMBAI_BECOME_ANGEL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mumbai_Become_Angel.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BECOME_ANGEL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "88adef78-2a19-45fb-9c95-988e82c056f1",
+                                "446ace07-c9c6-49fc-b157-fa58e812fcef"
+                            ]
+                        },
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": ["$.#", "$Value"]
+                                            },
+                                            "in": "$.EligibleDisguises"
+                                        }
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "ec2738aa-6bf8-42b0-a7b9-06552ee50116",
+                    "Name": "UI_CHALLENGES_MUMBAI_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/mumbai/area_discovered_mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 52
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_MUMBAI_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "0ae7300f-b3a8-4408-864d-55bf225ff91b",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_ASK_NAME",
+                    "ImageName": "images/challenges/Mumbai/Kingcobra_Ask.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_ASK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "AskForMoney"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "0c21725a-46a9-4764-9cda-8b91d593831e",
+                    "Name": "UI_CHALLENGES_MONGOOSE_FLAMES_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/mumbai/mumbai_opp_lover.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_FLAMES_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "8b7c3665-4ffc-4df0-8141-fd2a9d25d5a5"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "0e7bf5ca-60ec-45f5-b3c2-e2e5b80940cb",
+                    "Name": "UI_CHALLENGES_MONGOOSE_PAINT_SNIPE_NAME",
+                    "ImageName": "images/challenges/Mumbai/Paint_Snipe_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_PAINT_SNIPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MumbaiPaintSnipeEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "0f57bf3a-4109-4e31-9354-3e9e55096202",
+                    "Name": "UI_CHALLENGES_MONGOOSE_STORYTAILOR_NAME",
+                    "ImageName": "images/challenges/Mumbai/Story_Tailor_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_STORYTAILOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TailorOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "11f71672-a5e1-47e0-bbcc-e14130eb65bc",
+                    "Name": "UI_CHALLENGES_MONGOOSE_FLAG_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_flag.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_FLAG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RaiseFlagEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "169b5a66-0baa-4f26-860f-d3b16ab876d8",
+                    "Name": "UI_CHALLENGES_MONGOOSE_WIND_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/mumbai/mumbai_opp_fan.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_WIND_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "172cbd1d-3877-4309-97bd-bebfb7b5a71b"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "1ad14b76-b0dc-490a-a8f8-b53dbf06fa97",
+                    "Name": "UI_CHALLENGES_MONGOOSE_HARDHAT_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_hardhat.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_HARDHAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleTargets": [
+                                "bfb171c7-61f2-40da-aece-5f40c6654333",
+                                "c8734bd3-d451-41a3-a4ec-eb28cb0d344e",
+                                "22a19308-5b21-4e80-a915-467ebc43a1de",
+                                "38277677-eb1b-4de6-8ef1-3835999b8bca",
+                                "cd032e96-95b2-4be2-8bda-15b0dc2d7d50",
+                                "6f791881-7fa3-418d-a057-eb509fc3f5c0",
+                                "263b376b-632a-48b7-83c1-2481d4634c6c",
+                                "d45c4ba4-7260-436d-941d-3359248bcac2",
+                                "b1ab76fd-2602-45b9-a7cc-4013c2df192b",
+                                "2fd04601-824e-44c6-a9b2-2de5798ab8e8",
+                                "6cca1f8f-260d-41e9-a208-958f8d3e9a19",
+                                "037e9369-d072-4eeb-947a-405cabdf64a1"
+                            ]
+                        },
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.EligibleTargets"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "5cc4d1ea-b4fa-4667-ba3a-b6e859f03059"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "1b570a84-a97c-4fe9-85e8-6d9190ca5225",
+                    "Name": "UI_CHALLENGES_MONGOOSE_LAPTOP_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_laptop.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_LAPTOP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ReadDawoodsLaptopEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "1f178e0d-c025-40f2-97d0-fabbb5ee43fe",
+                    "Name": "UI_CHALLENGES_MONGOOSE_CALLDAWOOD_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_callDawood.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_CALLDAWOOD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PhoneCallDawoodEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "1fb2774e-881a-42f7-a299-fe37fffc6ac4",
+                    "Name": "UI_CHALLENGES_MONGOOSE_REAL3_NAME",
+                    "ImageName": "images/challenges/mumbai/Mongoose_real3.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_REAL3_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "47b263f0-285b-4f43-91dc-46ff2073c2c0",
+                                "fdc3082d-b333-4506-8a8d-b99e4f27e3fa",
+                                "650f1771-6caf-4d4e-8c21-b1ec603bc991"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "279f7cd2-18c9-46c7-a6b3-71f1b2aa364f",
+                    "Name": "UI_CHALLENGES_MONGOOSE_TVGUARD_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_tvguard.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_TVGUARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShowsOverEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "2c697604-34e1-4217-a5ad-dc84dacd49e2",
+                    "Name": "UI_CHALLENGES_MONGOOSE_TAPES_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_tapes.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_TAPES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_MONGOOSE_TAPES_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FindAllMaelstromsTapesEvent": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "32cabeda-e600-4e46-b299-60bdc077a391",
+                    "Name": "UI_CHALLENGES_MONGOOSE_CALLVANYA_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_callVanya.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_CALLVANYA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PhoneCallVanyaEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "47b263f0-285b-4f43-91dc-46ff2073c2c0",
+                    "Name": "UI_CHALLENGES_MONGOOSE_REALPAINTER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_realpainter.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_REALPAINTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RealPainterEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "48d94c33-e255-4968-95d8-de1bf0b881b2",
+                    "Name": "UI_CHALLENGES_MONGOOSE_CEMENT_NAME",
+                    "ImageName": "images/challenges/Mumbai/Cement_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_CEMENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MumbaiCementEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "5a74b11e-e5ee-4348-adba-ca70e805effe",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BOYZ_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_Boyz.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BOYZ_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 4,
+                            "EligibleTargets": [
+                                "c4043de4-9c70-4b50-a1ca-8bb39c68ad98",
+                                "dcfe2f5d-0da0-4b70-8ca4-117071cbf443",
+                                "4b49edae-c711-47a9-b68d-176d5399fb0b",
+                                "38acd088-5cf9-462b-8267-e87fd9ac1bb4",
+                                "253ffa72-1ecd-4f37-b9af-6d369b607588",
+                                "d89dd811-be7c-480c-8dda-d78d94f8714f",
+                                "7d5cde6a-d65f-4d5c-8f0b-811e2cd2dc52",
+                                "863a6934-7504-4ebc-9613-2f7396fc20d4",
+                                "f7b1b5c0-4231-4d16-b93e-a7128d41e9aa",
+                                "53c4c739-ae83-44f3-abcf-1e1b336178d5",
+                                "2479d620-81a7-45b6-b1b5-fc6cb5f95359",
+                                "70a54ef8-ccfe-421e-84aa-6c9c037a2998",
+                                "8de45b76-2fef-4603-824d-cdb608e7f961",
+                                "613dc931-2494-435a-9691-395dc482cccd"
+                            ]
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.EligibleTargets"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Transition": "Start"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "62fa4a07-170f-4bbe-a872-9fe25579e2fd",
+                    "Name": "UI_CHALLENGES_MONGOOSE_MAELSTROM_KASHMIRIAN_NAME",
+                    "ImageName": "images/challenges/Mumbai/Maelstrom_Kashmirian_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_MAELSTROM_KASHMIRIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MaelstromKashmirianEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "650f1771-6caf-4d4e-8c21-b1ec603bc991",
+                    "Name": "UI_CHALLENGES_MONGOOSE_REALKASHMIRIAN_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_realkashmirian.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_REALKASHMIRIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RealKashmirianEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "707720c2-8c4b-4d0c-8f5c-72303e717558",
+                    "Name": "UI_CHALLENGES_MONGOOSE_MOLE_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mole_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_MOLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SaveMoleEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "75f9e248-07fb-4b19-b555-dcd7f71b59dc",
+                    "Name": "UI_CHALLENGES_MONGOOSE_STORYKASHMIRIAN_NAME",
+                    "ImageName": "images/challenges/Mumbai/Story_Kashmirian_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_STORYKASHMIRIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "KashmirianOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "90213be0-a52e-4539-8bf9-8cd3b187ffce",
+                    "Name": "UI_CHALLENGES_MONGOOSE_MOLE_KILL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mole_Kill_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_MOLE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MumbaiMoleKillEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "a1403283-a635-4be0-bae6-82dcd967d22b",
+                    "Name": "UI_CHALLENGES_MONGOOSE_SKYWALKSNIPE_NAME",
+                    "ImageName": "images/challenges/Mumbai/Skywalk_Snipe_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_SKYWALKSNIPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MumbaiSkywalkSnipeEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "a9bda680-4ca1-4c5f-abe4-56758e104e02",
+                    "Name": "UI_CHALLENGES_MONGOOSE_FAN_MANUAL_NAME",
+                    "ImageName": "images/challenges/Mumbai/Find_Fan_Manual_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_FAN_MANUAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FindFanManualEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "ae33e6a7-6159-41f3-b464-3e81a329032b",
+                    "Name": "UI_CHALLENGES_MONGOOSE_MANUSCRIPT_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_manuscript.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_MANUSCRIPT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FindMissingManuscriptEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "ce2ea6f4-8a6c-45bb-89c8-c8f7f2c3c9bc",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BRIDGEMEETING_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_bridgemeeting.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BRIDGEMEETING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "21eeff62-dc2b-4906-a271-4c3b2731b260"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "d34b8153-2e51-4e17-bc5f-df6f7e5cf033",
+                    "Name": "UI_CHALLENGES_MONGOOSE_STORYPHOTO_NAME",
+                    "ImageName": "images/challenges/Mumbai/Story_Photo_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_STORYPHOTO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PhotoOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "d522bcba-8f38-4110-8f78-b657db0d6223",
+                    "Name": "UI_CHALLENGES_MONGOOSE_HOT_WATER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_tank.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_HOT_WATER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "WaterTankEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "f07634a2-46d4-4c7f-8b49-00d654bd256b",
+                    "Name": "UI_CHALLENGES_MONGOOSE_IDENTIFY_MAELSTROM_NAME",
+                    "ImageName": "images/challenges/Mumbai/Identify_Maelstrom_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_IDENTIFY_MAELSTROM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "IdentifyMaelstrom": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "f238811a-c53b-46d6-b220-4f93d0eef4ee",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BARBERSHOP_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_barbershop.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BARBERSHOP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpenBarberShopEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "f4e42a47-54c1-4e2f-9dd8-e8b0030484b0",
+                    "Name": "UI_CHALLENGES_MONGOOSE_PHOTOSHOOT_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_photoshoot.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_PHOTOSHOOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "LeadActorInPhotoShootEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "fdc3082d-b333-4506-8a8d-b99e4f27e3fa",
+                    "Name": "UI_CHALLENGES_MONGOOSE_REALFOREMAN_NAME",
+                    "ImageName": "images/challenges/Mumbai/Mongoose_realforeman.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_REALFOREMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RealForemanEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "98ff330a-ffd9-419d-a612-c2ca1856cc5c",
+                    "Name": "UI_CONTRACT_GLORIOSA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Mumbai_Gloriosa.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "dc16d4c4-f9a5-491f-a2f4-2c0b8e0a66a3"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["9badee3e-0014-46b1-9ef6-edf8858ba038"]
+                    }
+                },
+                {
+                    "Id": "d9e9d625-a2ef-45bc-a6ed-500bdbf7f0ae",
+                    "Name": "UI_CONTRACT_ANTHOGONIUM_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Mumbai_Anthogonium.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "3bf086b7-2fb6-49b3-bd95-7f46535801df"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["b6a6330a-301a-4e8e-a26f-0f3e0ea809b5"]
+                    }
+                },
+                {
+                    "Id": "438c816a-0cb1-40ae-896d-7de967047620",
+                    "Name": "UI_CONTRACT_MONKSHOOD_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Mumbai_Monkshood.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "d6f4777a-14df-40c6-a541-d8c974d9d4a1"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["4a62b328-dfe7-4956-ac0f-a3a8990fce26"]
+                    }
+                },
+                {
+                    "Id": "a138731b-6b5d-4eb9-b47b-adc9281b39d0",
+                    "Name": "UI_CONTRACT_PROTEA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Mumbai_Protea.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "cb7d1f3e-996f-4955-9b87-bdc40e4160ee"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a10472e4-0eb3-451d-814d-38837dd0f407"]
+                    }
+                },
+                {
+                    "Id": "abc19a1c-03c7-4435-8147-81c783f556d7",
+                    "Name": "UI_CONTRACT_ASHOKA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Ashoka.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "2469e028-6d85-4b50-a54c-a32c36792241"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["ae0bd6cd-7062-4336-8cb0-5fafad3d0f4f"]
+                    }
+                },
+                {
+                    "Id": "cebc09bc-8512-43c2-afff-3e171fc79fab",
+                    "Name": "UI_CONTRACT_NUTMEG_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Mumbai_Nutmeg.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "469ce2cb-a2d1-4296-bfe6-8a95bbf43fac"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["b47f34cb-6537-421c-8fc8-720a4a118540"]
+                    }
+                },
+                {
+                    "Id": "18dcdd03-a1ac-45f0-b5fd-ba4abbe5221e",
+                    "Name": "UI_CHALLENGES_MUMBAI_CAMERAS_NAME",
+                    "ImageName": "images/challenges/Mumbai/cameras.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_CAMERAS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_MUMBAI_CAMERAS_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "CameraDestroyed",
+                                                "$Value.event"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                },
+                {
+                    "Id": "63955a0c-242c-423e-afef-66e9bc81bed0",
+                    "Name": "CHALLENGEPACK_SODIUM_SPAGHETTI_NAME",
+                    "ImageName": "images/challenges/Categories/PackSodium/Sodium_Spaghetti.jpg",
+                    "Description": "CHALLENGEPACK_SODIUM_SPAGHETTI_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "ac77e98d-4ffa-4755-80fc-cd6e7adc63fb"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "easy", "feats"]
+                },
+                {
+                    "Id": "f0820fa6-52fc-42e4-8f16-e371e23b0aed",
+                    "Name": "UI_CHALLENGES_MUMBAI_BIG_SPENDER_NAME",
+                    "ImageName": "images/challenges/Mumbai/Big_Spender.jpg",
+                    "Description": "UI_CHALLENGES_MUMBAI_BIG_SPENDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BigSpenderEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "4cdba104-4bd8-4886-b6af-9474a322f095",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_BASIL_KILLED_NAME",
+                    "ImageName": "images/challenges/Mumbai/Kingcobra_Kill_Basil.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_BASIL_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "07ccfa5d-6dd3-4d2b-9f79-75b300524857"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "237b98e3-2112-4e7e-a1f7-2c0ff96e9a08",
+                    "Name": "UI_CHALLENGES_MONGOOSE_MAELSTROM_KILLED_NAME",
+                    "ImageName": "images/challenges/Mumbai/Maeostrom_Killed_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_MAELSTROM_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "c7c9e213-16f9-4215-bf07-dd8f801ce3e0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "bfabd367-bd0a-44e5-a09b-e80cccf1ba39",
+                    "Name": "UI_CHALLENGES_MONGOOSE_VANYA_KILLED_NAME",
+                    "ImageName": "images/challenges/Mumbai/Vanya_Killed_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_VANYA_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "076f23cc-09d8-423f-b890-74020f53b1d6"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "d436c2f5-b0cb-4546-a50b-e40d6040cc20",
+                    "Name": "UI_CHALLENGES_MONGOOSE_DAWOOD_KILLED_NAME",
+                    "ImageName": "images/challenges/Mumbai/Dawood_Killed_Mongoose.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_DAWOOD_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "78f98c70-b7be-4578-9b6a-1c96a3e1ff1a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "09fbbce8-c13e-46aa-b3b1-4f8a028a9437",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "3735dfb7-fc3c-46a3-b167-961d26844791",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "7c09b3db-71ea-4f3b-9719-052bdb57ed05",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "801590aa-ec88-405b-9b35-50a63a26fa9f",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "7c09b3db-71ea-4f3b-9719-052bdb57ed05",
+                                "8752b6fc-f435-4a33-a0f2-277f7f90bd60",
+                                "3735dfb7-fc3c-46a3-b167-961d26844791",
+                                "09fbbce8-c13e-46aa-b3b1-4f8a028a9437"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "8752b6fc-f435-4a33-a0f2-277f7f90bd60",
+                    "Name": "UI_CHALLENGES_KINGCOBRA_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_KINGCOBRA_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["a8036782-de0a-4353-b522-0ab7a384bade"]
+                    }
+                },
+                {
+                    "Id": "78cd6055-0f50-48a3-9c97-4c0dd2b200af",
+                    "Name": "UI_CHALLENGES_MONGOOSE_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "7bd1dbeb-4b2f-4c57-9741-5c5e28b53c23",
+                    "Name": "UI_CHALLENGES_MONGOOSE_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "7f1022ef-b40b-488e-ae24-b909cc32fadb",
+                    "Name": "UI_CHALLENGES_MONGOOSE_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "7bd1dbeb-4b2f-4c57-9741-5c5e28b53c23",
+                                "99e006bc-7437-4058-ba4c-a38beb6d63f3",
+                                "78cd6055-0f50-48a3-9c97-4c0dd2b200af",
+                                "f422f498-c917-4eb0-8012-55ce82406f3a"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "99e006bc-7437-4058-ba4c-a38beb6d63f3",
+                    "Name": "UI_CHALLENGES_MONGOOSE_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                },
+                {
+                    "Id": "f422f498-c917-4eb0-8012-55ce82406f3a",
+                    "Name": "UI_CHALLENGES_MONGOOSE_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_MONGOOSE_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_MUMBAI",
+                    "ParentLocationId": "LOCATION_PARENT_MUMBAI",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0fad48d7-3d0f-4c66-8605-6cbe9c3a46d7"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/NEWYORK/_NEWYORK_CHALLENGES.json
+++ b/contractdata/NEWYORK/_NEWYORK_CHALLENGES.json
@@ -1,0 +1,3115 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_GREEDY"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "7af765b0-466f-4ca6-b3f5-3b19ef141623",
+                    "Name": "UI_CHALLENGES_RACCOON_ATHENA_CLOCK_NAME",
+                    "ImageName": "images/challenges/Greedy/athena_clock.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_ATHENA_CLOCK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "AthenaPushed_Event": {
+                                    "Transition": "CheckKill"
+                                }
+                            },
+                            "CheckKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 5
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "8e2e80cd-52d1-49e8-9dc6-7b8b41bb7b8e",
+                    "Name": "UI_CHALLENGES_RACCOON_ATHENA_MIRROR_NAME",
+                    "ImageName": "images/challenges/Greedy/athena_mirror.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_ATHENA_MIRROR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "InVolume": false
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "MirrorKillPositionsIn": {
+                                    "$set": ["InVolume", true]
+                                },
+                                "MirrorKillPositionsOut": {
+                                    "$set": ["InVolume", false]
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "ballistic"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$.InVolume", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "922aab75-b38d-47a2-9573-df834e1066bd",
+                    "Name": "UI_CHALLENGES_RACCOON_ATHENA_VODKA_NAME",
+                    "ImageName": "images/challenges/Greedy/athena_vodka.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_ATHENA_VODKA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.KillItemRepositoryId",
+                                            "a42a9432-8af3-4702-abc3-17b88a3cb5b7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "a0f5ce66-67d7-417e-98cd-8c2d00f62b16",
+                    "Name": "UI_CHALLENGES_RACCOON_ATHENA_AWARD_NAME",
+                    "ImageName": "images/challenges/Greedy/athena_award.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_ATHENA_AWARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.SetPieceId",
+                                            "1a29d28c-be03-4149-b49c-b0c38d060772"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "17eb0598-7c74-4d44-99d5-cad68a64f206",
+                    "Name": "UI_CHALLENGES_GREEDY_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "2c73e761-c4a6-4752-b3f7-3d583eaf0879",
+                    "Name": "UI_CHALLENGES_GREEDY_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "3fe6a468-4bbd-4075-9bd6-8f8cd52d3022",
+                    "Name": "UI_CHALLENGES_GREEDY_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "72a3cf1e-e58c-410f-8c73-568af559332e",
+                    "Name": "UI_CHALLENGES_GREEDY_47_ASSASINATION_FIBER_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_47_ASSASINATION_FIBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "855dcc4f-04dc-4ec2-914e-ba95e8bab662",
+                    "Name": "UI_CHALLENGES_GREEDY_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "8c09f9d6-550e-49e3-8780-db87ab04ab1b",
+                                "2c73e761-c4a6-4752-b3f7-3d583eaf0879",
+                                "17eb0598-7c74-4d44-99d5-cad68a64f206",
+                                "3fe6a468-4bbd-4075-9bd6-8f8cd52d3022",
+                                "72a3cf1e-e58c-410f-8c73-568af559332e"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "8c09f9d6-550e-49e3-8780-db87ab04ab1b",
+                    "Name": "UI_CHALLENGES_GREEDY_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "38b4cedd-4190-4807-aefe-ea02341d18d8",
+                    "Name": "UI_CHALLENGES_RACCOON_INNER_SANCTUM_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_innersanctum.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_INNER_SANCTUM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FoundInnerSanctum": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "b0043a98-f569-4d2e-86ad-c56608f6e064",
+                    "Name": "UI_CHALLENGES_RACCOON_CONKRITE_FILES_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_obtain_conkritefiles.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_CONKRITE_FILES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "a10ff3bb-d4eb-44b4-8a95-62b7f08430a9"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "eb5e0fdb-9b01-4ce6-8482-abca99d5b1ae",
+                    "Name": "UI_CHALLENGES_RACCOON_HIGHSEC_KEYCARD_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_highsec_card.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_HIGHSEC_KEYCARD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "2d0293ca-4d7c-471d-9189-2c6a9506a710"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "0477d763-6ee7-460e-ad54-8af8d1e871dc",
+                    "Name": "UI_CHALLENGES_RACCOON_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_locationdiscovery.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 18
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_RACCOON_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "049f68e6-6038-478b-a16f-2c3858dfb66e",
+                    "Name": "UI_CHALLENGES_GREEDY_DUMP_VENTILATION_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_dump_ventilation.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_DUMP_VENTILATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "a463867d-db4c-46b1-9fdb-b8ab9e8d7788"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4a89ca35-dfcd-48d8-a4d7-78c0512a9582",
+                    "Name": "UI_CHALLENGES_GREEDY_JANITOR_KEY_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_janitorkey.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_JANITOR_KEY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "1d71317b-5cee-45a8-b560-2fddbe68a5f8"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4d34fe34-3759-49d5-9790-dabd97fff136",
+                    "Name": "UI_CHALLENGES_GREEDY_BECOME_JOB_APPLICANT_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_jobapplicant_outfit.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_BECOME_JOB_APPLICANT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "d7939c60-087c-461e-9798-c0069cfec299"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a071ab5f-2f8c-459b-b020-1e60c516b7f2",
+                    "Name": "UI_CHALLENGES_GREEDY_BECOME_IT_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_it_outfit.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_BECOME_IT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "88156045-87c6-4aff-9f99-f2fd40e0ab19"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "af61714c-3ff2-41f5-bc22-e952c2e75875",
+                    "Name": "UI_CHALLENGES_GREEDY_EXIT_GARAGE_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_car_exit.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_EXIT_GARAGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "79120c31-9a46-41e3-b45e-6ef8c80891bf"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "cadb8948-db71-41f3-9490-5b46729e1148",
+                    "Name": "UI_CHALLENGES_GREEDY_PEEP_HOLE_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_peephole.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_PEEP_HOLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "d9637ecf-b0ab-48d5-9dcb-93306c46d15d"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "d2155242-4972-4ad5-8e00-6456116de5a7",
+                    "Name": "UI_CHALLENGES_GREEDY_OPEN_ACCOUNT_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_open_account.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_OPEN_ACCOUNT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "47OpenedAccount": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "dd8ab775-7637-4f5c-b308-e0793330588d",
+                    "Name": "UI_CHALLENGES_GREEDY_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "513c0da0-1cb0-4029-85c9-ad9e9522818d",
+                                "e2f6fbfb-0237-477d-b93f-2374b02f0354",
+                                "88156045-87c6-4aff-9f99-f2fd40e0ab19",
+                                "ee38c686-f447-4a0d-bc5f-3822550db095",
+                                "f4e27f1a-3e30-42fe-aa80-dc368590886b",
+                                "589d5082-92e5-4136-922d-786646fb781a",
+                                "6b22a1db-861c-42fd-ae2d-a4a7bcda72ab",
+                                "c105fd1e-a017-42e5-8a0c-2996363352eb",
+                                "d7939c60-087c-461e-9798-c0069cfec299"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "e01fba4b-ea11-4c72-ae06-7715b8febdd8",
+                    "Name": "UI_CHALLENGES_GREEDY_EXIT_LOCKED_DOOR_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_lockeddoor_exit.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_EXIT_LOCKED_DOOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "c44664bd-de96-408b-b150-403ffa3f2ca0"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "e06b07db-374e-438d-bd39-15f3f4d4809e",
+                    "Name": "UI_CHALLENGES_GREEDY_OPEN_DEPOSIT_BOX_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_depositbox.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_OPEN_DEPOSIT_BOX_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "ee96a681-c74a-49aa-88d1-b350be853169"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "e886f894-961f-4780-bfea-b7daf9108152",
+                    "Name": "UI_CHALLENGES_GREEDY_ACED_INTERVIEW_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_aceinterview.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_ACED_INTERVIEW_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AcedInterview": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "f56578a5-0f0b-4fe3-9799-00aefc824d58",
+                    "Name": "UI_CHALLENGES_GREEDY_BECOME_FIRED_BANKER_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_firedbanker_outfit.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_BECOME_FIRED_BANKER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "c105fd1e-a017-42e5-8a0c-2996363352eb"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f5f226c7-083c-4ffb-b798-a04a03a66984",
+                    "Name": "UI_CHALLENGES_GREEDY_EXIT_JANITOR_NAME",
+                    "ImageName": "images/challenges/Greedy/exit_janitor.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_EXIT_JANITOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "afafe3d3-4a65-49d2-9397-01081e3169a0"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f74a5259-282a-45d8-9c1c-005b5de6bddc",
+                    "Name": "UI_CHALLENGES_GREEDY_BECOME_BANK_ROBBER_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_bankrobber_outfit.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_BECOME_BANK_ROBBER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "6b22a1db-861c-42fd-ae2d-a4a7bcda72ab"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": ["$.Target", "$Value"]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "317bd7a5-0dbb-494c-b7b8-0ec43714702b",
+                    "Name": "UI_CHALLENGES_RACCOON_MISSIONSTORY_FIRED_NAME",
+                    "ImageName": "images/challenges/Greedy/missionstory_fired.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_MISSIONSTORY_FIRED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "e18ca915-d2b6-4a8d-8ac2-661e51c2df84"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "39443889-95d6-4513-942d-b364067f1199",
+                    "Name": "UI_CHALLENGES_RACCOON_CROWBAR_VAULT_BUTTON_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_crowbar_vault.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_CROWBAR_VAULT_BUTTON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VaultButtonCrowbared": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "3948ef99-fc3b-4f51-ac8a-860748470baa",
+                    "Name": "UI_CHALLENGES_RACCOON_MISSIONSTORY_HEIST_NAME",
+                    "ImageName": "images/challenges/Greedy/missionstory_heist.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_MISSIONSTORY_HEIST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "bcbd4477-3e9d-4650-a552-b908090bbfaf"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "5830625d-3f31-49e9-8917-493ffc94d1bd",
+                    "Name": "UI_CHALLENGES_RACCOON_DATACORE_KNOCKOUT_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_datacoreknockout.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_DATACORE_KNOCKOUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.KillItemRepositoryId",
+                                            "7f90421c-fd20-499e-8821-0950cc8995bc"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "5a7cb2ec-9d22-4550-9eb0-b0f8b011cfca",
+                    "Name": "UI_CHALLENGES_RACCOON_GET_FIRED_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_get_fired.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_GET_FIRED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GetFired": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "5ab85882-76f9-42ec-a003-82aec02c18df",
+                    "Name": "UI_CHALLENGES_RACCOON_INTERVIEW_MS_RETROFIT_NAME",
+                    "ImageName": "images/challenges/Greedy/missionstory_job_interview.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_INTERVIEW_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "49ed98fb-c007-47ac-8d95-45629d12553e"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "600a17af-b4c3-483d-8424-a9ae92ef4248",
+                    "Name": "UI_CHALLENGES_RACCOON_CONKRITE_INVESTIGATOR_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_cronkite_investigator.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_CONKRITE_INVESTIGATOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CronkiteInvestigator": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "76f93fa8-4375-48c7-9c0b-6409997e5edb",
+                    "Name": "UI_CHALLENGES_RACCOON_POISON_FIRED_DRINK_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_poison_fired_drink.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_POISON_FIRED_DRINK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Poison_Fired_Drink": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "8d2de7b0-1e63-4f09-a9a4-0f1ce3aa53e3",
+                    "Name": "UI_CHALLENGES_RACCOON_MEETING_STARTED_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_reschedule.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_MEETING_STARTED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MeetingStarted": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "c3dd3d58-38d2-4fdc-bb01-7296531ac6f5",
+                    "Name": "UI_CHALLENGES_RACCOON_GET_THREE_PIECES_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_get_pieces.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_GET_THREE_PIECES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DiskPieceFound": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Goal", "$.Count"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "d9fa1cae-8362-4cc2-b20d-1dc6b953ef27",
+                    "Name": "UI_CHALLENGES_RACCOON_ONOFF_MS_RETROFIT_NAME",
+                    "ImageName": "images/challenges/Greedy/missionstory_it.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_ONOFF_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "d9fa1cae-8362-4cc2-b20d-1dc6b953ef27"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "e4ad5b7f-7d9b-43b0-a680-bc7ea32a2209",
+                    "Name": "UI_CHALLENGES_RACCOON_GET_DATA_CORE_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_getdatacore.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_GET_DATA_CORE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "McGuffinGotEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "f03913f1-9d47-4540-a7a5-ec79f1901c36",
+                    "Name": "UI_CHALLENGES_RACCOON_OPEN_VAULT_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_openvault.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_OPEN_VAULT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "3ddb05e1-edfd-465c-b6fc-a0b8d8a7fd0d"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "f26dba53-b9dd-4849-9285-9d8cad93cdb1",
+                    "Name": "UI_CHALLENGES_RACCOON_IT_ALLOWED_UPSTAIRS_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_it_allowed.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_IT_ALLOWED_UPSTAIRS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "47AllowedUpstairsIT": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "fadab5cb-50cd-42de-bfb1-bbad8ce539bc",
+                    "Name": "UI_CHALLENGES_RACCOON_MISSIONSTORY_EXPOSE_NAME",
+                    "ImageName": "images/challenges/Greedy/missionstory_expose.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_MISSIONSTORY_EXPOSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "19019a2b-7d9a-4b6f-aa99-a4c639a1f1ad"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "ff0b1f2c-628a-4d2a-a20b-708d9e491234",
+                    "Name": "UI_CHALLENGES_RACCOON_STOCK_MARKET_CRASH_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_stockmarketcrash.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_STOCK_MARKET_CRASH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "StockMarketCrash": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "5fe292f2-9fa6-4882-8604-64cb4d1a3ec8",
+                    "Name": "UI_CONTRACT_DANDELION_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Greedy_Dandelion.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "5adfcf3a-0696-4593-b755-c2c8d44f59a6"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["55063d85-e84a-4c76-8bf7-e70fe2cab651"]
+                    }
+                },
+                {
+                    "Id": "8321569d-4f6f-4f0a-bc6b-96445d84f95b",
+                    "Name": "UI_CHALLENGES_GREEDY_RUIN_FRANKS_DAY_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_ruin_frank_day.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_RUIN_FRANKS_DAY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": ["3f808b28-3647-44f3-9aeb-4d5ae6d63573"]
+                        },
+                        "Context": {},
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "3f808b28-3647-44f3-9aeb-4d5ae6d63573"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "dff2a0bb-855a-4cc2-a11e-2720ea45141e",
+                    "Name": "UI_CHALLENGES_GREEDY_SHOOT_PIGEON_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_shoot_pigeon.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_SHOOT_PIGEON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "APigeonDied": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "eae5bd4f-0187-49a9-b6b0-1fc9d8f443fb",
+                    "Name": "UI_CHALLENGES_GREEDY_POSION_VENTILATION_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_poison_ventilation.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_POSION_VENTILATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "400e95e1-b451-4886-af79-189a8b67f5d4"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$.Target",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                },
+                {
+                    "Id": "fabb42f9-d4f6-436c-acf1-6008d4f22358",
+                    "Name": "UI_CHALLENGES_GREEDY_GOLDBAR_KNOCKOUT_NAME",
+                    "ImageName": "images/challenges/Greedy/greedy_goldknockout.jpg",
+                    "Description": "UI_CHALLENGES_GREEDY_GOLDBAR_KNOCKOUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_GREEDY_RACCOON",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.KillItemRepositoryId",
+                                            "4292fe64-aac6-4bbe-be73-31671640172a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "be9b74c2-9892-4cb1-b63d-fec036e53af7",
+                    "Name": "UI_CHALLENGES_RACCOON_ATHENA_KILLED_NAME",
+                    "ImageName": "images/challenges/Greedy/athena_killed.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_ATHENA_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "ad93e268-3d6e-4aba-bec0-607cb5451ac7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "532d54af-e19f-437a-94cd-44d02cbf93ea",
+                    "Name": "UI_CHALLENGES_RACCOON_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "c929980a-6f5b-4677-9666-4350344f658c",
+                                "5f06aaa2-679e-4cd3-a60f-b612c1649660",
+                                "c8cf11a8-d0c6-4dd9-aad4-cf2f36f5bead",
+                                "fb6b9533-a9d1-41dc-8627-124be6df1b33"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "5f06aaa2-679e-4cd3-a60f-b612c1649660",
+                    "Name": "UI_CHALLENGES_RACCOON_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "c8cf11a8-d0c6-4dd9-aad4-cf2f36f5bead",
+                    "Name": "UI_CHALLENGES_RACCOON_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "c929980a-6f5b-4677-9666-4350344f658c",
+                    "Name": "UI_CHALLENGES_RACCOON_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                },
+                {
+                    "Id": "fb6b9533-a9d1-41dc-8627-124be6df1b33",
+                    "Name": "UI_CHALLENGES_RACCOON_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_RACCOON_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_GREEDY",
+                    "ParentLocationId": "LOCATION_PARENT_GREEDY",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["7a03a97d-238c-48bd-bda0-e5f279569cce"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/PARIS/_PARIS_CHALLENGES.json
+++ b/contractdata/PARIS/_PARIS_CHALLENGES.json
@@ -224,9 +224,19 @@
                                                     ]
                                                 },
                                                 {
-                                                    "$eq": [
-                                                        "$Value.OutfitRepositoryId",
-                                                        "315400cd-90d8-43cc-8c22-62c0cb8969a5"
+                                                    "$or": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.OutfitRepositoryId",
+                                                                "315400cd-90d8-43cc-8c22-62c0cb8969a5"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.OutfitRepositoryId",
+                                                                "31ac5259-ff59-46e0-ab0f-8ddeaf296a36"
+                                                            ]
+                                                        }
                                                     ]
                                                 }
                                             ]
@@ -243,6 +253,95 @@
                         }
                     },
                     "Tags": ["story", "hard", "assassination", "live"],
+                    "InclusionData": {
+                        "ContractIds": ["4e45e91a-94ca-4d89-89fc-1b250e608e73"]
+                    }
+                },
+                {
+                    "Id": "adf48d58-2ee4-4066-944d-f7cdbc4b3dcc",
+                    "Name": "UI_CHALLENGES_NOEL_GIFTANDTAKE_NAME",
+                    "ImageName": "images/challenges/paris/noel_GiftAndTake.jpg",
+                    "Description": "UI_CHALLENGES_NOEL_GIFTANDTAKE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 4,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "c601c095-e1dc-4490-aeae-e8e200dd9ac8",
+                                "UnlockOrder": 10
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_DEVICE_EXPLOSIVE_PRESENT_NAME",
+                            "Id": "PROP_DEVICE_EXPLOSIVE_PRESENT",
+                            "Type": "gear",
+                            "Subtype": "explosive",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "0a447781-8552-4b55-9651-c95bde9e5a7e"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "c601c095-e1dc-4490-aeae-e8e200dd9ac8"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.OutfitRepositoryId",
+                                                            "315400cd-90d8-43cc-8c22-62c0cb8969a5"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.OutfitRepositoryId",
+                                                            "31ac5259-ff59-46e0-ab0f-8ddeaf296a36"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
                     "InclusionData": {
                         "ContractIds": ["4e45e91a-94ca-4d89-89fc-1b250e608e73"]
                     }
@@ -3255,6 +3354,89 @@
                     }
                 },
                 {
+                    "Id": "5e0d4f1e-4e45-43e4-8fe3-6e38067afe93",
+                    "Name": "UI_CHALLENGES_NOEL_5PRESENTS_NAME",
+                    "ImageName": "images/challenges/paris/noel_5Presents.jpg",
+                    "Description": "UI_CHALLENGES_NOEL_5PRESENTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Quality": 4,
+                                "LoadoutSlot": "gear",
+                                "Rarity": "common",
+                                "RepositoryId": "6561a437-86ef-4338-a01f-005b3476be20",
+                                "UnlockOrder": 10
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_PROP_DEVICE_LIL_FLASHY_REMOTE_FLASH_NAME",
+                            "Id": "PROP_DEVICE_LIL_FLASHY_REMOTE_FLASH",
+                            "Type": "gear",
+                            "Subtype": "explosive",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": 149,
+                            "GamePrice": 149,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "a556efcf-123a-4fe2-b9dd-87b03d98c232"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PresentOpened": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["4e45e91a-94ca-4d89-89fc-1b250e608e73"]
+                    }
+                },
+                {
                     "Id": "dd37d9a2-87fc-416b-aa60-4b09cc4e4044",
                     "Name": "UI_CHALLENGES_NOEL_FIND_ITEMS_NAME",
                     "ImageName": "images/challenges/paris/noel_find_items.jpg",
@@ -5107,6 +5289,28 @@
             "CategoryId": "arcade",
             "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
             "Challenges": [
+                {
+                    "Id": "8e95c10a-c710-41c5-830e-9f0711965259",
+                    "Name": "UI_ORANGE_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Orange_Group.jpg",
+                    "Description": "UI_ORANGE_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["223aa1f3-64a1-43c0-b3c8-36aebd7998e4"]
+                    }
+                },
                 {
                     "Id": "5750363c-3332-4df4-9235-7c3d991d6133",
                     "Name": "UI_SALAK_COMPLETION_CHALLENGE_NAME",

--- a/contractdata/SANTAFORTUNA/_SANTAFORTUNA_CHALLENGES.json
+++ b/contractdata/SANTAFORTUNA/_SANTAFORTUNA_CHALLENGES.json
@@ -1,0 +1,5964 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_COLOMBIA"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "1d82917a-96b8-4b64-9744-a3df0942dd17",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "20bc940f-e242-4b5f-8ff4-58895de291cc",
+                    "Name": "UI_CHALLENGES_ANACONDA_STEW_NAME",
+                    "ImageName": "images/challenges/colombia/Anaconda_Stew.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_STEW_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "1e8bbf5a-473e-4b00-b58a-4706f13e497b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "9d316f01-7701-41b8-a9bb-153908768168"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "3575edd0-806f-4602-8374-8c60121e6f26",
+                    "Name": "UI_CHALLENGES_ANACONDA_SNAKETRAP_NAME",
+                    "ImageName": "images/challenges/colombia/Anaconda_SnakeTrap.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_SNAKETRAP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Blair_Close_And_Bomb_Ready"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Blair_Not_Close_Or_Bomb_Not_Ready"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "1e8bbf5a-473e-4b00-b58a-4706f13e497b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "5f1859b2-ceb9-43b0-ae58-6a2817c3f5db",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "665ae7e8-9307-4bf2-ae73-4ce8615fad6e",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_MASTER_OF_TRADE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_MASTER_OF_TRADE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "bae428d5-861c-4d1b-9187-d6bf67f4515f",
+                                "5f1859b2-ceb9-43b0-ae58-6a2817c3f5db",
+                                "8318a1d6-5859-4ad9-8d6c-59b1376d6384",
+                                "76108443-1bdf-45c3-8432-897dd8f7a49b",
+                                "1d82917a-96b8-4b64-9744-a3df0942dd17"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "76108443-1bdf-45c3-8432-897dd8f7a49b",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "8318a1d6-5859-4ad9-8d6c-59b1376d6384",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "8bf91a99-7840-4666-9545-8c650e416c39",
+                    "Name": "UI_CHALLENGES_ANACONDA_COCONUT_NAME",
+                    "ImageName": "images/challenges/colombia/Anaconda_Coconut.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_COCONUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "1e8bbf5a-473e-4b00-b58a-4706f13e497b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "bae428d5-861c-4d1b-9187-d6bf67f4515f",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "1839d93b-7799-43fe-8ded-08fabe46c98a",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_FRANCO_MACHINE_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_franco_machine.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_FRANCO_MACHINE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Machine_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "26b72b1d-fc45-4970-9c5b-99b81ab25f40",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_SUB_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_delgado_sub.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_SUB_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "00df867e-f27f-4904-8bc7-9504443ccb5a"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "4cc908da-6827-4c0a-915b-f78ccd02a025"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "2b6c1d37-236c-4686-9302-457a75a0e44c",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_CEMENT_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_martinez_cement.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_CEMENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "db21a429-add2-46fa-8176-540f846d89e0"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "314c82b7-1120-48c3-a4fa-c7a3f412afb6"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "614d1b1d-b076-425f-8be3-3a5bf4f4ddc1",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_BOTH_STATUE_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_both_statue.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_BOTH_STATUE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "StatueKills": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "StatueKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "e4e1b6a1-25b6-4f02-b381-9b086cbe306f"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.StatueKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "00df867e-f27f-4904-8bc7-9504443ccb5a",
+                                                    "db21a429-add2-46fa-8176-540f846d89e0"
+                                                ]
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "6c1fc97d-7441-47ba-a813-9afc210d6438",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_ART_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_art.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_ART_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "00df867e-f27f-4904-8bc7-9504443ccb5a"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "c63b8218-b6cf-46f3-8c94-95d0652ae470"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "728c9851-8add-4898-b462-534b32a5eda7",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_STATUE_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_delgado_statue.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_STATUE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "00df867e-f27f-4904-8bc7-9504443ccb5a"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "e4e1b6a1-25b6-4f02-b381-9b086cbe306f"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "76cebaff-3e5a-4d4a-94da-02162d37d987",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_CRANE_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_martinez_crane.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_CRANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "db21a429-add2-46fa-8176-540f846d89e0"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "e4e4ca0d-ee50-4928-8357-69ed283700a0"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "9e220950-307e-4e28-85c9-932b9267936c",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_FRANCO_FLOWER_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_franco_flower.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_FRANCO_FLOWER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Flower_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "b7207050-f0da-4b18-9c63-95dc0ff2c6a8",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_TATTOO_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_delgado_tattoo.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_TATTOO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "00df867e-f27f-4904-8bc7-9504443ccb5a"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "d054a8ca-2dcf-442b-8eb8-f73350a045b6"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "d236a485-ca91-418c-a8ff-83350c1ebd03",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_PACKAGE_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_martinez_letterbomb.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_PACKAGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_BombInTray"
+                                        ]
+                                    },
+                                    "Transition": "Bomb_Dropped"
+                                }
+                            },
+                            "Bomb_Dropped": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "db21a429-add2-46fa-8176-540f846d89e0"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "30fa1ade-386f-49b7-bddd-a23cd912611d"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "de1380f3-4ebe-43c3-8a03-beb7973db2b6",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_LETTER_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_martinez_letter.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_MARTINEZ_LETTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Letter_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "e2fd269d-39d0-45e6-a830-f02ffbac8e16",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_HIPPO_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_delgado_hippo.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_DELGADO_HIPPO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Hippo_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "e3842229-df42-42bb-8cdd-d61dfc3d4655",
+                    "Name": "UI_CHALLENGES_HIPPO_SIGN_FRANCO_POISON_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_sign_franco_poison.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SIGN_FRANCO_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "Collection": [
+                                "b8c1e512-602e-48f7-8459-aa5fef7cebef",
+                                "c8ad7a5b-8f57-4b0f-9242-4f7a9e9cc6e8"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b87b242e-4ef4-42d8-94ed-17cbfc9009bf"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Collection"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "0fab3445-e7fb-46e6-b75d-7802f9a101a7",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "1a098cb8-89ef-491d-9936-00fa8a4a513b",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_HOTTUB_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_hottub.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_HOTTUB_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "671746f4-eecd-417d-b0cd-1ad49e88f0c2"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "9f67fab1-7b57-4c3c-bd92-a9109891d5ca"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "2c29a13a-c760-4fb0-aef8-8d0b2e0361ed",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "3e07dda5-ed91-4c2d-9258-92094480f0ad",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "69c887b5-008b-4525-8e8c-9bac49bd89cc",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_MEAT_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_meat.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_MEAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "cac6e4cb-8e4a-44ac-accb-0c74d8f4a2e2"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "acc9d7b8-80f1-4bb0-ba81-3a69b09e0543"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Target_Killed"
+                                }
+                            },
+                            "Target_Killed": {
+                                "DumpInOcean": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "cac6e4cb-8e4a-44ac-accb-0c74d8f4a2e2"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "8795532f-c394-45ab-bd92-fb7967ef201b",
+                    "Name": "CHALLENGEPACK_LITHIUM_COCAFIELD_GUARDS_NAME",
+                    "ImageName": "images/challenges/Categories/PackLithium/Lithium_Cocafields.jpg",
+                    "Description": "CHALLENGEPACK_LITHIUM_COCAFIELD_GUARDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 10
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "CHALLENGEPACK_LITHIUM_COCAFIELD_GUARDS_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_CocafieldKill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "hard", "assassination"]
+                },
+                {
+                    "Id": "88b6629f-4fdf-4591-9579-92935fc8943f",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_STREETFOOD_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_streetfood.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_STREETFOOD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "Collection": [
+                                "5760baa0-7f73-421c-ae81-0a1359f610d8"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "87d7baa2-0442-46a8-b9ed-f8c822d953fe"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Collection"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "9a6377ac-5e72-426f-aa15-090d358349c0",
+                    "Name": "CHALLENGEPACK_LITHIUM_CONSTRUCTIONPIT_NAME",
+                    "ImageName": "images/challenges/Categories/PackLithium/Lithium_ConstPit.jpg",
+                    "Description": "CHALLENGEPACK_LITHIUM_CONSTRUCTIONPIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "CHALLENGEPACK_LITHIUM_CONSTRUCTIONPIT_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_ConstructionPit_Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "medium", "assassination"]
+                },
+                {
+                    "Id": "b3782bb7-6472-4532-b209-6fca3589b0fa",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "e136da3a-9374-43cd-9956-a49c4a6b6edf",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_MASTER_OF_TRADE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_MASTER_OF_TRADE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "b3782bb7-6472-4532-b209-6fca3589b0fa",
+                                "0fab3445-e7fb-46e6-b75d-7802f9a101a7",
+                                "efbcd572-990e-4dd9-9436-1fef6eac5a3f",
+                                "2c29a13a-c760-4fb0-aef8-8d0b2e0361ed",
+                                "3e07dda5-ed91-4c2d-9258-92094480f0ad"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "e33f7a73-5863-42a1-ac69-f30f9b6c3411",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_COKE_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_coke.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_COKE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "ee277dd3-825d-46bb-ac6f-95f25c94676f"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceType",
+                                                        "a56ee73f-1aec-4612-b9ff-48b9ed09137a"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "efbcd572-990e-4dd9-9436-1fef6eac5a3f",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "20f8ecb4-efcf-4a4b-b90b-9f64784d3437",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_SPEEDBOAT_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exit_gate_speedboat.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_SPEEDBOAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "b4fe489f-bd01-446c-869c-b37efb7cab33"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "2b6fa515-7dc7-4939-a1eb-6f8c0800f865",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_SPORTSCAR_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exit_gate_sportscar.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_SPORTSCAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "18b7dd32-caf9-4710-ad42-f7594b3a96fe"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "3896ae0f-9199-470b-877b-db9fc7b99252",
+                    "Name": "UI_CHALLENGES_COLOMBIA_47_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_47_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "30005896-2b39-49c0-bb04-3475d4a12ae6",
+                                "bbc1dd7c-a0ef-41eb-9bef-a4c38fded3fa",
+                                "fc0491ac-8592-486d-9dc2-b39af13cf6e3",
+                                "dfaa8260-20af-4112-b1ca-88a98481127b",
+                                "4a145036-e4cc-4798-a795-42bcee511524",
+                                "177410f1-4fd7-4ef2-8ed7-2119bcba3661",
+                                "ab5a46a2-6e53-4b15-a48e-c336df1ef5ff",
+                                "57342129-03a9-47a4-a509-cc0656e0a76a",
+                                "cfacf46a-eb59-4a16-a221-a690defd05a3",
+                                "f0d1dfab-ac73-4fe9-bbac-a5587fbc0f91",
+                                "d0fe70cb-c30b-41a3-8d1c-5503e898f686",
+                                "886c3b26-b81f-4731-8080-524f2d6da5dd",
+                                "2dec1e42-0093-462a-83aa-c0f4d82ac224",
+                                "56a589d8-bf28-489f-a30c-2ecea87177f5",
+                                "11f2849d-87c5-4806-a25e-1a9dad85981d",
+                                "a741cd97-135e-465e-89c3-4fa52a2bbf9d",
+                                "fbf1ca6f-8559-410d-a0b4-66a5a32d1d90",
+                                "f86848e7-ca8c-48e0-94d1-2d925e96a3e7"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "507b9b41-55ba-4654-a677-e12ab38fd341",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_MOTORBIKE_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exit_gate_motorbike.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_MOTORBIKE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "a58d7495-ea70-45e5-be02-690698b74a33"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "796b367d-de45-45f7-808d-6a7091462843",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_CAR_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exit_gate_car.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXIT_GATE_CAR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "6e23cf2d-42b0-4474-baa8-3e175a6ed206"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "bc1b80fb-fb48-4d9d-b8ba-078b661c850f",
+                    "Name": "UI_CHALLENGES_HIPPO_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/colombia/area_discovered_hippo.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 56
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HIPPO_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "15b2ae71-735d-4307-9fc5-14e34f68734a",
+                    "Name": "UI_CHALLENGES_ANACONDA_SHAMAN_NAME",
+                    "ImageName": "images/challenges/colombia/Anaconda_Shaman.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_SHAMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShamanEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "1ecb427c-fc67-429d-a73c-43c0b5dbc8c5",
+                    "Name": "UI_CHALLENGES_ANACONDA_SACREDPOOL_NAME",
+                    "ImageName": "images/challenges/colombia/Anaconda_SacredPool.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_SACREDPOOL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SacredPoolEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "7f366a20-a20f-43ba-8bbc-b5f778ae44f0",
+                    "Name": "UI_CHALLENGES_ANACONDA_JUNGLEKEY_NAME",
+                    "ImageName": "images/challenges/colombia/Anaconda_JungleKey.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_JUNGLEKEY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "7b5f8f1c-06a3-4ea7-bb27-8d39d5916e86"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "1da6b2ae-24f7-407e-bf98-49d2440dacbf",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_TATTOOIST_ENTERED_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_tattooist_entered.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_TATTOOIST_ENTERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Tattooist_Entered"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "2c17215c-4eed-4099-a7c3-76b1ee31949e",
+                    "Name": "UI_CHALLENGES_HIPPO_STORY_CHALLENGE_DEADLY_NAME",
+                    "ImageName": "images/challenges/colombia/story_deadly_hippo.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_STORY_CHALLENGE_DEADLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "DeadlyArtStory_Event"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "2dfa4a89-1459-44f4-94dc-7aebd8ecf83d",
+                    "Name": "UI_CHALLENGES_HIPPO_SUBMERGED_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/colombia/colombia_opp_submarine.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SUBMERGED_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "fccf719c-94b9-43b8-acb1-60f494743622"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "3349afb0-ffac-4704-b7dd-5da1286ae776",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_HIPPO_FED_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_hippo_fed.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_HIPPO_FED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Hippo_Fed"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "363b832f-0452-4dd5-aa4c-f8dbd215f16f",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_FISHFOOD_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_fishfood.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_FISHFOOD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 4
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_COLOMBIA_EXP_FISHFOOD_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_FishGuards": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "449e7053-1192-4558-83eb-d4192b8bb932",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_MUSEUM_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_museum.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_MUSEUM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 4
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_COLOMBIA_EXP_MUSEUM_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_Museum": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "46fe54cb-48e8-48c0-97d5-1ac60f095d8d",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_SECRET_KNIFE_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_secret_knife.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_SECRET_KNIFE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Easter_Egg_Knife"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "5391e4cf-8c6f-4ae4-b824-59ba2b7de50b",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_FROGS_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_frogs.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_FROGS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_COLOMBIA_EXP_FROGS_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_FroggyTime": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "554e389f-cfa6-4598-b522-0859ab50f744",
+                    "Name": "UI_CHALLENGES_HIPPO_LOVE_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/colombia/colombia_opp_undyinglove.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_LOVE_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "3ddbfc15-7a59-423e-834a-822cfaf6c507"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "59730f14-cd66-4311-b335-ae76466df27a",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_SHOW_PASSPORT_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_show_passport.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_SHOW_PASSPORT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Passport_Shown"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "620207a2-0f3c-4243-9a9b-4f65da453355",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_MEET_SHAMAN_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_meet_shaman.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_MEET_SHAMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Shaman_Martinez_Meet"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "6bd35168-1ef1-4db1-abbe-942d31948544",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_BARTENDER_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_bartender.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_BARTENDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_ChattyBarman"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "7105f918-fc5d-4ca0-89c8-4b700701bb68",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_FIND_MACHINEPART_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_find_machinepart.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_FIND_MACHINEPART_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "926f4484-7f95-470e-aed8-918a1e4d4bd3"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "7c0d7aa1-7333-4f2f-b0e3-d3b1409f0fac",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_BRICKS_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_bricks.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_BRICKS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_COLOMBIA_EXP_BRICKS_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_RedBricks": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "96869870-a5ec-4deb-b4b3-be43367a22b6",
+                    "Name": "UI_CHALLENGES_HIPPO_BAKED_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/colombia/colombia_opp_halfbaked.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_BAKED_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "0c0c243f-8a43-4e6c-aee3-6d167ae31d7a"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "a2e8e786-c681-49aa-85ed-573b240bf512",
+                    "Name": "UI_CHALLENGES_HIPPO_BACKPACKER_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/colombia/colombia_opp_backpacker.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_BACKPACKER_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "7c2f850f-e804-45bf-88c2-e5483d976d9a"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "a563da5b-dcb3-4f2f-9a99-93bb3ba9b6b0",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_KEYMASTER_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_keymaster.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_KEYMASTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Secret_Doors"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "aaa17ca5-c67d-4f07-927d-96f6c28a1a5b",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_SUB_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_sub_discovered.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_SUB_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Engineer_In_Cave"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "b1551cf5-2f08-40d7-b282-8266ffa3adef",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_DESTROY_FLOWER_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_destroy_flower.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_DESTROY_FLOWER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Flower_Destroyed"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "b243a399-3ded-449d-8da9-03bb2b8a1bcc",
+                    "Name": "UI_CHALLENGES_HIPPO_STORY_CHALLENGE_HALLOWED_NAME",
+                    "ImageName": "images/challenges/colombia/story_hallowed_hippo.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_STORY_CHALLENGE_HALLOWED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "HallowedGround_Event"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "b8b108fa-cc81-439b-b0df-a55fca3f5b19",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_RAPTOR_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_raptor.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_RAPTOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_COLOMBIA_EXP_RAPTOR_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_Raptor": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "cac24510-66e8-422c-8c99-c192fb67cf71",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_MEET_BAND_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_meet_band.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_MEET_BAND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Statue_Loose"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "e633ca93-1d27-4c4a-b98f-77b1a0fc99ed",
+                    "Name": "UI_CHALLENGES_HIPPO_EXP_FIND_LOVELETTER_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_exp_find_loveletter.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_EXP_FIND_LOVELETTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "9c14b7fc-667e-4967-af96-22d69db518a1"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "fb900e0c-62ab-431e-924f-e96fa81ae247",
+                    "Name": "UI_CHALLENGES_COLOMBIA_EXP_RETURN_LETTER_NAME",
+                    "ImageName": "images/challenges/colombia/colombia_c_exp_return_letter.jpg",
+                    "Description": "UI_CHALLENGES_COLOMBIA_EXP_RETURN_LETTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Return_Letter"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "fc16735a-9048-4e02-802e-ef3baba250e9",
+                    "Name": "UI_CHALLENGES_HIPPO_STORY_CHALLENGE_HEART_NAME",
+                    "ImageName": "images/challenges/colombia/story_heart_hippo.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_STORY_CHALLENGE_HEART_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "HeartOfStoneStory_Event"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "6c200073-f444-4493-958d-2d6bc96697a2",
+                    "Name": "UI_CONTRACT_HOLLY_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Holly.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "a4013b71-f772-4e2a-8b35-6511ed132bcf"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["390ba7b6-de27-464a-b8af-6d0ff54c2aec"]
+                    }
+                },
+                {
+                    "Id": "146eae09-17ab-403e-9992-91a0409b20d2",
+                    "Name": "UI_CONTRACT_SNAPDRAGON_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Snapdragon.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "e1e117f4-cf3e-4538-b085-4a226116f143"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["70150cd2-ef76-4ba8-80cc-b1e63871b030"]
+                    }
+                },
+                {
+                    "Id": "1b3e21c7-1e56-47d1-9e7a-091f91f7d823",
+                    "Name": "UI_CONTRACT_TITANUMARUM_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Titanumarum.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "79d966d9-5756-4a2f-b7e7-468a1a1ac351"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["be567ad3-23f4-4d0b-9d2e-b261ea845ef0"]
+                    }
+                },
+                {
+                    "Id": "0dce1e59-9b32-46b0-9a18-5469bb681170",
+                    "Name": "UI_CONTRACT_ZINNIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Zinnia.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "f0d8a930-3581-41c8-b985-31eaeef9b920"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["a5e81878-0eae-4bcf-af9b-9a7e7833f85d"]
+                    }
+                },
+                {
+                    "Id": "39651a66-ffad-403c-be38-54625bb27dd7",
+                    "Name": "UI_CONTRACT_RAFFLESIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Rafflesia.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "19623520-8a89-4cc5-93f1-a4356fda16b2"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["757fd132-0300-45ec-b5bd-bdd48c543b5c"]
+                    }
+                },
+                {
+                    "Id": "d356f0ef-0a7a-4de9-b9a4-6809d9b56d0a",
+                    "Name": "UI_CONTRACT_RAFFLESIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Rafflesia_SA.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_SA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$ContractId",
+                                                    "19623520-8a89-4cc5-93f1-a4356fda16b2"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["757fd132-0300-45ec-b5bd-bdd48c543b5c"]
+                    }
+                },
+                {
+                    "Id": "ab6c1c39-c164-40ef-917f-5a8fabc5ee7c",
+                    "Name": "UI_CONTRACT_ARRAYAN_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Arrayan.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "5d6f7b13-13be-414f-8010-3e97e5b7b490"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["41ecf8ce-dfd4-4c08-8f44-52dedc3f089a"]
+                    }
+                },
+                {
+                    "Id": "cec8bda2-c6ce-47f5-a7f7-fa6efc833bb6",
+                    "Name": "UI_CONTRACT_CALLUNA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Colombia_Calluna.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "c03510ef-1932-4b59-997a-3d75ef6e8e8d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["d336d894-024a-4cd4-9867-dee7de70ee79"]
+                    }
+                },
+                {
+                    "Id": "a799a65b-4bee-4814-8390-0fecac34113b",
+                    "Name": "CHALLENGEPACK_NEON_DROP_NAME",
+                    "ImageName": "images/challenges/Categories/PackNeon/Neon_Drop.jpg",
+                    "Description": "CHALLENGEPACK_NEON_DROP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "CHALLENGEPACK_NEON_DROP_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_Musician_Bricked": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "live", "hard", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "aafbdf54-a728-4ae1-bae5-97a5cf9fd942",
+                    "Name": "UI_CHALLENGES_ANACONDA_BLAIR_KILLED_NAME",
+                    "ImageName": "images/challenges/Colombia/Anaconda_Kill_Blair.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_BLAIR_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "1e8bbf5a-473e-4b00-b58a-4706f13e497b"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "232f7eae-6aee-4c5b-a21e-1e7d06b1ce30",
+                    "Name": "UI_CHALLENGES_HIPPO_FRANCO_COOK_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_franco_cook.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_FRANCO_COOK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "KilledActors": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "b87b242e-4ef4-42d8-94ed-17cbfc9009bf"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "primary", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "698257ee-1fea-4996-b22a-cf4d71c49180",
+                    "Name": "UI_CHALLENGES_HIPPO_MARTINEZ_FACE_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_martinez_face.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_MARTINEZ_FACE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "KilledActors": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "db21a429-add2-46fa-8176-540f846d89e0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "primary", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "992305bf-93c3-4857-8a3a-0c9282f99695",
+                    "Name": "UI_CHALLENGES_HIPPO_DELGADO_BOSS_NAME",
+                    "ImageName": "images/challenges/colombia/hippo_c_delgado_boss.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_DELGADO_BOSS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "KilledActors": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "00df867e-f27f-4904-8bc7-9504443ccb5a"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "primary", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "19ef07a7-65ed-454c-a789-f843f7e12939",
+                    "Name": "UI_CHALLENGES_ANACONDA_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "2f47d774-7033-4089-8e52-e3a1bd667859",
+                    "Name": "UI_CHALLENGES_ANACONDA_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "671c906c-4bab-4996-a899-de42fb5acfa2",
+                    "Name": "UI_CHALLENGES_ANACONDA_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "76e2aa76-d571-434e-b8e9-8992321fa1a4",
+                    "Name": "UI_CHALLENGES_ANACONDA_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "9372623f-32e1-436c-963a-3e6da60961fe",
+                    "Name": "UI_CHALLENGES_ANACONDA_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_ANACONDA_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "2f47d774-7033-4089-8e52-e3a1bd667859",
+                                "19ef07a7-65ed-454c-a789-f843f7e12939",
+                                "671c906c-4bab-4996-a899-de42fb5acfa2",
+                                "76e2aa76-d571-434e-b8e9-8992321fa1a4"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["179563a4-727a-4072-b354-c9fff4e8bff0"]
+                    }
+                },
+                {
+                    "Id": "0a4678f9-025f-4497-8a30-8efaac9bbca4",
+                    "Name": "UI_CHALLENGES_HIPPO_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "56ac7bf9-2e82-425b-b644-3b1d61fe10c4",
+                    "Name": "UI_CHALLENGES_HIPPO_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "57bf21f6-813c-449e-b9d9-623d3522cecb",
+                    "Name": "UI_CHALLENGES_HIPPO_BIG5_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "82fc6843-ce7c-4c5f-a517-22464b7dc572",
+                                "0a4678f9-025f-4497-8a30-8efaac9bbca4",
+                                "66a0fca7-59eb-4697-b643-5d0d08b439c3",
+                                "56ac7bf9-2e82-425b-b644-3b1d61fe10c4"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "66a0fca7-59eb-4697-b643-5d0d08b439c3",
+                    "Name": "UI_CHALLENGES_HIPPO_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                },
+                {
+                    "Id": "82fc6843-ce7c-4c5f-a517-22464b7dc572",
+                    "Name": "UI_CHALLENGES_HIPPO_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_HIPPO_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["422519be-ed2e-44df-9dac-18f739d44fd9"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "3caf1ad2-1c2c-4aa1-89ae-ac74ec45a9fa",
+                    "Name": "UI_APRICOT_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Apricot_Group.jpg",
+                    "Description": "UI_APRICOT_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_COLOMBIA",
+                    "ParentLocationId": "LOCATION_PARENT_COLOMBIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["90121ee0-0431-4a97-9bc8-8a7e2ca30d65"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/SGAIL/_SGAIL_CHALLENGES.json
+++ b/contractdata/SGAIL/_SGAIL_CHALLENGES.json
@@ -1,0 +1,3953 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_NORTHSEA"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "07545ae7-6bad-4633-9514-d4850fc01d82",
+                    "Name": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_ZOE_NECKLACE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_zoe_necklace_kill.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_ZOE_NECKLACE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "7eb39f2d-1030-44d2-be82-6df608085ec0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "92d68841-8552-40b1-b8a5-c36c6efdb6b1"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "28205259-704a-4207-825d-c8e28968768b",
+                    "Name": "UI_CHALLENGES_MAGPIE_SIGN_SERENA_NECKLACE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_sign_necklace.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SIGN_SERENA_NECKLACE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Necklace_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "5cae5183-4174-49d7-a5bc-0d263d7d0caa",
+                    "Name": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_SERENA_GARGOYLE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_serena_gargoyle_kill.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_SERENA_GARGOYLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "67f39ab8-c25f-48c3-84be-0ec495a553ec"
+                                                ]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "49ae6820-1f4f-4cff-b0e0-f5b3c87ad9fc"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "9e0ff42e-33d0-4cf1-baa7-9f9bd499e23a"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "449f9fc3-18be-4210-81c4-552c9c0bd299"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "62793045-579f-40ab-ae71-8a8528a67838"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "be78efa1-caf2-4fef-9b5d-8cce1e93d73a"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "5d97b28f-93a0-4bf7-9bdc-834b33ce66a6",
+                    "Name": "UI_CHALLENGES_MAGPIE_SIGN_ZOE_FUNERAL_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_sign_funeral.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SIGN_ZOE_FUNERAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Funeral_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "6d15c7e5-e478-4e91-944c-09dae62a64a6",
+                    "Name": "UI_CHALLENGES_MAGPIE_SIGN_SERENA_MEETING_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_sign_meeting.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SIGN_SERENA_MEETING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Meeting_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "8a038e1b-5959-4995-9205-0003e9ec08cf",
+                    "Name": "UI_CHALLENGES_MAGPIE_TARGETS_KILLED_AFTER_C_ESCAPE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_kill_targets_after_c_escape.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_TARGETS_KILLED_AFTER_C_ESCAPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_TargetsKilled_AfterCEscapes"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "aeda5ea9-7d64-49ea-89bd-9691c85dc103",
+                    "Name": "UI_CHALLENGES_MAGPIE_SIGN_SERENA_VOTE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_sign_vote.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SIGN_SERENA_VOTE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Vote_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "b4019a75-aa30-48d7-a857-b52d77952094",
+                    "Name": "UI_CHALLENGES_MAGPIE_SIGN_ZOE_EFFIGY_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_sign_effigy.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SIGN_ZOE_EFFIGY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Effigy_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "de60fe5f-13e2-4923-a337-271586e3df6f",
+                    "Name": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_ZOE_CANNON_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_zoe_cannon_kill.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_ZOE_CANNON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "7eb39f2d-1030-44d2-be82-6df608085ec0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "daecdad7-2aab-4b31-9e8b-3a12d7ca5dac"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "ee5b08d2-775c-48d2-894d-a7be066807bd",
+                    "Name": "UI_CHALLENGES_MAGPIE_SIGN_ZOE_INITIATION_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_sign_initiation.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SIGN_ZOE_INITIATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Initiation_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "167b25b4-ea3e-436e-872a-5ee4491ca6ee",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "271c8e4a-2958-4f8a-a81f-369e3bb44964",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_VIKING_AXE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_viking_axe_kill.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_VIKING_AXE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "9a7711c7-ede9-4230-853e-ab94c65fc0c9"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "41b1df30-e957-4818-bd1d-03508b198f99",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "57e2898e-6a3c-466c-850c-60aafb267d17",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_MASTER_OF_TRADE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_MASTER_OF_TRADE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "41b1df30-e957-4818-bd1d-03508b198f99",
+                                "af52c0b5-4bf7-4e82-a196-0f518eaaa427",
+                                "a6e59ac3-080d-44b6-89e8-1ab67ec88729",
+                                "a90e200b-13b2-4e40-873e-90e9c9c278e2",
+                                "167b25b4-ea3e-436e-872a-5ee4491ca6ee"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "7a222dc0-12b8-468d-af34-5543a160a35a",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_GIBBET_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_gibbet_kill.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_GIBBET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "26353452-9302-4fd6-bd1d-d26051728d23"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "a6e59ac3-080d-44b6-89e8-1ab67ec88729",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "a90e200b-13b2-4e40-873e-90e9c9c278e2",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "af52c0b5-4bf7-4e82-a196-0f518eaaa427",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                },
+                {
+                    "Id": "c9a919be-3fb3-467b-9fa9-9403f7916593",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_LONGSWORD_ARMOUR_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_knight_sword_kill.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_LONGSWORD_ARMOUR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "12200bd8-9605-4111-8b26-4e73cb07d816"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "fae73e92-2307-4163-8e9f-30401ca884bf"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "4fe2347a-f972-4b8e-b40f-eabb35ed9c96",
+                    "Name": "UI_CHALLENGES_MAGPIE_EXP_FIND_KILLSWITCH_PLANS_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_find_killswitch_plans.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_EXP_FIND_KILLSWITCH_PLANS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "c_discovery_meeting"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "6bb9e9a9-f83c-44c2-a241-05a4e9a97a71",
+                    "Name": "UI_CHALLENGES_MAGPIE_EXP_BECOME_MASTER_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_become_master.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_EXP_BECOME_MASTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "c_discovery_vote"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "a9b06d87-fe4c-476a-823e-604eea964292",
+                    "Name": "UI_CHALLENGES_MAGPIE_EXP_STEAL_NECKLACE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_steal_necklace.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_EXP_STEAL_NECKLACE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "c_discovery_necklace"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "b5be2e17-9156-435c-8973-da2ec822d5c5",
+                    "Name": "UI_CHALLENGES_MAGPIE_EXP_BECOME_INITIATE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_become_initiate.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_EXP_BECOME_INITIATE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "c_discovery_initiation"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "1692ae11-eb63-4834-9f1f-795f4be64440",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "9db0a810-7549-4932-b0ab-9d6241afdc2c",
+                                "b8b1d3c2-cf47-4a44-acc8-d8aa965ec8d8",
+                                "8d2b15f2-1d23-4b5e-b128-d2f47b53faf7",
+                                "daf223e8-0b22-405f-a3b9-40d2b9992c2f",
+                                "f9a34b19-f9ff-44a9-b232-86b1b8fcdbb0",
+                                "ae340f4d-6282-48d0-8e0d-c3dcb414bb4f",
+                                "d40fe7e8-ec8d-429b-a86b-7844c0e4d1c7",
+                                "bef91840-e5aa-4a44-9f2e-30c732b1f7be",
+                                "fae73e92-2307-4163-8e9f-30401ca884bf",
+                                "6565bf3a-aa59-44f5-9b89-ef645f99d4fa",
+                                "58f91772-a202-49e4-a558-159f762d78e3",
+                                "84c55eed-6891-40b3-9449-6881b53fabdd",
+                                "e4aeb186-bedd-41a1-b4c0-bb9c49bc7982",
+                                "04d72492-1b6b-4e6b-8372-5e65dc209cc4",
+                                "e3d61bbf-5b28-45cb-88bd-b386f5daa605",
+                                "e9a9b20d-93de-48b7-8840-73411bace252",
+                                "415c3c97-3c45-43a8-b930-40bece444a55"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "78c10759-0787-4ce7-9f2f-747298418b73",
+                    "Name": "UI_CHALLENGES_NORTHSEA_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/northsea/area_discovered_magpie.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 49
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_NORTHSEA_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "7a1e2522-758f-4576-abbf-720973e0d348",
+                    "Name": "UI_CHALLENGES_NORTHSEA_EXIT_GATE_EFFIGY_DIVE_NAME",
+                    "ImageName": "images/challenges/northsea/northsea_c_exit_gate_effigy_dive.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_EXIT_GATE_EFFIGY_DIVE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "4bc9583a-4921-409f-9968-973b247110c7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "a77901d9-3eb3-4ead-a6e8-f58975f03a0f",
+                    "Name": "UI_CHALLENGES_NORTHSEA_EXIT_GATE_HELIPAD_NAME",
+                    "ImageName": "images/challenges/northsea/northsea_c_exit_gate_helipad.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_EXIT_GATE_HELIPAD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "a585684e-31b8-49ca-86bd-8106aff128bd"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "c5a1bb35-b84e-42e9-aa8c-7d3f7ddfff69",
+                    "Name": "UI_CHALLENGES_NORTHSEA_EXIT_GATE_ROOFTOP_NAME",
+                    "ImageName": "images/challenges/northsea/northsea_c_exit_gate_rooftop.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_EXIT_GATE_ROOFTOP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "0e33cf29-7d01-430e-a3a9-8a50c0aa8ba5"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "f85fa429-5186-4665-a0ee-9c04d387c603",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_OPEN_ARK_CRATES_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_open_ark_crates.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_OPEN_ARK_CRATES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 9
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_NORTHSEA_47_OPEN_ARK_CRATES_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_ArkCrates_Opened": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "11c45d2b-ecb9-4d0d-92d1-81ee345b3259",
+                    "Name": "UI_CHALLENGES_MAGPIE_PHOENIX_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/theisland/theisland_opp_effigy.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_PHOENIX_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "7df5f11d-c5b6-4ac4-a333-17a6eb7675fe"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "14341433-3e5f-46e4-aefa-f9c12e7a57e3",
+                    "Name": "UI_CHALLENGES_MAGPIE_COLLECT_X_TOKENS_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_collect_coins.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_COLLECT_X_TOKENS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 30
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_MAGPIE_COLLECT_X_TOKENS_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "C_Tokens_Found": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "307db007-edfa-4ca6-95a9-d051810dbe16",
+                    "Name": "UI_CHALLENGES_MAGPIE_CLUB_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/theisland/theisland_opp_initiation.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_CLUB_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "78009af6-e504-4d79-9cc4-5c058f1d8d09"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "5b6612b0-5347-4e36-bc4e-e874d13bd621",
+                    "Name": "UI_CHALLENGES_MAGPIE_EXP_ATTEND_FUNERAL_JANUS_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_attend_funeral_janus.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_EXP_ATTEND_FUNERAL_JANUS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "c_discovery_funeral"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "69d876e7-9962-4a6a-8867-df335fd2ea13",
+                    "Name": "UI_CHALLENGES_MAGPIE_SPOOK_SOPHIA_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_spook_sophia.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SPOOK_SOPHIA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Spook_Sophia"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "71ae4b54-d48c-435b-be2a-9fbc42396080",
+                    "Name": "UI_CHALLENGES_MAGPIE_STORYWINDS_NAME",
+                    "ImageName": "images/challenges/Northsea/Story_Winds_Magpie.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_STORYWINDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "WindsOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "74cbb469-137e-4c49-89c0-8a3f56d66075",
+                    "Name": "UI_CHALLENGES_MAGPIE_POISON_SOPHIA_BARFOOD_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_poison_serena_barfood.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_POISON_SOPHIA_BARFOOD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_SerenaPoisonedAtBar"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "79fb8277-28aa-463c-9a26-0201320121d8",
+                    "Name": "UI_CHALLENGES_MAGPIE_POISON_SOPHIA_TOAST_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_poison_sophia_toast.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_POISON_SOPHIA_TOAST_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_SophiaPoisoned_Toast"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "7c86b7cb-6a57-469b-85a0-fdb67b8ac141",
+                    "Name": "UI_CHALLENGES_NORTHSEA_LIGHT_BRAZIER_TORCH_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_lightbraziertorch.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_LIGHT_BRAZIER_TORCH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_LightBrazier_Torch"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "8a004af3-dd1c-444c-86e2-72c8ce8b5f9d",
+                    "Name": "UI_CHALLENGES_MAGPIE_EXP_DESTROY_HYDRAULICS_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_destroy_hydraulics.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_EXP_DESTROY_HYDRAULICS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "c_discovery_effigy"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "a0c11926-9274-4974-ab75-1925e7b5a7e4",
+                    "Name": "UI_CHALLENGES_MAGPIE_INITIATION_PASS_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_pass_initiation.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_INITIATION_PASS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Initiation_Pass"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "a7e6f01b-9f52-4015-979e-242681135efe",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_AS_MUSICIAN_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_musician_kill.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_AS_MUSICIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Musician_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "b829dd63-87b9-46c9-9e3d-af7b052aa1fb",
+                    "Name": "UI_CHALLENGES_MAGPIE_MUSEUM_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/theisland/theisland_opp_necklace.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_MUSEUM_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "5df965c0-ac44-4c15-8aeb-cc3bef6a8cf7"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "ba16530d-f03c-4c2d-877a-26075cabdc9c",
+                    "Name": "UI_CHALLENGES_NORTHSEA_SWITCHEROO_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_switcheroo.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_SWITCHEROO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Project_Jam"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "bd69bc95-10ac-4b17-9162-ee3a8287e826",
+                    "Name": "UI_CHALLENGES_MAGPIE_PERFORM_SUCCESFUL_CEREMONY_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_effigy_ceremony_success.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_PERFORM_SUCCESFUL_CEREMONY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Effigy_Success"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "c0f8e8d7-e249-4fda-b46f-51758972ffdd",
+                    "Name": "UI_CHALLENGES_NORTHSEA_LEAVE_COFFIN_DURING_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_leave_coffin_during_wake.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_LEAVE_COFFIN_DURING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_LeaveCoffinDuring_Wake"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "c3e39bdd-eebf-49a3-b840-f5ee6a330336",
+                    "Name": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_CONSTANT_KILLSWITCH_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_constant_killswitch_kill.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_CONSTANT_KILLSWITCH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Constant_Killswitch"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "c7dbb586-1e49-4105-a744-fcf8c054faf9",
+                    "Name": "UI_CHALLENGES_MAGPIE_STORYENTRAPMENT_NAME",
+                    "ImageName": "images/challenges/Northsea/Story_Entrapment_Magpie.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_STORYENTRAPMENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "EntrapmentOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "d75e9d5f-ae0d-420b-9576-5782fe5af2a7",
+                    "Name": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_BOTH_AS_JANUS_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_kill_both_as_janus.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_47_ASSASINATION_BOTH_AS_JANUS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_TwinKill_Janus"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "e6afdbcb-9c7e-4e6f-afd6-e4744d586412",
+                    "Name": "UI_CHALLENGES_MAGPIE_ESCORT_CONSTANT_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_escort_constant.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_ESCORT_CONSTANT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_Constant_Escorted"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "ec3f3f2f-f6d8-4eb4-a4ac-8ccda8b76607",
+                    "Name": "UI_CHALLENGES_MAGPIE_IN_COFFIN_WITH_FISH_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_funeral_fish.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_IN_COFFIN_WITH_FISH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_In_Coffin_With_Fish"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "fd898a7b-6f07-4e29-a0c0-478547a43b0a",
+                    "Name": "UI_CHALLENGES_MAGPIE_STORYHONOURS_NAME",
+                    "ImageName": "images/challenges/Northsea/Story_honours_Magpie.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_STORYHONOURS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HonoursOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "ffe26e50-f541-4fa7-99ae-4edaf50c2b4a",
+                    "Name": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_HAMMERSICKLE_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_hammersickle_kill.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_47_ASSASINATION_HAMMERSICKLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "C_HammerSickle_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "d5e872bf-d5b2-4aa7-be73-a48be0393205",
+                    "Name": "UI_CONTRACT_HEATHER_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Magpie_Heather.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "6ada7787-9a8f-474a-aa96-af9407a02b6f"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["e63eeb62-29ef-428d-b003-ea043b1f11f9"]
+                    }
+                },
+                {
+                    "Id": "7ad55353-c473-4498-bdcc-a800898cfc27",
+                    "Name": "UI_CONTRACT_LOTUS_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Magpie_Lotus.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "778f0ff0-fd13-4c7d-b120-a6bf75421c63"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["b66f151d-47a7-4681-a403-c48a46916224"]
+                    }
+                },
+                {
+                    "Id": "fcf7b356-143b-41fc-817c-5356809f6f4c",
+                    "Name": "UI_CONTRACT_GALIUM_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Magpie_Galium.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "e04758d6-fb6c-4854-a0bf-753b80e93e96"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["dbb0e22d-084b-4b57-8616-42290982fd90"]
+                    }
+                },
+                {
+                    "Id": "8e3c0195-025a-4d6b-88e8-33e4817d6c68",
+                    "Name": "UI_CONTRACT_DAHLIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Dahlia.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "04fdd55f-2ac5-4f1f-aa8d-00a9b0c6dfc4"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["4fbfae2e-a5e7-4b79-b008-94f6cbcb13cb"]
+                    }
+                },
+                {
+                    "Id": "fe84be58-0798-4458-aa95-952207478029",
+                    "Name": "UI_CONTRACT_HOGWEED_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Magpie_Hogweed.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "2ab943ef-ba1b-48bf-9391-5b7725b4d4c7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["3721e543-b5e6-4af8-a4fc-c92e9a4453bd"]
+                    }
+                },
+                {
+                    "Id": "4bc18ea3-d740-4266-a120-898c1e827d87",
+                    "Name": "UI_CONTRACT_PANSY_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Magpie_Pansy.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "952dd0bc-29ec-4080-b179-c1c0db8c3dc6"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["8c6daf5e-5974-4438-af20-71ff570c7ff3"]
+                    }
+                },
+                {
+                    "Id": "2004e52a-c91a-4a6d-ab42-3d68584d17d1",
+                    "Name": "UI_CHALLENGES_NORTHSEA_KNIGHT_SHOVEL_PACIFY_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_knight_shovel_pacify.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_KNIGHT_SHOVEL_PACIFY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 10
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "type": "challengecounter",
+                                "text": "UI_CHALLENGES_NORTHSEA_KNIGHT_SHOVEL_PACIFY_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "1066917f-2e04-4c54-b8cb-55cb1dcc2f26"
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.OutfitRepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "fae73e92-2307-4163-8e9f-30401ca884bf"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"]
+                },
+                {
+                    "Id": "53b75a9c-43d0-464b-88a3-12a60f51bbc5",
+                    "Name": "UI_CHALLENGES_NORTHSEA_PACIFY_EGGS_6_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_pacify_eggs_6.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_PACIFY_EGGS_6_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 6
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "type": "challengecounter",
+                                "text": "UI_CHALLENGES_NORTHSEA_PACIFY_EGGS_6_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.KillItemRepositoryId",
+                                                "c88a59cd-d5cc-4435-a3f1-2312abcc817e"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"]
+                },
+                {
+                    "Id": "8467462c-9bc5-41fe-ab71-572603ac4f16",
+                    "Name": "UI_CHALLENGES_NORTHSEA_PORTCULLIS_KILL_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_exp_kill_3_portcullis.jpg",
+                    "Description": "UI_CHALLENGES_NORTHSEA_PORTCULLIS_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "type": "challengecounter",
+                                "text": "UI_CHALLENGES_NORTHSEA_PORTCULLIS_KILL_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.SetPieceType",
+                                                "d756bbae-26cf-4b8d-9792-86b37629403f"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "feats"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "98762d92-4607-492a-9eef-16bf6ee1fccd",
+                    "Name": "UI_CHALLENGES_MAGPIE_SERENA_CKILL_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_serena.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SERENA_CKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "KilledActors": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "67f39ab8-c25f-48c3-84be-0ec495a553ec"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "primary", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "c4862b6d-e101-4eb2-a4cb-896be9b5faac",
+                    "Name": "UI_CHALLENGES_MAGPIE_ZOE_CKILL_NAME",
+                    "ImageName": "images/challenges/northsea/magpie_c_zoe.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_ZOE_CKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "KilledActors": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "7eb39f2d-1030-44d2-be82-6df608085ec0"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "primary", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "29acb552-1c22-4995-bbb7-d29e827b26b2",
+                    "Name": "UI_CHALLENGES_MAGPIE_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "3e95d6f2-bc9c-46e7-981e-de9474f1124c",
+                    "Name": "UI_CHALLENGES_MAGPIE_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "e27f2f6e-aef1-4147-ba18-388af0e8da4b",
+                                "8d43608c-5706-4311-8f71-038e90574b34",
+                                "29acb552-1c22-4995-bbb7-d29e827b26b2",
+                                "e8c35c20-3f4d-4b24-8ad7-745a3c623f10"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "8d43608c-5706-4311-8f71-038e90574b34",
+                    "Name": "UI_CHALLENGES_MAGPIE_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "e27f2f6e-aef1-4147-ba18-388af0e8da4b",
+                    "Name": "UI_CHALLENGES_MAGPIE_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                },
+                {
+                    "Id": "e8c35c20-3f4d-4b24-8ad7-745a3c623f10",
+                    "Name": "UI_CHALLENGES_MAGPIE_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_MAGPIE_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0d225edf-40cd-4f20-a30f-b62a373801d3"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "c5f46486-8dda-4ff7-a7c9-4bc755ea81cf",
+                    "Name": "UI_BLUEBERRY_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Blueberry_Group.jpg",
+                    "Description": "UI_BLUEBERRY_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["07bc9bbf-7cba-4cdf-92bb-3ab57f09b1cc"]
+                    }
+                },
+                {
+                    "Id": "55af44d3-54f7-4bba-8bef-3dfaa75597c5",
+                    "Name": "UI_MANDARIN_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Mandarin_Group.jpg",
+                    "Description": "UI_MANDARIN_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["74278853-5990-4058-8972-1f10ad12b6d8"]
+                    }
+                },
+                {
+                    "Id": "8dfd78d7-8950-421c-98be-6e1e951201f7",
+                    "Name": "UI_AVOCADO_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Avocado_Group.jpg",
+                    "Description": "UI_AVOCADO_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["6de90688-ad4c-457e-ae25-c4bbc8f55196"]
+                    }
+                },
+                {
+                    "Id": "9f309b7a-1ec6-48f7-876b-2f3d06b39a83",
+                    "Name": "UI_CARAMBOLA_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Carambola_Group.jpg",
+                    "Description": "UI_CARAMBOLA_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["09a40d33-4820-454b-89af-a10e0b8d3e08"]
+                    }
+                },
+                {
+                    "Id": "d00653ca-d00d-4b30-bff9-3c03c358adc8",
+                    "Name": "UI_APPLE_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Apple_Group.jpg",
+                    "Description": "UI_APPLE_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NORTHSEA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHSEA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["b9f55fc3-c53f-4661-a4b6-9956303422aa"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/SNIPER/_AUSTRIA_CHALLENGES.json
+++ b/contractdata/SNIPER/_AUSTRIA_CHALLENGES.json
@@ -1,0 +1,3219 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_AUSTRIA"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "26b61596-8bad-44f7-b6ed-e36989c1d092",
+                    "Name": "UI_CHALLENGES_HAWK_LABYRINTH_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_labyrith.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_LABYRINTH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "6f9a2965-f69d-463e-899f-b10731d97e7f",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_LABYRINTH_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_LABYRINTH",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "4d2139d0-1b2f-4443-beed-ac8a2adb7db8"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Complete": 0,
+                            "Count": 0,
+                            "Goal": 2
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "a95228f3-14ac-4305-8993-24a7f73ec4b6"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "ac9302b6-6f8d-47f5-a148-6431e381e619"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "ac9302b6-6f8d-47f5-a148-6431e381e619"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Actions": {
+                                            "$set": ["Complete", 1]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "3aaff26e-711c-4e9f-ab6d-22b8b414e05a",
+                    "Name": "UI_CHALLENGES_HAWK_ELECTRIFIED_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_electified.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_ELECTRIFIED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "dd3278aa-eee9-44e7-a0c9-46d5bfc8bc22",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_ELECTRIFIED_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_ELECTRIFIED",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "9b72f822-c1c5-45ba-b34c-6a3e57e5e8a7"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "TargetGoal": 3,
+                            "DeadTargets": 0,
+                            "TooManyKilled": 16
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.TargetGoal",
+                                "text": "UI_CHALLENGES_HAWK_ELECTRIFIED_NAME",
+                                "icon": "some_icon"
+                            },
+                            "ForceUpdateCounters": {
+                                "type": "force-update",
+                                "target": "Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$inc": "DeadTargets"
+                                            }
+                                        ],
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "Electric"
+                                                            ]
+                                                        },
+                                                        "in": "$Value.DamageEvents"
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "TimerStart"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.DeadTargets",
+                                                "$.TooManyKilled"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "TimerStart": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 30
+                                    },
+                                    "Actions": {
+                                        "$set": ["Count", 0]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$inc": "DeadTargets"
+                                            }
+                                        ],
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "Electric"
+                                                            ]
+                                                        },
+                                                        "in": "$Value.DamageEvents"
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.DeadTargets",
+                                                "$.TooManyKilled"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "4f27adcf-4bd0-4ffe-bc90-123f088aa262",
+                    "Name": "UI_CHALLENGES_HAWK_WATER_DUMP_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_dump_five_targets.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_WATER_DUMP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "9bb8b263-75e2-4944-88b3-473f4a620c99",
+                                "Multiplier": 0.08
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_WATER_DUMP_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_WATER_DUMP",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "1478ffb1-843d-4150-b5f9-4f8df6891fae"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "TargetsDumpedInWater": [],
+                            "Count": 0,
+                            "Goal": 5
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_WATER_DUMP_NAME",
+                                "icon": "some icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DumpInOcean": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetsDumpedInWater",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "2d241583-bce0-4822-822b-b2f7f155207c",
+                                                            "2e51798e-bbf2-4872-adc6-d40d847962e4",
+                                                            "4b4044da-5495-49b6-b624-97606e57ff3a",
+                                                            "7b108fd9-e385-4766-b428-8bef36e34cae",
+                                                            "b00f75a8-5ba8-4178-84ba-5458310eb780",
+                                                            "29cdbd3d-7879-4fea-b8fb-246f9800504e",
+                                                            "2c7cf854-9027-479e-a7a9-ad5b3142229f",
+                                                            "c3bfa937-56cd-468e-8b4e-dbbed662e0ca",
+                                                            "8b5dfea4-7278-4f1b-8e57-1cbcef0dc29b",
+                                                            "f2512414-e04f-46b3-96ec-bedb6e6aeb88",
+                                                            "dd0071eb-0a49-4759-86ae-92581fd9dce6",
+                                                            "47de9521-bd32-4306-a070-0418cd20cfcb",
+                                                            "d99e8574-63a0-43ca-8943-ac7dfdd5b815",
+                                                            "a245e588-c084-4464-89c8-acb0ae73e337",
+                                                            "c90f9a15-b42e-4b00-86de-fc8808159c99",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "5d522dc9-6097-4af3-a190-b354a840edd2",
+                    "Name": "UI_CHALLENGES_HAWK_BODYGUARDS_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_bodygards.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_BODYGUARDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "a5b36908-04b8-42b3-ae3e-615c0d8d9178",
+                                "Multiplier": 0.05
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_BODYGUARDS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_BODYGUARDS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "e8f4770b-ab74-4d4b-8418-7df82fec1773"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 15
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_BODYGUARDS_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "2d241583-bce0-4822-822b-b2f7f155207c",
+                                                            "2e51798e-bbf2-4872-adc6-d40d847962e4",
+                                                            "4b4044da-5495-49b6-b624-97606e57ff3a",
+                                                            "7b108fd9-e385-4766-b428-8bef36e34cae",
+                                                            "b00f75a8-5ba8-4178-84ba-5458310eb780",
+                                                            "29cdbd3d-7879-4fea-b8fb-246f9800504e",
+                                                            "2c7cf854-9027-479e-a7a9-ad5b3142229f",
+                                                            "c3bfa937-56cd-468e-8b4e-dbbed662e0ca",
+                                                            "8b5dfea4-7278-4f1b-8e57-1cbcef0dc29b",
+                                                            "f2512414-e04f-46b3-96ec-bedb6e6aeb88",
+                                                            "dd0071eb-0a49-4759-86ae-92581fd9dce6",
+                                                            "47de9521-bd32-4306-a070-0418cd20cfcb",
+                                                            "d99e8574-63a0-43ca-8943-ac7dfdd5b815",
+                                                            "a245e588-c084-4464-89c8-acb0ae73e337",
+                                                            "c90f9a15-b42e-4b00-86de-fc8808159c99"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "5f7e240d-bdde-4f34-9bae-1ce8ae2f9d9e",
+                    "Name": "UI_CHALLENGES_HAWK_BODYHIDER_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_bodyhider.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_BODYHIDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "ab3431a8-0b1f-46fa-9821-ca199f1b1ef4",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_BODYHIDER_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_BODYHIDER",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ca40cc60-cdfd-4119-83de-db9c6fe8f9b8"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 18
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_BODYHIDER_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyHidden": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87",
+                                                            "a245e588-c084-4464-89c8-acb0ae73e337",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf",
+                                                            "d99e8574-63a0-43ca-8943-ac7dfdd5b815",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6",
+                                                            "c90f9a15-b42e-4b00-86de-fc8808159c99",
+                                                            "f2512414-e04f-46b3-96ec-bedb6e6aeb88",
+                                                            "dd0071eb-0a49-4759-86ae-92581fd9dce6",
+                                                            "8b5dfea4-7278-4f1b-8e57-1cbcef0dc29b",
+                                                            "c3bfa937-56cd-468e-8b4e-dbbed662e0ca",
+                                                            "2c7cf854-9027-479e-a7a9-ad5b3142229f",
+                                                            "29cdbd3d-7879-4fea-b8fb-246f9800504e",
+                                                            "b00f75a8-5ba8-4178-84ba-5458310eb780",
+                                                            "7b108fd9-e385-4766-b428-8bef36e34cae",
+                                                            "4b4044da-5495-49b6-b624-97606e57ff3a",
+                                                            "2e51798e-bbf2-4872-adc6-d40d847962e4",
+                                                            "2d241583-bce0-4822-822b-b2f7f155207c",
+                                                            "47de9521-bd32-4306-a070-0418cd20cfcb",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "9eb5dcbe-66fc-4bb5-9697-afccaed09d97",
+                    "Name": "UI_CHALLENGES_HAWK_NO_LOOSE_ENDS_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_no_loose_ends.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_NO_LOOSE_ENDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "f802479b-e9ed-4e17-8983-30f154126072",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_NO_LOOSE_ENDS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_NO_LOOSE_ENDS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ddc6625d-99cc-4f46-8385-6c710ebdcbab"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 15
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_NO_LOOSE_ENDS_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "2d241583-bce0-4822-822b-b2f7f155207c",
+                                                            "2e51798e-bbf2-4872-adc6-d40d847962e4",
+                                                            "4b4044da-5495-49b6-b624-97606e57ff3a",
+                                                            "7b108fd9-e385-4766-b428-8bef36e34cae",
+                                                            "b00f75a8-5ba8-4178-84ba-5458310eb780",
+                                                            "29cdbd3d-7879-4fea-b8fb-246f9800504e",
+                                                            "2c7cf854-9027-479e-a7a9-ad5b3142229f",
+                                                            "c3bfa937-56cd-468e-8b4e-dbbed662e0ca",
+                                                            "8b5dfea4-7278-4f1b-8e57-1cbcef0dc29b",
+                                                            "f2512414-e04f-46b3-96ec-bedb6e6aeb88",
+                                                            "dd0071eb-0a49-4759-86ae-92581fd9dce6",
+                                                            "47de9521-bd32-4306-a070-0418cd20cfcb",
+                                                            "d99e8574-63a0-43ca-8943-ac7dfdd5b815",
+                                                            "a245e588-c084-4464-89c8-acb0ae73e337",
+                                                            "c90f9a15-b42e-4b00-86de-fc8808159c99"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "CombatStarted": {
+                                    "Transition": "InCombat"
+                                }
+                            },
+                            "InCombat": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "2d241583-bce0-4822-822b-b2f7f155207c",
+                                                            "2e51798e-bbf2-4872-adc6-d40d847962e4",
+                                                            "4b4044da-5495-49b6-b624-97606e57ff3a",
+                                                            "7b108fd9-e385-4766-b428-8bef36e34cae",
+                                                            "b00f75a8-5ba8-4178-84ba-5458310eb780",
+                                                            "29cdbd3d-7879-4fea-b8fb-246f9800504e",
+                                                            "2c7cf854-9027-479e-a7a9-ad5b3142229f",
+                                                            "c3bfa937-56cd-468e-8b4e-dbbed662e0ca",
+                                                            "8b5dfea4-7278-4f1b-8e57-1cbcef0dc29b",
+                                                            "f2512414-e04f-46b3-96ec-bedb6e6aeb88",
+                                                            "dd0071eb-0a49-4759-86ae-92581fd9dce6",
+                                                            "47de9521-bd32-4306-a070-0418cd20cfcb",
+                                                            "d99e8574-63a0-43ca-8943-ac7dfdd5b815",
+                                                            "a245e588-c084-4464-89c8-acb0ae73e337",
+                                                            "c90f9a15-b42e-4b00-86de-fc8808159c99"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "a412d186-3d2a-46b1-bc16-6973ac52e1b2",
+                    "Name": "UI_CHALLENGES_HAWK_KILLER_SHOT_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_photoshoot.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_KILLER_SHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "36dc596d-d69c-4367-abeb-703b0b8182d9",
+                                "Multiplier": 0.09
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_KILLER_SHOT_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_KILLER_SHOT",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "4466f2e9-4bc2-4a5e-9935-6ea997ef2544"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "25bf69be-5ee3-4a5c-b413-9665b7e673df"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "25bf69be-5ee3-4a5c-b413-9665b7e673df"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "25bf69be-5ee3-4a5c-b413-9665b7e673df"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "25bf69be-5ee3-4a5c-b413-9665b7e673df"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "b6d092b4-add8-4653-9dab-04e9050d68fa",
+                    "Name": "UI_CHALLENGES_HAWK_ALL_HEADSHOTS_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_all_headshots.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_ALL_HEADSHOTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "9f85be0e-ff1e-481a-bfa4-53ad952f5e34",
+                                "Multiplier": 0.12
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_ALL_HEADSHOTS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_ALL_HEADSHOTS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "4fe82175-758d-4a6d-b4ee-e6a334f8d77d"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 18
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_ALL_HEADSHOTS_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsHeadshot",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsHeadshot",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "c865cc6b-9644-4a1e-8ef0-520910576e11",
+                    "Name": "UI_CHALLENGES_HAWK_HEAVY_BURDEN_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_triple_death_from_above.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_HEAVY_BURDEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "20e56468-0095-4a4f-aa66-74b4ea57bf93",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_HEAVY_BURDEN_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_HEAVY_BURDEN",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "fd662553-90f1-49a7-bdc5-597289e32862"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_TripleKill"
+                                }
+                            },
+                            "Is_TripleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "SuspendedObject"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "cc61fdf8-a8c9-4fc8-87ac-8db82718b320",
+                    "Name": "UI_CHALLENGES_HAWK_TOUCH_AND_GO_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_touch_and_go.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_TOUCH_AND_GO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "2514a062-e9e9-4e9e-9c4e-734409a61893",
+                                "Multiplier": 0.08
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_TOUCH_AND_GO_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_TOUCH_AND_GO",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "8a6c9a78-cf53-451e-9eed-3664dbf48829"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 3
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_TOUCH_AND_GO_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TargetsEscaping": {
+                                    "Transition": "EliminateTargets"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "EliminateTargets": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "TargetEscaped": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "d096942e-37ec-4a68-af1c-74d8aec6ffc6",
+                    "Name": "UI_CHALLENGES_HAWK_GOT_A_LIGHT_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_triple_explosion.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_GOT_A_LIGHT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "b45fd9d7-6104-4ae8-a35b-0fb5622f8efd",
+                                "Multiplier": 0.14
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_BOOM_BOOM_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_BOOM_BOOM",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "32ad8d57-055b-49d8-873f-572689ad26a8"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_TripleKill"
+                                }
+                            },
+                            "Is_TripleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d81e6d6c-d10b-4ee3-b313-b4e296464e87"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b5a423f5-7f02-4ddc-8dc6-fdb64c1ebfcf"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "a95228f3-14ac-4305-8993-24a7f73ec4b6"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "accident_explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "dd4058f1-6bbc-4f40-a6a3-b2022add4978",
+                    "Name": "UI_CHALLENGES_HAWK_EXPLOSION_TIME_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_explosion_time.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_EXPLOSION_TIME_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "bed96689-f27f-4738-aa8c-87805f42deba",
+                                "Multiplier": 0.09
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_EXPLOSION_TIME_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_EXPLOSION_TIME",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "7bd500e3-94f2-4a45-aed2-6fc6de4f3da2"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "TargetGoal": 5,
+                            "DeadTargets": 0,
+                            "TooManyKilled": 14
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.TargetGoal",
+                                "text": "UI_CHALLENGES_HAWK_EXPLOSION_TIME_NAME",
+                                "icon": "some_icon"
+                            },
+                            "ForceUpdateCounters": {
+                                "type": "force-update",
+                                "target": "Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$inc": "DeadTargets"
+                                            }
+                                        ],
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillMethodStrict",
+                                                        "accident_explosion"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "TimerStart"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.DeadTargets",
+                                                "$.TooManyKilled"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "TimerStart": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 30
+                                    },
+                                    "Actions": {
+                                        "$set": ["Count", 0]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": [
+                                            {
+                                                "$inc": "Count"
+                                            },
+                                            {
+                                                "$inc": "DeadTargets"
+                                            }
+                                        ],
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillMethodStrict",
+                                                        "accident_explosion"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.DeadTargets",
+                                                "$.TooManyKilled"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "e104192c-88f3-465f-ad17-f2e705cd0546",
+                    "Name": "UI_CHALLENGES_HAWK_WALTZ_OF_DEATH_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_death_waltz.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_WALTZ_OF_DEATH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "2a91284c-001f-484a-99cd-f8a1d231d539",
+                                "Multiplier": 0.09
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_WALTZ_OF_DEATH_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_WALTZ_OF_DEATH",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "eda5834b-dbb6-48c4-80d7-4a2bf9a72257"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 7,
+                            "TargetsKilled": 0,
+                            "TooManyKilled": 12
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_WALTZ_OF_DEATH_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CoupleDancing": {
+                                    "Transition": "CoupleIsDancing"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "TargetsKilled"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.TargetsKilled",
+                                                "$.TooManyKilled"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "CoupleIsDancing": {
+                                "CombatStarted": {
+                                    "Transition": "Failure"
+                                },
+                                "DancingPaused": {
+                                    "Transition": "WaitForDancingResumed"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "9d97662a-cbd8-435c-8c8c-c5652f3cb8f2",
+                                                            "0074795b-8de4-4a29-8754-218266e25e44"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "CoupleDoneDancing": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "WaitForDancingResumed": {
+                                "DancingResumed": {
+                                    "Transition": "CoupleIsDancing"
+                                },
+                                "DancingOver": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "0e12e4fd-6666-4871-91b8-1340af438e03",
+                    "Name": "UI_CHALLENGES_HAWK_AGNOMALY_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_shoot_allgnomes.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_AGNOMALY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "c4ce6750-2925-4e6a-80f6-23866b265b95",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_AGNOMALY_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_AGNOMALY",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "425b85e1-841f-47d7-b079-513bc40789c1"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 6
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_AGNOMALY_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GnomeShot": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "13cd05da-1fad-4c9d-b6b8-7c2004384fa3",
+                    "Name": "UI_CHALLENGES_HAWK_BLACKOUT_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_lights_out.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_BLACKOUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "94471830-e77b-4625-8ebb-27fb4adbc2a3",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_BLACKOUT_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_BLACKOUT",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "fe534e48-f0ad-4e5d-a270-7d17e8708764"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_BLACKOUT_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 18
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "LightsOff": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "269235f8-8ab1-40c0-96cc-df94ed93bc8f",
+                    "Name": "UI_CHALLENGES_HAWK_47_VASES_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_47_vases.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_47_VASES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "b8f7c10f-458f-48ec-9024-05a1e2307016",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_47_VASES_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_47_VASES",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c5f255e8-87b7-4953-88f3-fa5c19a513fa"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 47
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_47_VASES_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "VaseShot": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "26a2739b-4d68-4c49-98f1-1ecbe9fcd323",
+                    "Name": "UI_CHALLENGES_HAWK_BONFIRE_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_bonfire.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_BONFIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "eadf9087-654d-4efb-8765-66ee0d710e72",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_BONFIRE_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_BONFIRE",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "82009ff6-1cb3-4dde-89b7-624942c2a428"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Complete": {
+                                "type": "challengecounter",
+                                "count": "$.Complete",
+                                "total": 1,
+                                "text": "PLACEHOLDER",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Bonfire_Activated": {
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "329e9fab-35f2-4265-a99a-f44a6e79f257",
+                    "Name": "UI_CHALLENGES_HAWK_SHOOT_BASE_JUMPER_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_shoot_basejumper.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_SHOOT_BASE_JUMPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "db081c92-11a5-44e6-a6bd-042b74297508",
+                                "Multiplier": 0.08
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_SHOOT_BASE_JUMPER_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_SHOOT_BASE_JUMPER",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c352274a-d780-41cd-ba2c-a4f258daeccc"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Complete": {
+                                "type": "challengecounter",
+                                "count": "$.Complete",
+                                "total": 1,
+                                "text": "PLACEHOLDER",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Base_Jumper_Jumped": {
+                                    "Transition": "InAir"
+                                }
+                            },
+                            "InAir": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "8ef3a023-5ff3-4c77-8f2e-6002504adb02"
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "6eb9c3c8-94dd-4d0d-8b82-e7f29d0857e0",
+                    "Name": "UI_CHALLENGES_HAWK_HELP_HIKER_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_help_hiker.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_HELP_HIKER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "46115c7a-5b69-4b50-818b-2659130ac210",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_HELP_HIKER_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_HELP_HIKER",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "fba678fd-2dc2-4367-91d5-3e0d12374bd1"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Complete": {
+                                "type": "challengecounter",
+                                "count": "$.Complete",
+                                "total": 1,
+                                "text": "PLACEHOLDER",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HikerFree": {
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "ab2b8eac-67c2-46ef-a85e-e751d97ee925",
+                    "Name": "UI_CHALLENGES_HAWK_KILL_MICE_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_kill_mice.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_KILL_MICE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "c3da3304-2295-49be-8ebd-ddd0d9f186df",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_KILL_MICE_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_KILL_MICE",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "5e22d1e3-b6d3-4a2b-ac13-1d3a42b37970"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 2
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_KILL_MICE_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "MouseShot": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "c2dae7e5-ea16-40cd-b167-1be1619e8b00",
+                    "Name": "UI_CHALLENGES_HAWK_DESTROY_PAINTING_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_destroy_painting.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_DESTROY_PAINTING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "12687533-224f-4524-9ccf-7fb318470361",
+                                "Multiplier": 0.05
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_DESTROY_PAINTING_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_DESTROY_PAINTING",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c584e853-d4ee-4380-8acd-2469c9f77995"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Complete": {
+                                "type": "challengecounter",
+                                "count": "$.Complete",
+                                "total": 1,
+                                "text": "PLACEHOLDER",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PaintingShot": {
+                                    "Transition": "WaitPaintingFixed"
+                                }
+                            },
+                            "WaitPaintingFixed": {
+                                "PaintingFixed": {
+                                    "Transition": "DestroyPoster"
+                                }
+                            },
+                            "DestroyPoster": {
+                                "PosterShot": {
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "c46d278a-0323-43e0-96b0-73ae424057a2",
+                    "Name": "UI_CHALLENGES_HAWK_BRIDAL_BOUQUET_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_bridal_bouquet.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_BRIDAL_BOUQUET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "640741f7-5b0d-46bd-ade4-55760cf638e0",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_BOUQUET_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_BOUQUET",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "8c81d683-1a29-43cf-a5f4-8a5805bbbbd6"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Complete": {
+                                "type": "challengecounter",
+                                "count": "$.Complete",
+                                "total": 1,
+                                "text": "PLACEHOLDER",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Bouquet_Destroyed": {
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "c7fb5b50-5e70-400c-a023-21aa3590bb62",
+                    "Name": "UI_CHALLENGES_HAWK_FAITHLESS_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_no_priest.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_FAITHLESS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "d0ddb457-db2c-4fa2-a2e7-486f244ceaf4",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_FAITHLESS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_FAITHLESS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "93ebdd54-563c-446a-b177-924a7ba9929d"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Complete": {
+                                "type": "challengecounter",
+                                "count": "$.Complete",
+                                "total": 1,
+                                "text": "PLACEHOLDER",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Priest_Left": {
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "cd15acc3-ef6c-49b8-af63-59cbb25f72f5",
+                    "Name": "UI_CHALLENGES_HAWK_SHOOT_ALL_PIGEONS_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_shoot_allpigeons.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_SHOOT_ALL_PIGEONS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "b0fa05c2-ac80-4501-a0f0-610e06670e19",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_SHOOT_ALL_PIGEONS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_SHOOT_ALL_PIGEONS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "6bb2cbc1-e1ca-4995-9f9c-656442421d44"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 10
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_SHOOT_ALL_PIGEONS_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PigeonShot": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "d1c98e07-1d8c-460a-8dd4-ced22cd7adca",
+                    "Name": "UI_CHALLENGES_HAWK_RUBBER_DUCK_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_rubber_ducks.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_RUBBER_DUCK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "08731d00-2f22-4611-9e2d-bc1ad492fbf6",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_DUCKS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_DUCKS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "fe9f39b6-d99f-4877-a591-7d675e0ce04d"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 10
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_RUBBER_DUCK_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RubberDuckHit": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "e4db8fea-b84a-4dbd-9226-9ff15dbcaf1d",
+                    "Name": "UI_CHALLENGES_HAWK_SHOOT_RICE_BAG_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_shoot_ricebag.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_SHOOT_RICE_BAG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "7c8cfb29-11e3-49c7-9255-d601b45c2b66",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_SHOOT_RICE_BAG_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_SHOOT_RICE_BAG",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "60971e47-924d-4c7e-9406-6fd45651e146"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "ContextListeners": {
+                            "Complete": {
+                                "type": "challengecounter",
+                                "count": "$.Complete",
+                                "total": 1,
+                                "text": "PLACEHOLDER",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Context": {
+                            "Complete": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RiceBag_Shot": {
+                                    "Actions": {
+                                        "$set": ["Complete", 1]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                },
+                {
+                    "Id": "f9938bbc-401f-4f89-891c-14fb6848f5d2",
+                    "Name": "UI_CHALLENGES_HAWK_KILL_ALL_HAWKS_NAME",
+                    "ImageName": "images/challenges/hawk/hawk_kill_hawks.jpg",
+                    "Description": "UI_CHALLENGES_HAWK_KILL_ALL_HAWKS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "c12064d1-18d0-45e4-917a-2d459eaa0eca",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_HAWK_KILL_ALL_HAWKS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_HAWK_KILL_ALL_HAWKS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c1e20101-2de8-4ce7-8500-53349f872978"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_AUSTRIA",
+                    "ParentLocationId": "LOCATION_PARENT_AUSTRIA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "Goal": 3
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_HAWK_KILL_ALL_HAWKS_NAME",
+                                "icon": "some_icon"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HawkShot": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["ff9f46cf-00bd-4c12-b887-eac491c3a96d"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/SNIPER/_CAGED_CHALLENGES.json
+++ b/contractdata/SNIPER/_CAGED_CHALLENGES.json
@@ -1,0 +1,2232 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_CAGED"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "02da8256-9c11-4c49-bb5b-a68019f90441",
+                    "Name": "UI_CHALLENGES_FALCON_ALL_HEADSHOTS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_all_headshots.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_ALL_HEADSHOTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "eea56136-c1e3-4245-8006-9209ea5c0787",
+                                "Multiplier": 0.12
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_ALL_HEADSHOTS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_ALL_HEADSHOTS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "afd6fa0a-6556-4c43-978e-5111b8f7b598"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 17
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsHeadshot",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsHeadshot",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "12b960c7-43cd-4451-a98a-c9efc6505476",
+                    "Name": "UI_CHALLENGES_FALCON_ONLY_ACCIDENTS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_only_accidents.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_ONLY_ACCIDENTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "62c52761-bd28-4af3-b620-8e4b031db495",
+                                "Multiplier": 0.13
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_ONLY_ACCIDENTS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_ONLY_ACCIDENTS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "2a59a2d3-e3f7-486f-a084-94800226840e"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "Goal": 17
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        4
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "1f420eab-496c-48e8-9e67-a38a785b920e",
+                    "Name": "UI_CHALLENGES_FALCON_EXTINGUISER_KILL_NAME",
+                    "ImageName": "images/challenges/caged/falcon_extinguiser_kill.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_EXTINGUISER_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "cab3db8d-2a47-45a5-b4e2-f0fb3843c8df",
+                                "Multiplier": 0.13
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_EXTINGUISER_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_EXTINGUISER_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "b7d48051-26c7-4f3d-9e6d-14d9302725cd"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "d1fcedd5-b0bc-4d91-bf7f-97ff6392d2c9"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "3f701f37-d1ae-4c61-97e6-717d179cbcf5",
+                    "Name": "UI_CHALLENGES_FALCON_STAR_KILL_NAME",
+                    "ImageName": "images/challenges/caged/falcon_star_kill.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_STAR_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "27a0c7a3-6916-478a-ac9d-40dec67fb749",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_STAR_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_STAR_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "a4e98f6e-6778-41e4-8d65-59bfb67cc645"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "SetPiece": "447811c4-b843-4d54-9c69-7fac169e1407"
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "4688b423-2993-4826-8f7a-bfab58d7346b",
+                    "Name": "UI_CHALLENGES_FALCON_ELECTRIFIED_NAME",
+                    "ImageName": "images/challenges/caged/falcon_electrified.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_ELECTRIFIED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "8100fe5d-745a-446d-9cf6-2c83cfe05d46",
+                                "Multiplier": 0.09
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_ELECTRIFIED_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_ELECTRIFIED",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "d980be40-dbdc-4d1c-9ce7-1a4e1147179d"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "accident_electric"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "$Value.KillMethodBroad",
+                                                            "$Value.KillMethodStrict"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "4b5903bc-e4b3-4f7f-a634-9d401e6ed7d9",
+                    "Name": "UI_CHALLENGES_FALCON_BURN_DOUBLE_KILL_NAME",
+                    "ImageName": "images/challenges/caged/falcon_burn_double_kill.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_BURN_DOUBLE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "fe2e2330-8f31-48f0-941e-c8c45eae0d22",
+                                "Multiplier": 0.12
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_BURN_DOUBLE_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_BURN_DOUBLE_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "68c700d9-de18-42ee-82b1-4744925b9be5"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BurnDoubleKill_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "53d8235a-3b2f-470b-b321-493f16a74e34",
+                    "Name": "UI_CHALLENGES_FALCON_STAR_DOUBLE_KILL_NAME",
+                    "ImageName": "images/challenges/caged/falcon_star_double_kill.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_STAR_DOUBLE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "3a88655a-aa02-46b9-97bf-4f095cff6f07",
+                                "Multiplier": 0.12
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_STAR_DOUBLE_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_STAR_DOUBLE_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "93c44274-9b35-4623-bd63-e22c821f773b"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "SetPiece": "447811c4-b843-4d54-9c69-7fac169e1407",
+                            "Targets": [
+                                "d1fcedd5-b0bc-4d91-bf7f-97ff6392d2c9",
+                                "ff2d44f1-133b-466a-bb63-cdc5ed21d440"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.5
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Targets"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "$.SetPiece"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "62dedca5-41ac-4263-93a6-1af54eb8c2f5",
+                    "Name": "UI_CHALLENGES_FALCON_GRENADE_KILL_NAME",
+                    "ImageName": "images/challenges/caged/falcon_grenade_kill.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_GRENADE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "1317d707-eae1-49e8-b975-4a04814e5f28",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_GRENADE_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_GRENADE_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "987ce5f8-ac6d-4b2e-82cf-fe83af6b97fc"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "States": {
+                            "Start": {
+                                "FireExtinguisher_Exploded_Carried_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "65d63e43-b231-45d3-84ab-ad2a8a9dd897",
+                    "Name": "UI_CHALLENGES_FALCON_NO_LOOSE_ENDS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_no_loose_ends.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_NO_LOOSE_ENDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "42c774e9-7099-4c25-a760-cb7f68965cfb",
+                                "Multiplier": 0.12
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_NO_LOOSE_ENDS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_NO_LOOSE_ENDS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "440d3687-0fc1-45f9-aa7b-a96ac1074636"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Targets": [
+                                "52210fdd-4e64-4bd9-a50e-3ca3e6d4feaa",
+                                "5ad4f481-43b1-4cdd-852b-e23e44456d65",
+                                "5eca3cc3-5c5c-4d94-9add-d01439381a7c",
+                                "bf7d1e19-89e4-425c-9391-e0b21b9a8719",
+                                "d86ff8bb-283d-479b-a9a5-ce9b9b05f504",
+                                "1ab92327-545e-4fa3-8a3d-a01857e6481e",
+                                "798635a3-95eb-42c3-a851-08aa8eee6e4c",
+                                "4f7e3731-9f55-4f8d-9537-9e99b651f0c3",
+                                "fdd864ec-edbf-48b9-b4ec-e53a73f7f211",
+                                "3c418097-2077-48dd-bad3-19ea2b17516b",
+                                "1a639843-940f-4777-8b8f-9d357d8751b9",
+                                "ee98f38a-a955-451b-9ef5-7d908acb2055",
+                                "7c2c2c44-1351-49f8-a31f-7e2ea268ea52",
+                                "e1694891-b8c0-484b-bf27-495bcaf54622",
+                                "d840b6ea-2b73-460d-bd91-5138d5e0fffa"
+                            ]
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "($.Targets).Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": [
+                                                    "$.#",
+                                                    "$Value.RepositoryId"
+                                                ]
+                                            },
+                                            "in": "$.Targets"
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "CombatStarted": {
+                                    "Transition": "InCombat"
+                                }
+                            },
+                            "InCombat": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.Targets"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.Count",
+                                                "($.Targets).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "6920d1f8-ef9c-464d-8c74-d3c85881d47e",
+                    "Name": "UI_CHALLENGES_FALCON_BODYHIDER_BODYGUARDS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_bodyhider_bodyguards.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_BODYHIDER_BODYGUARDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "51f2aeb6-9f2f-4586-992f-4bfa26fa1a3d",
+                                "Multiplier": 0.09
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_BODYHIDER_BODYGUARDS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_BODYHIDER_BODYGUARDS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3fc09c48-2ffd-43fb-bab5-a58d8a9dcc5c"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Targets": [
+                                "52210fdd-4e64-4bd9-a50e-3ca3e6d4feaa",
+                                "5ad4f481-43b1-4cdd-852b-e23e44456d65",
+                                "5eca3cc3-5c5c-4d94-9add-d01439381a7c",
+                                "bf7d1e19-89e4-425c-9391-e0b21b9a8719",
+                                "d86ff8bb-283d-479b-a9a5-ce9b9b05f504",
+                                "1ab92327-545e-4fa3-8a3d-a01857e6481e",
+                                "798635a3-95eb-42c3-a851-08aa8eee6e4c",
+                                "4f7e3731-9f55-4f8d-9537-9e99b651f0c3",
+                                "fdd864ec-edbf-48b9-b4ec-e53a73f7f211",
+                                "3c418097-2077-48dd-bad3-19ea2b17516b",
+                                "1a639843-940f-4777-8b8f-9d357d8751b9",
+                                "ee98f38a-a955-451b-9ef5-7d908acb2055",
+                                "7c2c2c44-1351-49f8-a31f-7e2ea268ea52",
+                                "e1694891-b8c0-484b-bf27-495bcaf54622",
+                                "d840b6ea-2b73-460d-bd91-5138d5e0fffa"
+                            ]
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "($.Targets).Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TargetKilledByNotHitman_Event": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyHidden": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.Targets"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.Count",
+                                                "($.Targets).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "7b8bb544-e60a-4015-9cf1-b9c3f0e21f22",
+                    "Name": "UI_CHALLENGES_FALCON_ICICLE_KILL_NAME",
+                    "ImageName": "images/challenges/caged/falcon_icicle_kill.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_ICICLE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "adfea7d4-75ab-4e4a-8501-674b40d05366",
+                                "Multiplier": 0.05
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_ICICLE_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_ICICLE_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "106aa805-56ee-4bd8-83e7-3612e1fc9108"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "Icicles": [
+                                "b340e071-fe32-4b23-8fe7-6f5451e26e46",
+                                "d53b3758-7336-47a8-8692-d8c8334fa7c9",
+                                "39ba9dbe-2068-4f51-840b-0301e961a3f8",
+                                "36f6624e-41ee-4dea-bd06-6de7d6f65cde",
+                                "b54c8492-1c27-4fdd-a0d4-0106e6ebad04",
+                                "b3a340c5-c15d-4254-bf01-3a3610aca314",
+                                "d468933a-53fc-4839-8fa3-526dc35e97f9"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Icicles"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "d7eeed38-3437-4d59-9bb2-f30776750e25",
+                    "Name": "UI_CHALLENGES_FALCON_BODYHIDER_TARGETS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_bodyhider_targets.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_BODYHIDER_TARGETS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "6c812634-edb0-4eba-b8f9-457d362e5294",
+                                "Multiplier": 0.09
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_BODYHIDER_TARGETS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_BODYHIDER_TARGETS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "f708aa52-3ff1-46c5-b972-458120f83a72"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Targets": [
+                                "d1fcedd5-b0bc-4d91-bf7f-97ff6392d2c9",
+                                "ff2d44f1-133b-466a-bb63-cdc5ed21d440"
+                            ]
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "($.Targets).Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyHidden": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.Targets"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.Count",
+                                                "($.Targets).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "fcc059d7-60e6-42cb-95e9-6e7ccce10778",
+                    "Name": "UI_CHALLENGES_FALCON_SAVE_SCHEVCHENKO_NAME",
+                    "ImageName": "images/challenges/caged/falcon_save_schevchenko.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_SAVE_SCHEVCHENKO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "79b0434b-4b6e-47eb-aa12-3d15d58e626a",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_SAVE_SCHEVCHENKO_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_SAVE_SCHEVCHENKO",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "bdb33e41-c85d-4957-ab87-a03dae60a126"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SaveSchevchenko_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "235dbd3c-dd84-47d9-8678-f727624a2701",
+                    "Name": "UI_CHALLENGES_FALCON_SHOOT_BOTTLES_NAME",
+                    "ImageName": "images/challenges/caged/falcon_shoot_bottles.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_SHOOT_BOTTLES_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "04ad82b5-7367-4d91-9162-1dd812abd892",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_SHOOT_BOTTLES_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_SHOOT_BOTTLES",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "363641f9-6668-4faf-82bf-e54a8666347a"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShootBottles_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "4a8f39f6-add2-476c-ac33-00180fa2a734",
+                    "Name": "UI_CHALLENGES_FALCON_RUBBER_DUCK_NAME",
+                    "ImageName": "images/challenges/caged/falcon_rubber_ducks.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_RUBBER_DUCK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "be71963e-780e-4a46-9505-c5048a26f7fa",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_RUBBER_DUCK_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_RUBBER_DUCK",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c194adca-d713-4367-9c54-f93f352aad02"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 10
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShootDuck_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "6b329562-542d-4af5-8400-c8392c81787a",
+                    "Name": "UI_CHALLENGES_FALCON_POISON_DELIVERY_NAME",
+                    "ImageName": "images/challenges/caged/falcon_poison_delivery.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_POISON_DELIVERY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "9d744b72-43a3-47ea-854c-ff726ab4e25e",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_POISON_DELIVERY_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_POISON_DELIVERY",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "47bcf872-cb14-4c40-a6c0-ea5ccf4101e1"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "States": {
+                            "Start": {
+                                "PoisonDelivery_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "6c34f63e-0e11-4bfd-931e-07fcafdcece7",
+                    "Name": "UI_CHALLENGES_FALCON_RATS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_rats.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_RATS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "513a37ab-7e2a-4927-aea7-ed6d36ce950b",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_RATS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_RATS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "37d7ffdd-d7cd-4920-97a5-3828af8df2cc"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 6
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RatHit_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "6c475f1d-89a7-453d-9b35-56f11e08707a",
+                    "Name": "UI_CHALLENGES_FALCON_DROP_NPC_INTO_RIOT_NAME",
+                    "ImageName": "images/challenges/caged/falcon_drop_npc_into_riot.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_DROP_NPC_INTO_RIOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "522739b8-0ead-4492-a39d-e1bc50e34234",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_DROP_NPC_INTO_RIOT_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_DROP_NPC_INTO_RIOT",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "91e83fc0-4dc6-4da1-a922-7456c4b4559f"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TargetHiddenRiot_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "7da92a70-6d65-4137-9088-5fe350d391d7",
+                    "Name": "UI_CHALLENGES_FALCON_SNOW_DUMP_NAME",
+                    "ImageName": "images/challenges/caged/falcon_snow_dump.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_SNOW_DUMP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "c8c4f65f-4566-4840-8e3f-649fff1b0322",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_SNOW_DUMP_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_SNOW_DUMP",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "83d8dd42-503e-436e-ae25-66a1bf798de1"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Snowpile": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "88d77378-cf0b-4fa6-9538-4c3eaa01388c",
+                    "Name": "UI_CHALLENGES_FALCON_HIDE_BODIES_TOILET_NAME",
+                    "ImageName": "images/challenges/caged/falcon_hide_bodies_toilet.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_HIDE_BODIES_TOILET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "aa92d626-5143-4ee7-8b2b-50533a4776a1",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_HIDE_BODIES_TOILET_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_HIDE_BODIES_TOILET",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "edaaeca6-8d97-4c1a-a983-9da67b98bc50"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Toilet": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "9550af87-6c1b-4b57-bf00-99349d943ccc",
+                    "Name": "UI_CHALLENGES_FALCON_GREAT_ESCAPE_NAME",
+                    "ImageName": "images/challenges/caged/falcon_great_escape.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_GREAT_ESCAPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "3aadb9db-9344-4910-95ed-b68c48723cc7",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_GREAT_ESCAPE_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_GREAT_ESCAPE",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "e44fc13c-c083-4960-9b0f-585c7af2d3c8"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "GreatEscape_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "9f1627fe-1a5a-4e6a-a447-3dbae928a710",
+                    "Name": "UI_CHALLENGES_FALCON_FULL_ON_RIOT_NAME",
+                    "ImageName": "images/challenges/caged/falcon_full_on_riot.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_FULL_ON_RIOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "656a9844-b12f-4a99-b12f-721b35ad9b85",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_FULL_ON_RIOT_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_FULL_ON_RIOT",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "1fb9351b-e8fc-426a-8f77-be2e75ec30c0"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "FullOnRiot_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "a2ca6280-f59f-4958-a8b2-818cb24107c1",
+                    "Name": "UI_CHALLENGES_FALCON_START_FIRE_NAME",
+                    "ImageName": "images/challenges/caged/falcon_start_fire.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_START_FIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "8da824f0-27f7-4674-b624-e7066b6bdee0",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_START_FIRE_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_START_FIRE",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "f675ad01-bbfc-4103-b8e8-20f9e0005ee4"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "StartFire_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "bc31ce93-8d2f-4dc3-ba25-0112c2881fd5",
+                    "Name": "UI_CHALLENGES_FALCON_SHOOT_PANTS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_shoot_pants.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_SHOOT_PANTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "7fc9cedb-e50d-4e0b-ba90-0575bc0f415c",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_SHOOT_PANTS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_SHOOT_PANTS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "b028ded2-06ce-4e59-ae71-2df041728648"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShootPants_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "e2eec03c-a831-4670-8156-e66486e39dbe",
+                    "Name": "UI_CHALLENGES_FALCON_SHOOT_FLAG_NAME",
+                    "ImageName": "images/challenges/caged/falcon_shoot_flag.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_SHOOT_FLAG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "97974412-3e89-49a3-b26b-249597b94e38",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_SHOOT_FLAG_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_SHOOT_FLAG",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "77819a08-0821-45a0-9fc1-649fcc1b2256"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShootFlag_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "f7656ff1-56ac-4354-8320-bdceac711e5e",
+                    "Name": "UI_CHALLENGES_FALCON_SHOOT_PIGEONS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_shoot_pigeons.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_SHOOT_PIGEONS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "6d6280f7-529a-4de3-b18c-72c813c4654a",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_SHOOT_PIGEONS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_SHOOT_PIGEONS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "0d2fc6f8-b20e-40c0-bb64-696df9e5fcfd"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 8
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ShootCrow_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                },
+                {
+                    "Id": "fb1db9af-df85-4b0d-b9ac-9a58d3c71095",
+                    "Name": "UI_CHALLENGES_FALCON_SHOOT_LAMPS_NAME",
+                    "ImageName": "images/challenges/caged/falcon_shoot_lamps.jpg",
+                    "Description": "UI_CHALLENGES_FALCON_SHOOT_LAMPS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "91696571-ffdb-4273-9608-c96aa26bd319",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_FALCON_SHOOT_LAMPS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_FALCON_SHOOT_LAMPS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "5c68c27d-a13d-4bc8-a51b-9451c3e57634"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_CAGED",
+                    "ParentLocationId": "LOCATION_PARENT_CAGED",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 10,
+                            "SetPiece": "2d7a91b9-1b3a-4db3-a8bf-6249db70c339"
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "$.SetPiece"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["25b20d86-bb5a-4ebd-b6bb-81ed2779c180"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/SNIPER/_SALTY_CHALLENGES.json
+++ b/contractdata/SNIPER/_SALTY_CHALLENGES.json
@@ -1,0 +1,2479 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_SALTY"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "2fa4d785-af92-494c-8a9f-7475f04c0f7f",
+                    "Name": "UI_CHALLENGES_SEAGULL_BARRIER_KILL_NAME",
+                    "ImageName": "images/challenges/salty/seagull_barrier_kill.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_BARRIER_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "65065587-ff8f-4a9b-bda4-2be8817fd157",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_BARRIER_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_BARRIER_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "83b7488e-ee38-41cd-afc9-b5153a1d0496"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "22283ca4-89cf-4235-be1d-4f76cd1bd321"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "0de9e3ce-b466-459a-9006-066a453304aa"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "373929a9-bec4-405b-bad0-9bf6c175dcaf",
+                    "Name": "UI_CHALLENGES_SEAGULL_CANNON_KILL_NAME",
+                    "ImageName": "images/challenges/salty/seagull_cannon_kill.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_CANNON_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "5dc08f96-48f5-417d-b6e0-96efa1b43247",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_CANNON_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_CANNON_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "d1a8f3c0-a14d-4d0f-adfe-0a31ec68dee5"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "HiddenID": "00000000-0000-0000-000000000000"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "e75026c3-9629-4899-851a-d842f343cdb3"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "510d8eb0-69fe-4bb1-be10-faed574b038f"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Actions": {
+                                        "$set": [
+                                            "HiddenID",
+                                            "$Value.RepositoryId"
+                                        ]
+                                    },
+                                    "Transition": "IsHidden"
+                                }
+                            },
+                            "IsHidden": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 5
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "BodyHidden": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "$.HiddenID"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "3b857633-a6fd-45ce-a0cb-3fe4d2540863",
+                    "Name": "UI_CHALLENGES_SEAGULL_RAFT_KILL_NAME",
+                    "ImageName": "images/challenges/salty/seagull_raft_kill.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_RAFT_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "f215c15a-7c82-4b1a-a1aa-b1bb7c0f85ba",
+                                "Multiplier": 0.09
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_RAFT_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_RAFT_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ca04630c-6672-4181-bb0f-e204fa78d191"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "LifeRaftIDs": [
+                                "3d8c0d23-4203-445f-96ee-b6be23ad5e92",
+                                "22a8f5ee-ef76-461f-bb42-2b83af54c921",
+                                "00721b7b-d7e2-49e3-a169-350f2a95a707",
+                                "d5ec885d-9436-474c-a5cc-a012c9678724",
+                                "26869ece-112b-4d0f-98c4-343bd63ae5b0",
+                                "12587caa-4a53-4914-a358-6c2e0f8e2ad1"
+                            ],
+                            "MainTargetIDs": [
+                                "22283ca4-89cf-4235-be1d-4f76cd1bd321",
+                                "0a4e517a-e1e1-41d7-af91-751bc663df35",
+                                "55334e2d-45c6-41b3-920e-aeb5c5111b37"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.MainTargetIDs"
+                                                }
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceId"
+                                                        ]
+                                                    },
+                                                    "in": "$.LifeRaftIDs"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.2
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.MainTargetIDs"
+                                                }
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceId"
+                                                        ]
+                                                    },
+                                                    "in": "$.LifeRaftIDs"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "3d1aa487-67c9-4bce-8ba4-fb25f71cfa9f",
+                    "Name": "UI_CHALLENGES_SEAGULL_ALL_HEADSHOTS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_all_headshots.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_ALL_HEADSHOTS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "02d97e32-8d31-4127-9079-9cb15f795360",
+                                "Multiplier": 0.12
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_ALL_HEADSHOTS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_ALL_HEADSHOTS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "e86f5188-3715-4213-b705-59088174c151"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 18
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsHeadshot",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsHeadshot",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "47f790ad-ac31-490b-9fbc-056d10d1d648",
+                    "Name": "UI_CHALLENGES_SEAGULL_HEAVY_BURDEN_NAME",
+                    "ImageName": "images/challenges/salty/seagull_heavy_burden.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_HEAVY_BURDEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "29dcad81-1871-47a4-b2a2-f69d8bd03181",
+                                "Multiplier": 0.11
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_HEAVY_BURDEN_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_HEAVY_BURDEN",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "235673df-f8cf-422b-be35-1f2d40b728a8"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "MainTargetIDs": [
+                                "22283ca4-89cf-4235-be1d-4f76cd1bd321",
+                                "0a4e517a-e1e1-41d7-af91-751bc663df35",
+                                "55334e2d-45c6-41b3-920e-aeb5c5111b37"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.MainTargetIDs"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f8e813be-ec8f-4b5c-997e-1b73ac11efc0"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.MainTargetIDs"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f8e813be-ec8f-4b5c-997e-1b73ac11efc0"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_TripleKill"
+                                }
+                            },
+                            "Is_TripleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.MainTargetIDs"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f8e813be-ec8f-4b5c-997e-1b73ac11efc0"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "543b2a4c-20be-4157-a9a3-6b08d033026b",
+                    "Name": "UI_CHALLENGES_SEAGULL_ELECTRIFIED_NAME",
+                    "ImageName": "images/challenges/salty/seagull_electrified.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_ELECTRIFIED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "8d045d6a-9b6e-481f-acd5-cd34ff8a5141",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_ELECTRIFIED_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_ELECTRIFIED",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "47e64d65-fbd6-4c84-95bb-56566a697b38"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 3
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "accident_electric"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "$Value.KillMethodBroad",
+                                                            "$Value.KillMethodStrict"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "573596d0-fd57-47a7-91fd-1024474a8aa4",
+                    "Name": "UI_CHALLENGES_SEAGULL_GOT_A_LIGHT_NAME",
+                    "ImageName": "images/challenges/salty/seagull_got_a_light.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_GOT_A_LIGHT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "54023c65-1f37-4b66-b2f7-6286ea47525e",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_GOT_A_LIGHT_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_GOT_A_LIGHT",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "5d4ede2d-4603-4693-8047-5d4b75b01869"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.2
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_TripleKill"
+                                }
+                            },
+                            "Is_TripleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.2
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "83462fc1-7cbd-46c9-8897-506e6d27194b",
+                    "Name": "UI_CHALLENGES_SEAGULL_NO_LOOSE_ENDS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_no_loose_ends.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_NO_LOOSE_ENDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "902aa7bb-d060-4ab3-9c84-e59ca647ea56",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_NO_LOOSE_ENDS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_NO_LOOSE_ENDS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "4903ecf3-dabd-4c15-90ae-34b6f5c998e5"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "BodyguardIDs": [
+                                "5eca3cc3-5c5c-4d94-9add-d01439381a7c",
+                                "0861b91d-daa9-4ffa-8c5f-efeb5a95a321",
+                                "856ec4d9-c19b-4f95-9a8e-2a139b891017",
+                                "af4d2c4b-89bb-48a5-a299-8123a05c567d",
+                                "56ef218a-fd31-4bc4-8430-107230e17c8e",
+                                "9bb32759-bdfa-467c-a972-a54a73ea0e11",
+                                "391f9fce-4ad5-4c02-93dd-a147679bd75f",
+                                "49c90dbd-0400-43e8-871b-03bfb7e425c5",
+                                "c99657d8-3975-409c-9326-abc55fdb1abd",
+                                "b528b5e9-35ff-4642-93b7-421866eecf92",
+                                "03024491-d477-4d74-a31f-4c50cd3b82f6",
+                                "d26ae5c0-7491-4d75-8fb3-d54ca7c6a4bf",
+                                "b3489b30-d15d-407b-9de3-1036ddd103b9",
+                                "bdc392d1-a48d-4326-ac87-b1e9838eb5cd",
+                                "af0577a8-016e-4c55-b314-ad3771d59e6c"
+                            ]
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "($.BodyguardIDs).Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$any": {
+                                            "?": {
+                                                "$eq": [
+                                                    "$.#",
+                                                    "$Value.RepositoryId"
+                                                ]
+                                            },
+                                            "in": "$.BodyguardIDs"
+                                        }
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "CombatStarted": {
+                                    "Transition": "InCombat"
+                                }
+                            },
+                            "InCombat": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.BodyguardIDs"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.Count",
+                                                "($.BodyguardIDs).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "90b2972f-c5f1-4e78-b6ab-f414bdfbea5d",
+                    "Name": "UI_CHALLENGES_SEAGULL_WATER_DUMP_NAME",
+                    "ImageName": "images/challenges/salty/seagull_water_dump.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_WATER_DUMP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "4d858780-ed2b-4b7a-96fc-e21b4a57bbbc",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_WATER_DUMP_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_WATER_DUMP",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ef08793f-4983-496c-ae3c-e8f40e4e8b3a"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "TargetsDumpedInWater": [],
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "DumpInOcean": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetsDumpedInWater",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "22283ca4-89cf-4235-be1d-4f76cd1bd321",
+                                                            "0a4e517a-e1e1-41d7-af91-751bc663df35",
+                                                            "55334e2d-45c6-41b3-920e-aeb5c5111b37",
+                                                            "5eca3cc3-5c5c-4d94-9add-d01439381a7c",
+                                                            "0861b91d-daa9-4ffa-8c5f-efeb5a95a321",
+                                                            "856ec4d9-c19b-4f95-9a8e-2a139b891017",
+                                                            "af4d2c4b-89bb-48a5-a299-8123a05c567d",
+                                                            "56ef218a-fd31-4bc4-8430-107230e17c8e",
+                                                            "9bb32759-bdfa-467c-a972-a54a73ea0e11",
+                                                            "391f9fce-4ad5-4c02-93dd-a147679bd75f",
+                                                            "49c90dbd-0400-43e8-871b-03bfb7e425c5",
+                                                            "c99657d8-3975-409c-9326-abc55fdb1abd",
+                                                            "b528b5e9-35ff-4642-93b7-421866eecf92",
+                                                            "03024491-d477-4d74-a31f-4c50cd3b82f6",
+                                                            "d26ae5c0-7491-4d75-8fb3-d54ca7c6a4bf",
+                                                            "b3489b30-d15d-407b-9de3-1036ddd103b9",
+                                                            "bdc392d1-a48d-4326-ac87-b1e9838eb5cd",
+                                                            "af0577a8-016e-4c55-b314-ad3771d59e6c"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "c2ff5178-474c-4c49-9393-af0c2d407578",
+                    "Name": "UI_CHALLENGES_SEAGULL_BODYHIDER_BODYGUARDS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_bodyhider_bodyguards.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_BODYHIDER_BODYGUARDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "109acf63-b950-4b14-b674-85b3d8ac28bc",
+                                "Multiplier": 0.08
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_BODYHIDER_BODYGUARDS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_BODYHIDER_BODYGUARDS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3e5abb9d-ee9b-4b47-8137-c24b5f6973ba"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 15
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyguardEscaped": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyHidden": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": [
+                                                    "5eca3cc3-5c5c-4d94-9add-d01439381a7c",
+                                                    "0861b91d-daa9-4ffa-8c5f-efeb5a95a321",
+                                                    "856ec4d9-c19b-4f95-9a8e-2a139b891017",
+                                                    "af4d2c4b-89bb-48a5-a299-8123a05c567d",
+                                                    "56ef218a-fd31-4bc4-8430-107230e17c8e",
+                                                    "9bb32759-bdfa-467c-a972-a54a73ea0e11",
+                                                    "391f9fce-4ad5-4c02-93dd-a147679bd75f",
+                                                    "49c90dbd-0400-43e8-871b-03bfb7e425c5",
+                                                    "c99657d8-3975-409c-9326-abc55fdb1abd",
+                                                    "b528b5e9-35ff-4642-93b7-421866eecf92",
+                                                    "03024491-d477-4d74-a31f-4c50cd3b82f6",
+                                                    "d26ae5c0-7491-4d75-8fb3-d54ca7c6a4bf",
+                                                    "b3489b30-d15d-407b-9de3-1036ddd103b9",
+                                                    "bdc392d1-a48d-4326-ac87-b1e9838eb5cd",
+                                                    "af0577a8-016e-4c55-b314-ad3771d59e6c"
+                                                ]
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "d6a1e18a-e9a5-4246-8299-bffb5976e332",
+                    "Name": "UI_CHALLENGES_SEAGULL_TOUCH_AND_GO_NAME",
+                    "ImageName": "images/challenges/salty/seagull_touch_and_go.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_TOUCH_AND_GO_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "98532f55-deb7-4f04-9413-949d2dc2a8b5",
+                                "Multiplier": 0.08
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_TOUCH_AND_GO_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_TOUCH_AND_GO",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "6c34d368-c166-4722-b6e9-d4e24c4350ca"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "MainTargetIDs": [
+                                "22283ca4-89cf-4235-be1d-4f76cd1bd321",
+                                "0a4e517a-e1e1-41d7-af91-751bc663df35",
+                                "55334e2d-45c6-41b3-920e-aeb5c5111b37"
+                            ]
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "($.MainTargetIDs).Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "TargetsEscaping": {
+                                    "Transition": "EliminateTargets"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.MainTargetIDs"
+                                            }
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "EliminateTargets": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.MainTargetIDs"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.Count",
+                                                "($.MainTargetIDs).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "TargetEscaped": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "de069d95-3ba6-4027-9fa5-9ea8589ace99",
+                    "Name": "UI_CHALLENGES_SEAGULL_BODYHIDER_TARGETS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_bodyhider_targets.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_BODYHIDER_TARGETS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "4d01afe4-bb11-4c68-93dc-c8f465861eb5",
+                                "Multiplier": 0.1
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_BODYHIDER_TARGETS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_BODYHIDER_TARGETS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "56716ea5-d749-4375-ab38-4b61d8854410"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "MainTargetIDs": [
+                                "22283ca4-89cf-4235-be1d-4f76cd1bd321",
+                                "0a4e517a-e1e1-41d7-af91-751bc663df35",
+                                "55334e2d-45c6-41b3-920e-aeb5c5111b37"
+                            ]
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "($.MainTargetIDs).Count"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BodyHidden": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.MainTargetIDs"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$.Count",
+                                                "($.MainTargetIDs).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "fa19971f-4edd-42ef-b986-4fe282dc5abb",
+                    "Name": "UI_CHALLENGES_SEAGULL_CAR_KILL_NAME",
+                    "ImageName": "images/challenges/salty/seagull_car_kill.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_CAR_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "df1278b3-53f8-4f5e-92b1-f80f37f4c8f3",
+                                "Multiplier": 0.08
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_CAR_KILL_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_CAR_KILL",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "fa11378d-ffe1-4862-8e04-122d995ecb69"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "TargetIDs": [
+                                "22283ca4-89cf-4235-be1d-4f76cd1bd321",
+                                "0a4e517a-e1e1-41d7-af91-751bc663df35",
+                                "55334e2d-45c6-41b3-920e-aeb5c5111b37",
+                                "5eca3cc3-5c5c-4d94-9add-d01439381a7c",
+                                "0861b91d-daa9-4ffa-8c5f-efeb5a95a321",
+                                "856ec4d9-c19b-4f95-9a8e-2a139b891017",
+                                "af4d2c4b-89bb-48a5-a299-8123a05c567d",
+                                "56ef218a-fd31-4bc4-8430-107230e17c8e",
+                                "9bb32759-bdfa-467c-a972-a54a73ea0e11",
+                                "391f9fce-4ad5-4c02-93dd-a147679bd75f",
+                                "49c90dbd-0400-43e8-871b-03bfb7e425c5",
+                                "c99657d8-3975-409c-9326-abc55fdb1abd",
+                                "b528b5e9-35ff-4642-93b7-421866eecf92",
+                                "03024491-d477-4d74-a31f-4c50cd3b82f6",
+                                "d26ae5c0-7491-4d75-8fb3-d54ca7c6a4bf",
+                                "b3489b30-d15d-407b-9de3-1036ddd103b9",
+                                "bdc392d1-a48d-4326-ac87-b1e9838eb5cd",
+                                "af0577a8-016e-4c55-b314-ad3771d59e6c"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": "$.TargetIDs"
+                                                }
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "2fa9b901-9c26-4ba1-820e-b9f28695141b"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "084c0484-459d-4d53-a9d0-7bb74e789962",
+                    "Name": "UI_CHALLENGES_SEAGULL_HOSTAGES_MOVED_NAME",
+                    "ImageName": "images/challenges/salty/seagull_hostages_moved.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_HOSTAGES_MOVED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "0d1f7075-4d8e-4a87-994a-3dbaf0b4cdaf",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_HOSTAGES_MOVED_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_HOSTAGES_MOVED",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "1f9b506e-5883-4b14-a7c0-22aa05c30482"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Hostages_Moved_Event": {
+                                    "Transition": "Failure"
+                                },
+                                "Hostages_Remained_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "1153979c-b557-4974-a8ad-b195387efb6a",
+                    "Name": "UI_CHALLENGES_SEAGULL_START_CRANE_NAME",
+                    "ImageName": "images/challenges/salty/seagull_start_crane.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_START_CRANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "7872376d-fd88-4be9-8909-de186aabf54d",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_START_CRANE_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_START_CRANE",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "97583446-a30a-431a-9216-9540e5d11cd7"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Start_Crane_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "11c5de45-dc87-40a0-b23a-50a72c7912bb",
+                    "Name": "UI_CHALLENGES_SEAGULL_SHOOT_SEAGULLS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_shoot_seagulls.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_SHOOT_SEAGULLS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "ee7d46df-ba58-4f92-a691-4a246959a86d",
+                                "Multiplier": 0.05
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_SEAGULLS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_SEAGULLS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "3e84d13c-f3a5-487c-b020-7535c0c7573b"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SeagullHit_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "18309f54-0357-4f6b-8006-01192b76e207",
+                    "Name": "UI_CHALLENGES_SEAGULL_FOG_HORN_NAME",
+                    "ImageName": "images/challenges/salty/seagull_fog_horn.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_FOG_HORN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "da0ee139-36e2-491e-8cfc-498ee0270e31",
+                                "Multiplier": 0.05
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_FOG_HORN_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_FOG_HORN",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c088144b-fd58-493e-82c8-4823e3cbd014"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Fog_Horn_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "243eb8ee-9602-4d27-bf16-b25d6ebf68ff",
+                    "Name": "UI_CHALLENGES_SEAGULL_AGENT_SMITH_NAME",
+                    "ImageName": "images/challenges/salty/seagull_agent_smith.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_AGENT_SMITH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "3bab3303-6bb9-4960-9d5f-88d244187f36",
+                                "Multiplier": 0.05
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_AGENT_SMITH_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_AGENT_SMITH",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "f6dc0c2e-5338-4604-8f76-46ae6f0e91f0"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Agent_Smith_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "35b0e116-25b8-4b10-bd3c-7bf0f4acdb40",
+                    "Name": "UI_CHALLENGES_SEAGULL_SATELLITE_DISH_NAME",
+                    "ImageName": "images/challenges/salty/seagull_satellite_dish.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_SATELLITE_DISH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "70ddbac1-0803-4e4d-b962-1914b4e76658",
+                                "Multiplier": 0.05
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_SATELLITE_DISH_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_SATELLITE_DISH",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "e318012e-d92d-46ca-b3c4-1a15f73d07c7"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Satellite_Dish_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "49e050f9-65e9-46b5-85e5-bf398b786b3e",
+                    "Name": "UI_CHALLENGES_SEAGULL_RUBBER_DUCK_NAME",
+                    "ImageName": "images/challenges/salty/seagull_rubber_duck.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_RUBBER_DUCK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "e579d385-9419-4b39-ac39-01296d63039f",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_RUBBER_DUCK_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_RUBBER_DUCK",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "91b6a6e2-5dd1-440f-ac32-2fb3713ac611"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 10
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RubberDuckHit_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "7facc8da-8147-43c4-9a3a-86f5697bae39",
+                    "Name": "UI_CHALLENGES_SEAGULL_SHOOT_CORDS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_shoot_cords.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_SHOOT_CORDS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "d15299e9-c5e0-49b4-9e35-609a705ca7e3",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_CORDS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_CORDS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "7867dcfe-14ec-4c09-a650-81b024cbf1fa"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 6
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Shoot_Cords_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "80666d64-5915-4c86-b89e-951997724a27",
+                    "Name": "UI_CHALLENGES_SEAGULL_SHOOT_LAMPS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_shoot_lamps.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_SHOOT_LAMPS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "7cb89fba-b229-4e11-aaef-ee7e984a523b",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_LAMPS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_LAMPS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "dec39b90-ac85-4ba6-9cae-9787283230c2"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Shoot_Lamps_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "a9218949-ef89-4b2a-9a70-f7892899ee1d",
+                    "Name": "UI_CHALLENGES_SEAGULL_RATS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_rats.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_RATS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "787c6a39-00f4-402c-baab-228ad7cc6136",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_RATS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_RATS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "9c709484-872e-487f-94e2-a6f44013c022"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 9
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RatHit_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "cc05ed79-7a8f-4dad-ae7b-4d52635c6351",
+                    "Name": "UI_CHALLENGES_SEAGULL_LILLY_ESCORT_NAME",
+                    "ImageName": "images/challenges/salty/seagull_lilly_escort.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_LILLY_ESCORT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "7464e1cb-bca7-4e4f-b8ba-d8f5a271fb1a",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_LILLY_ESCORT_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_LILLY_ESCORT",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "9306da98-d98e-411c-8ecc-170526d91f5c"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Lilly_Escort_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "e6331fe4-3c0c-4fed-8447-d90824e172c9",
+                    "Name": "UI_CHALLENGES_SEAGULL_OPEN_CONTAINERS_NAME",
+                    "ImageName": "images/challenges/salty/seagull_open_containers.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_OPEN_CONTAINERS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "04fcc4b9-5946-4979-8c96-4bd0990d9fe2",
+                                "Multiplier": 0.06
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_OPEN_CONTAINERS_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_OPEN_CONTAINERS",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "c61fdb85-502b-44b9-9e71-d57974791635"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 5
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Open_Containers_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "f1b6481e-0856-4243-b19a-c012525998b0",
+                    "Name": "UI_CHALLENGES_SEAGULL_CRANE_47_NAME",
+                    "ImageName": "images/challenges/salty/seagull_crane_47.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_CRANE_47_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "35434487-ccbe-456f-8d4e-14458d6c84ce",
+                                "Multiplier": 0.07
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_CRANE_47_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_CRANE_47",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "ef4f2229-deb8-4e11-b306-0a831f7c4c0e"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Crane_47_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                },
+                {
+                    "Id": "f83d2db1-9987-4712-9974-54552b4c2fcf",
+                    "Name": "UI_CHALLENGES_SEAGULL_SHOOT_BEER_NAME",
+                    "ImageName": "images/challenges/salty/seagull_shoot_beer.jpg",
+                    "Description": "UI_CHALLENGES_SEAGULL_SHOOT_BEER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 0
+                    },
+                    "Drops": [
+                        {
+                            "Properties": {
+                                "Rarity": "common",
+                                "IsConsumable": false,
+                                "RepositoryId": "e6179ca0-3fdd-4b31-a4b4-b2f55f50e4e9",
+                                "Multiplier": 0.04
+                            },
+                            "Rarity": "common",
+                            "DisplayNameLocKey": "UI_SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_BEER_NAME",
+                            "Id": "SCORE_MULTIPLIER_SC_SEAGULL_SHOOT_BEER",
+                            "Type": "challengemultiplier",
+                            "Subtype": "challengemultiplier",
+                            "GameAsset": null,
+                            "ImageId": "",
+                            "RMTPrice": -1,
+                            "GamePrice": -1,
+                            "IsPurchasable": false,
+                            "IsPublished": true,
+                            "IsDroppable": false,
+                            "Capabilities": [],
+                            "Qualities": {},
+                            "Guid": "5b9dea45-b163-411d-ab81-0dcdfd56f79a"
+                        }
+                    ],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": true,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_SALTY",
+                    "ParentLocationId": "LOCATION_PARENT_SALTY",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Shoot_Beer_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["00e57709-e049-44c9-a2c3-7655e19884fb"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/WHITTLETON/_WHITTLETON_CHALLENGES.json
+++ b/contractdata/WHITTLETON/_WHITTLETON_CHALLENGES.json
@@ -1,0 +1,6375 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_NORTHAMERICA"
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "Challenges": [
+                {
+                    "Id": "1cd02588-6752-4dc9-8597-53719739938d",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_ELECTRICITY_NAME",
+                    "ImageName": "images/challenges/Northamerica/Gartersnake_Electricity.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_ELECTRICITY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3cf8ef68-e6f3-466a-9299-de50e9f0a9bb"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_electric"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "2d25dd66-32b1-4012-a98f-dfb70282b87b",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "31e6afaa-8f19-4015-9354-f734e92c7e6a",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "50fe2fa6-f89e-42f3-ba23-1473d6e06ecd",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "651166c6-3e14-4610-80c8-da9347d96465",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_PEN_NAME",
+                    "ImageName": "images/challenges/Northamerica/GarterSnake_Pen.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_PEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "GSPen": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "97825c6f-e0ff-40a9-8038-b54ce13417b8",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "b04d57eb-03db-4dbc-93a0-1072559646eb",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "2d25dd66-32b1-4012-a98f-dfb70282b87b",
+                                "50fe2fa6-f89e-42f3-ba23-1473d6e06ecd",
+                                "d656c35b-c7d6-408b-a54b-013214644a2d",
+                                "31e6afaa-8f19-4015-9354-f734e92c7e6a",
+                                "97825c6f-e0ff-40a9-8038-b54ce13417b8"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "c2d89044-36e0-44db-a90b-235ec79d9f03",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_FIRE_NAME",
+                    "ImageName": "images/challenges/Northamerica/GarterSnake_Fire.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_FIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3cf8ef68-e6f3-466a-9299-de50e9f0a9bb"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_burn"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "d656c35b-c7d6-408b-a54b-013214644a2d",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "ebcad89d-81c1-43a8-8f43-389d5728bfad",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_EXPLOSION_NAME",
+                    "ImageName": "images/challenges/Northamerica/Gartersnake_Explosion.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_EXPLOSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "3cf8ef68-e6f3-466a-9299-de50e9f0a9bb"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "66f35369-9345-4c5e-ae46-63adc2b4c3f7",
+                    "Name": "UI_CHALLENGES_SKUNK_UNREASONABLE_SCOPE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Treehouse_Snipe_Both_OneShot.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_UNREASONABLE_SCOPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "InTreehouseChanged_Event": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "InSniperTower"
+                                }
+                            },
+                            "InSniperTower": {
+                                "InTreehouseChanged_Event": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$contains": [
+                                                            "$Value.KillItemCategory",
+                                                            "sniperrifle"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$contains": [
+                                                            "$Value.KillItemCategory",
+                                                            "sniperrifle"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b8f0bf6c-4826-4de2-a785-2d139967e09c"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$contains": [
+                                                            "$Value.KillItemCategory",
+                                                            "sniperrifle"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$contains": [
+                                                            "$Value.KillItemCategory",
+                                                            "sniperrifle"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b8f0bf6c-4826-4de2-a785-2d139967e09c"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "7cd380fd-dff8-4119-959b-a4d967d0ab42",
+                    "Name": "UI_CHALLENGES_SKUNK_JANUS_EAT_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Janus_Eat.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_JANUS_EAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f6782198-8f5e-4a17-a0a8-f24e7fb21bb9"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "7e26078f-ec6f-420b-8653-a427bc07436d",
+                    "Name": "UI_CHALLENGES_SKUNK_SMOKES_EXPLOSION_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Janus_Smoking.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SMOKES_EXPLOSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "64061ddd-2ca0-4543-a18b-e1472b61994a"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "7e9a7949-57e9-4368-bfca-3034cadd21f1",
+                    "Name": "UI_CHALLENGES_SKUNK_LASERROOM_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Explosive_Sale.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_LASERROOM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Sold_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "7f3b4440-9f0f-4847-959c-af55d977155d",
+                    "Name": "UI_CHALLENGES_SKUNK_DOABLE_SCOPE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Treehouse_Snipe_One.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_DOABLE_SCOPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "InTreehouseChanged_Event": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "InSniperTower"
+                                }
+                            },
+                            "InSniperTower": {
+                                "InTreehouseChanged_Event": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "847882ae-4eb1-498c-82e4-ded84056f978",
+                    "Name": "UI_CHALLENGES_SKUNK_EXPLOSIVE_POTENTIAL_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_BothTargets_Explosion_Accident.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_EXPLOSIVE_POTENTIAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$Value.KillMethodStrict",
+                                                            "$.#"
+                                                        ]
+                                                    },
+                                                    "in": [
+                                                        "accident_suspended_object",
+                                                        "accident_explosion"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "aba10ff5-f105-47db-a767-0f204cf02b71",
+                    "Name": "UI_CHALLENGES_SKUNK_PILLOW_CHOKE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Janus_Pillow.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_PILLOW_CHOKE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PillowChoke_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "bcb78d0e-7f42-4e88-ba46-e9600ecdd2c5",
+                    "Name": "UI_CHALLENGES_SKUNK_JANUS_DRINK_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Janus_Drink.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_JANUS_DRINK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "2af583dc-c85d-45ad-b1bb-67dc5e6e4573"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "c3ce777f-f84b-4655-92ec-b4304599dfbc",
+                    "Name": "UI_CHALLENGES_SKUNK_MOLEHOLE_KILL_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Janus_Mole_hole.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_MOLEHOLE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Janus_Close_And_Bomb_Ready"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Janus_Not_Close_Or_Bomb_Not_Ready"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "cd4a53d4-8150-4d07-b9f0-7c15ff7492ac",
+                    "Name": "UI_CHALLENGES_SKUNK_CASSIDY_TOILET_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Cassidy_Serve.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_CASSIDY_TOILET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b8f0bf6c-4826-4de2-a785-2d139967e09c"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "67ee7eb0-65ac-449e-8be6-33f8d7afdc3f"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "d1877668-b86e-4443-9d91-3e0eed037b40",
+                    "Name": "UI_CHALLENGES_SKUNK_REASONABLE_SCOPE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Treehouse_Snipe_Both.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_REASONABLE_SCOPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "SniperKillCount": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "InTreehouseChanged_Event": {
+                                    "Condition": {
+                                        "$eq": ["$Value", true]
+                                    },
+                                    "Transition": "InSniperTower"
+                                }
+                            },
+                            "InSniperTower": {
+                                "InTreehouseChanged_Event": {
+                                    "Condition": {
+                                        "$eq": ["$Value", false]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$contains": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "SniperKillCount"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.SniperKillCount", 2]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "d344add2-8a50-40c1-a16f-f89000d7e553",
+                    "Name": "UI_CHALLENGES_SKUNK_CASSIDY_GAS_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Pass_Gas.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_CASSIDY_GAS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "CassidyGas_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "f286342f-1906-4312-872f-65016a93d3a7",
+                    "Name": "UI_CHALLENGES_SKUNK_MEMORABILIA_KILL_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Memorabilia_Kill.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_MEMORABILIA_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "2258f06a-76d0-49a1-ba01-b34d894760bf"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "041fdf1a-282c-4fce-9cdd-633699d730b9",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_ELECTRICITY_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Electricity.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_ELECTRICITY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "accident_electric"
+                                                        ]
+                                                    },
+                                                    "in": [
+                                                        "$Value.KillMethodBroad",
+                                                        "$Value.KillMethodStrict"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"]
+                },
+                {
+                    "Id": "0c35ad8f-e8e4-48f1-93ee-2560932bdb38",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_POISON_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_poison.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "555097c6-6247-4957-9cf2-1548576e0cc5",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_HEADSHOT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_headshot.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_HEADSHOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "56496d61-ae8e-48ef-8871-b0e913cb729f",
+                    "Name": "CHALLENGEPACK_BORON_GARBAGE_NAME",
+                    "ImageName": "images/challenges/Categories/PackBoron/Boron_Garbage.jpg",
+                    "Description": "CHALLENGEPACK_BORON_GARBAGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "RequiredOutfit": "5d19c9f8-7df2-4113-b81d-b32d5e231717"
+                        },
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Disguise",
+                                                "$.RequiredOutfit"
+                                            ]
+                                        },
+                                        "Transition": "CorrectOutfit"
+                                    }
+                                ],
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value",
+                                                "$.RequiredOutfit"
+                                            ]
+                                        },
+                                        "Transition": "CorrectOutfit"
+                                    }
+                                ]
+                            },
+                            "CorrectOutfit": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "2b01e2d0-f302-4b8a-822b-867ba9728f76"
+                                        ]
+                                    },
+                                    "Transition": "CheckBody"
+                                },
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$not": {
+                                                "$eq": [
+                                                    "$Value",
+                                                    "$.RequiredOutfit"
+                                                ]
+                                            }
+                                        },
+                                        "Transition": "Start"
+                                    }
+                                ]
+                            },
+                            "CheckBody": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 2
+                                    },
+                                    "Transition": "CorrectOutfit"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": ["$Value.IsTarget", true]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"]
+                },
+                {
+                    "Id": "6eb9411d-06e6-427f-ad01-0a8b00e81f97",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_MASTER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_versatile.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_MASTER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "555097c6-6247-4957-9cf2-1548576e0cc5",
+                                "0c35ad8f-e8e4-48f1-93ee-2560932bdb38",
+                                "8f8992be-de6b-44ec-9b24-e112730a0683",
+                                "b50352ad-1e15-478e-8906-c2585b5b331b",
+                                "9bb9be61-16b8-4793-a9d0-684feabcc3e8"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "8f8992be-de6b-44ec-9b24-e112730a0683",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_ACCIDENT_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_accident.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_ACCIDENT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": ["$Value.Accident", true]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "9bb9be61-16b8-4793-a9d0-684feabcc3e8",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "assassination"]
+                },
+                {
+                    "Id": "b50352ad-1e15-478e-8906-c2585b5b331b",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_DROWN_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_drown.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_ASSASINATION_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodStrict",
+                                                    "accident_drown"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "assassination"]
+                },
+                {
+                    "Id": "dfc991ea-2b12-4d57-9f02-4f31d7b8b7ec",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BLACKOUT_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Blackout.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BLACKOUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "TargetGoal": 2
+                        },
+                        "Context": {
+                            "Count": 0,
+                            "TargetKilled": []
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "count": "$.Count",
+                                "total": "$.TargetGoal",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetKilled",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$not": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$Value.RepositoryId"
+                                                                ]
+                                                            },
+                                                            "in": "$.TargetKilled"
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "accident_electric"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "$Value.KillMethodBroad",
+                                                            "$Value.KillMethodStrict"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "hard"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+            "Image": "images/challenges/categories/discovery/tile.jpg",
+            "Icon": "challenge_category_discovery",
+            "CategoryId": "discovery",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_EXPLORATION",
+            "Challenges": [
+                {
+                    "Id": "228897d4-2007-4d3d-ba20-380340b704e5",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_MEETING_NAME",
+                    "ImageName": "images/challenges/Northamerica/Gartersnake_Meeting.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_MEETING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "GSMeeting": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "a71e7a95-ee79-43c4-8eb3-9002cc703303",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_TREEHOUSE_NAME",
+                    "ImageName": "images/challenges/Northamerica/GaterSnake_Treehouse.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_TREEHOUSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "GSTreehouse": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "db1366fa-1108-4016-9e53-99f18143b5ac",
+                    "Name": "UI_CHALLENGES_SKUNK_LOCATE_CONSTANT_NAME",
+                    "ImageName": "images/actors/skunk_trackingtheconstant.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_LOCATE_CONSTANT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "AllCluesCollected": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "011e18c8-dd1d-420b-8b0c-c21f6547678f",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_NURSE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_Nurse.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_NURSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "4b416b2a-ac08-4379-8c53-46e46d8bcbf8"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "18a3c7c6-282d-4c0f-a430-fd0432390fd8",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_EXIT_RAFT_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Exit_Raft.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_EXIT_RAFT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "ce89749c-6667-4871-be0f-26f644c83869"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "19775ff0-6290-4b78-8e0b-6846f614b658",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_BATTY_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_Batty.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_BATTY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "13cbccd1-8a96-435b-84e8-107c0a29349d"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "1c6b3d4e-2231-46eb-b788-3614ba345c4d",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_MAILMAN_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_Mailman.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_MAILMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "89f20c16-4e13-4f89-a85b-44dd17698bc7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "2b2c16be-2114-49a4-94f6-991b3541bbae",
+                    "Name": "UI_CHALLENGES_SKUNK_AREA_DISCOVERED_NAME",
+                    "ImageName": "images/challenges/NorthAmerica/NORTHAMERICA_Area_Discovered_skunk.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_AREA_DISCOVERED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 29
+                        },
+                        "Context": {
+                            "AreaIDs": []
+                        },
+                        "ContextListeners": {
+                            "AreaIDs": {
+                                "type": "challengecounter",
+                                "count": "($.AreaIDs).Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_SKUNK_AREA_DISCOVERED_NAME"
+                            }
+                        },
+                        "Scope": "profile",
+                        "States": {
+                            "Start": {
+                                "AreaDiscovered": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "AreaIDs",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.AreaIDs).Count",
+                                                "$.Goal"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "discovery"]
+                },
+                {
+                    "Id": "47e2164d-9842-499f-acdd-a248e29b95f6",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_EXIT_MANHOLE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Exit_Manhole.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_EXIT_MANHOLE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.RepositoryId"
+                                                        ]
+                                                    },
+                                                    "in": [
+                                                        "39f290bd-bb56-46f3-91f3-c4ac0c28c389",
+                                                        "e391eef9-4d71-4a46-a232-dc76c2b25618",
+                                                        "16b9530c-2cca-47c6-98e0-553f499710b1",
+                                                        "14584b57-90ca-4a16-8e1d-1c2ee4f18e9a",
+                                                        "5e243861-9490-4c98-a985-16170fef4180",
+                                                        "8ef90a56-cc5c-4457-a38e-62ad2611e6e5",
+                                                        "b350f180-3bad-4c87-915e-3eaca53188c1",
+                                                        "12c0604c-cdb3-475f-9865-a5af02472174"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "4d7025fb-2cd7-4a9f-bfcd-0c4a6d67c26d",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_BBQKING_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_BBQKING.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_BBQKING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "44f30ddb-cad9-402b-a307-6076fae3aa74"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "4e01ca4c-f615-46a3-b6fb-b473d31f30e8",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_EXIT_TRASHTRUCK_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Exit_TrashTruck.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_EXIT_TRASHTRUCK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "e0468c42-5030-4653-bc23-2a96c361768f"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "7a990fb8-4d4f-4d6f-b34f-11d9cb010ad0",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_EXTERMINATOR_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_Exterminator.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_EXTERMINATOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "b1739270-f9fc-4a24-a3e7-beb2deb235f2"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "869162b8-9a6b-48b1-9759-fbf736b9ed1b",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_ARKIAN_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_Arkian.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_ARKIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "e75d76b7-25ec-4500-9585-0ce34cec1e1f"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "904a67ad-81a6-417f-b139-fed6e695d2e2",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_EXIT_GATE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Exit_Gate.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_EXIT_GATE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "ee561705-e824-4904-aa09-1cd5591c9539"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "c2004551-66b8-4e7b-9237-6529764e3a75",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_EXIT_VAN_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Exit_Van.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_EXIT_VAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "exit_gate": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "1ee74d9d-1f20-487e-aabb-826d0ab3fef5"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "medium"]
+                },
+                {
+                    "Id": "d6d02217-d598-4695-a6cd-891c3550b483",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_PAPERBOY_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Paperboy.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_PAPERBOY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Paperboy_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "discovery", "easy"]
+                },
+                {
+                    "Id": "db8888ec-4901-4888-b1a2-3c7e82df41bf",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_POLITICIAN_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_Politician.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_POLITICIAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "64e48347-cac5-434b-b25c-711ff78c46fd"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                },
+                {
+                    "Id": "e3d5da4c-ad30-4bde-8c6b-781e836b84fc",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_47_MASTER_OF_DISGUISE_NAME",
+                    "ImageName": "images/challenges/profile_challenges/generic_location_47_chameleon.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_47_MASTER_OF_DISGUISE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleDisguises": [
+                                "078a5c70-737c-48b7-a190-b356438419b4",
+                                "13cbccd1-8a96-435b-84e8-107c0a29349d",
+                                "44f30ddb-cad9-402b-a307-6076fae3aa74",
+                                "4b416b2a-ac08-4379-8c53-46e46d8bcbf8",
+                                "5d19c9f8-7df2-4113-b81d-b32d5e231717",
+                                "64e48347-cac5-434b-b25c-711ff78c46fd",
+                                "699ce756-8eef-4a6e-bc65-264d0e763fde",
+                                "6d1a3100-5dc0-4a8a-b9fc-341c864e3841",
+                                "7edfb519-9d60-4cd9-b4f4-74dd64d622b9",
+                                "874efc03-afda-48f9-b073-b2db0e93bc3f",
+                                "89f20c16-4e13-4f89-a85b-44dd17698bc7",
+                                "8b162546-0eab-40a0-a66b-a08e8ddf2ea4",
+                                "98a9d41b-3a39-4fe3-ab6a-31d8b574f2ff",
+                                "aee5458a-51b7-4ee2-996a-b71b3e149354",
+                                "b1739270-f9fc-4a24-a3e7-beb2deb235f2",
+                                "b210be64-ea03-4983-aa0f-8d18882a23c7",
+                                "d47223f2-3fe4-46d1-a99a-09e0eb57aa7b",
+                                "e3256178-ce59-4796-bc5b-800cd6120b28",
+                                "e4c5735c-ea33-4d11-a72b-584902370cf3",
+                                "e75d76b7-25ec-4500-9585-0ce34cec1e1f"
+                            ]
+                        },
+                        "Context": {
+                            "DisguiseEquipped": []
+                        },
+                        "ContextListeners": {
+                            "DisguiseEquipped": {
+                                "count": "($.DisguiseEquipped).Count",
+                                "total": "($.EligibleDisguises).Count",
+                                "type": "challengecounter"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": ["$.#", "$Value"]
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "DisguiseEquipped",
+                                                "$Value"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.DisguiseEquipped"
+                                                    }
+                                                },
+                                                "in": "$.EligibleDisguises"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "discovery"]
+                },
+                {
+                    "Id": "ff9e94f0-ed43-462a-a7f5-b7f60e0c5ff0",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_BECOME_REALTESTATEBROKER_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Become_RealEstateAgent.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_BECOME_REALTESTATEBROKER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_EXPLORATION",
+                    "Icon": "challenge_category_discovery",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "d47223f2-3fe4-46d1-a99a-09e0eb57aa7b"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "discovery"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "challenge_category_feats",
+            "CategoryId": "feats",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_COMMUNITY",
+            "Challenges": [
+                {
+                    "Id": "017bec1b-fc43-484d-b9d1-89bafddf37ce",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_SECURITY_NAME",
+                    "ImageName": "images/challenges/Northamerica/Gatersnake_Security.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_SECURITY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "GSSecurity": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "083ab5a8-2ab8-45dd-90fd-5eb9da522908",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_POLICE_NAME",
+                    "ImageName": "images/challenges/Northamerica/Gartersnake_Police.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_POLICE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "b210be64-ea03-4983-aa0f-8d18882a23c7"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "b649b57a-3833-4046-bea4-80df07f738ad",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_MAILBOX_NAME",
+                    "ImageName": "images/challenges/Northamerica/Gartersnake_Mailbox.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_MAILBOX_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "GSMailbox": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "medium", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "0036f512-6a30-48eb-9bb9-fe6dd501ef85",
+                    "Name": "UI_CHALLENGES_SKUNK_STORYHEALTH_NAME",
+                    "ImageName": "images/challenges/Northamerica/Skunk_Story_Health.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_STORYHEALT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HealthOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "0c91138e-c5c8-4f44-932b-52e22cdd833b",
+                    "Name": "UI_CHALLENGES_SKUNK_DOORBELLS_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Doorbells.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_DOORBELLS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Doorbells_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "0e91ce08-949c-40ce-ba22-44b2d45e78e8",
+                    "Name": "UI_CHALLENGES_SKUNK_PACKAGE_DESTROY_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Package_Destroy.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_PACKAGE_DESTROY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BattyPackage_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "145c6fbc-2e77-4ab3-a8e1-d69aa5faba56",
+                    "Name": "UI_CHALLENGES_SKUNK_STORYSALE_NAME",
+                    "ImageName": "images/challenges/Northamerica/Skunk_Story_Sale.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_STORYSALE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SaleOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "1a190a78-b070-45ae-ad3f-ba8c4e2c0428",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_WETBANDIT_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_WetBandit.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_WETBANDIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Wetbandit_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "21f2c775-8115-4ce6-8785-1b7f5ac55651",
+                    "Name": "UI_CHALLENGES_SKUNK_MOLE_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/vermont/skunk_opp_moleholes.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_MOLE_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "03d541fb-1ad3-446f-b762-7d6adab99acd"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "2d83d6a7-9af2-407d-83bf-e19c4e3fe865",
+                    "Name": "UI_CHALLENGES_SKUNK_FRIENDLY_HITMAN_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_FriendlyHitman.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_FRIENDLY_HITMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "c5e30ea7-409f-4327-a13a-7be21c175f6c",
+                                "3cd4faad-c56c-46c9-8afc-4888cc5010dc",
+                                "a2c2d917-1bc2-489f-a66f-445226d0579b"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "3cd4faad-c56c-46c9-8afc-4888cc5010dc",
+                    "Name": "UI_CHALLENGES_SKUNK_HELP_MAILMAN_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Help_Mailman.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_HELP_MAILMAN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HelpMailman_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "4b0718ce-3450-48a1-b231-1c4d07117023",
+                    "Name": "UI_CHALLENGES_SKUNK_CHARBROILED_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/vermont/skunk_opp_bbqserve.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_CHARBROILED_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "8120be1a-e4a7-4052-8c7c-c235a0bc0b01"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "4b673969-db14-4dd0-aeb0-78d28d44c72f",
+                    "Name": "UI_CHALLENGES_SKUNK_MASTERDETECTIVE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_MasterDetective.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_MASTERDETECTIVE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Masterdetective_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "5d4b5e47-19f2-4d2f-9352-2da4fe52e41b",
+                    "Name": "UI_CHALLENGES_SKUNK_SECRET_TUNNEL_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Secret_Tunnel.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SECRET_TUNNEL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SecretTunnel_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "8a0ac612-f4ec-4c0b-bef6-9ff6caabef0e",
+                    "Name": "UI_CHALLENGES_SKUNK_DUMP_OVEN_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Dump_Oven.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_DUMP_OVEN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "57d69808-1233-4aa6-9bda-c38fe0122c80"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "937c7056-9b95-4abc-bacb-3f4ea38f889e",
+                    "Name": "UI_CHALLENGES_SKUNK_OBTAIN_FROG_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Obtain_Frog.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_OBTAIN_FROG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "963123fd-8a53-41b6-8950-335495b3f3af"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "9a5ea5a8-8b0b-4001-9c69-701a25aa94cb",
+                    "Name": "UI_CHALLENGES_SKUNK_LETTER_INTERCEPTOR_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Letter_Interceptor.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_LETTER_INTERCEPTOR_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "LetterInterceptor_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "a2c2d917-1bc2-489f-a66f-445226d0579b",
+                    "Name": "UI_CHALLENGES_SKUNK_HEALTHCHECK_NPC_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_HealthCheck_NPC.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_HEALTHCHECK_NPC_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "HealthcheckNpc_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "bb4a05de-53f1-403e-aafb-4df3f4fca78a",
+                    "Name": "UI_CHALLENGES_SKUNK_PRESENTATION_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Full_House_Presentation.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_PRESENTATION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 11
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_SKUNK_PRESENTATION_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "RoomPresented_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "c5e30ea7-409f-4327-a13a-7be21c175f6c",
+                    "Name": "UI_CHALLENGES_SKUNK_FORSALE_NPC_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_ForSale_NPC.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_FORSALE_NPC_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ForsaleNpc_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "c7708845-2fc9-49d3-91dc-efdc20a62aa1",
+                    "Name": "UI_CHALLENGES_SKUNK_FORSALE_MUFFIN_EAT_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_ForSale_MuffinEat.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_FORSALE_MUFFIN_EAT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ForsaleMuffinEat_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "cb8453c4-b39a-4c0b-b77e-ca406e2bc143",
+                    "Name": "UI_CHALLENGES_SKUNK_MASTERSERVER_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_MasterServer.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_MASTERSERVER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Masterserver_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "cbf153e3-b161-4682-abe8-4ce07e86cb2f",
+                    "Name": "UI_CHALLENGES_SKUNK_POLITICIAL_FLYER_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_PoliticalFlyer.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_POLITICIAL_FLYER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "PoliticalFlyer_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "d6510212-5e53-459e-9e5a-b29d864b5774",
+                    "Name": "UI_CHALLENGES_SKUNK_STORYBREAD_NAME",
+                    "ImageName": "images/challenges/Northamerica/Skunk_Story_Breadcrumbs.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_STORYBREAD_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "BreadOPPEvent": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "d6b6da25-35ca-43b6-8584-58a304824817",
+                    "Name": "UI_CHALLENGES_SKUNK_PEST_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/vermont/skunk_opp_exterminator.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_PEST_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "d7e86cc3-16bc-430a-b4cf-c790b5fe0a95"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "df80892e-849e-4e49-af4f-1797dc158fde",
+                    "Name": "UI_CHALLENGES_SKUNK_SINGING_FISH_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_SingingFish.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SINGING_FISH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SingingFish_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "e4846f8e-9edc-472b-b2c2-b866c6aa6d51",
+                    "Name": "UI_CHALLENGES_SKUNK_JANUS_HAPPY_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Janus_Happy.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_JANUS_HAPPY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 7
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_SKUNK_JANUS_HAPPY_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "JanusHappy_Event": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "ea3f6fa5-cd33-4f17-a59e-45558bc664fe",
+                    "Name": "UI_CHALLENGES_SKUNK_SMOKING_MS_RETROFIT_NAME",
+                    "ImageName": "images/opportunities/vermont/skunk_opp_smokes.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SMOKING_MS_RETROFIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Target": "024bb599-7dd6-42b0-a60c-5077ce66fa1b"
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "OpportunityEvents": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "$.Target"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.Event",
+                                                    "Completed"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "easy", "feats"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "ef77b715-7de9-424d-b6fd-51da258eec93",
+                    "Name": "UI_CHALLENGES_SKUNK_HATCHET_UNEARTH_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/SKUNK_Hatchet_Unearth.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_HATCHET_UNEARTH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ItemPickedUp": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "3a8207bb-84f5-438f-8f30-5c83aef2af80"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "8c3f87f5-fa20-4b64-9f76-32c55ee95edb",
+                    "Name": "UI_CONTRACT_BANEBERRY_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Skunk_Baneberry.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "a1e125fe-b9ac-428b-8ff0-2ba5a3d508dd"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["d1b9250b-33f6-4712-831b-f33fa11ee4d8"]
+                    }
+                },
+                {
+                    "Id": "ab8093e2-7edc-4e51-9bb8-cbea44c1fb09",
+                    "Name": "UI_CONTRACT_MILKWEED_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Skunk_Milkweed.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "7f05929f-f1c7-49f7-9428-c9a847b12a87"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["1d5dcf3e-9682-4e32-ac11-ad6586daa456"]
+                    }
+                },
+                {
+                    "Id": "afc4beb1-dfbd-42c8-af97-0c0a1359f91c",
+                    "Name": "UI_CONTRACT_MYRTLE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Skunk_Myrtle.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "d7bc0701-e9c9-465c-a1af-561863697fca"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["74e6b561-ff1a-4742-9a7b-890b7818c796"]
+                    }
+                },
+                {
+                    "Id": "8cc27d9c-21b2-4439-abd1-70f4d59ce62a",
+                    "Name": "UI_CONTRACT_CLAYTONIA_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Skunk_Claytonia.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "abddddf9-3dbc-46cb-a8e4-087418d97435"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["15b7ad4e-565a-4fdb-b669-c9a68176e665"]
+                    }
+                },
+                {
+                    "Id": "2edae6e2-365e-4bba-9916-b2a021a9836c",
+                    "Name": "UI_CONTRACT_GORSE_GROUP_TITLE",
+                    "ImageName": "images/contracts/escalation/ContractEscalation_Skunk_Gorse.jpg",
+                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$ContractId",
+                                            "5a2a91be-4591-40f7-aada-f55fce0cadbe"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["feats", "hard"],
+                    "InclusionData": {
+                        "ContractIds": ["fe088a10-5dbf-460f-bbe2-6b55e7a66253"]
+                    }
+                },
+                {
+                    "Id": "043f53b3-15ed-40ff-af46-51f03ce398ae",
+                    "Name": "CHALLENGEPACK_BORON_KILLMUFFINWORKERS_NAME",
+                    "ImageName": "images/challenges/Categories/PackBoron/Boron_KillMuffinWorkers.jpg",
+                    "Description": "CHALLENGEPACK_BORON_KILLMUFFINWORKERS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "RequiredTargets": [
+                                "3880a7bb-7b59-4a0c-87f2-590e87ccb1ce",
+                                "eceef7f6-d43d-4435-a088-0c686cf202dc",
+                                "233503c3-d3bd-4900-b501-90d4c95b03d4",
+                                "a07921d5-b47e-4f0a-b8a7-3a5f0d6f0f5a"
+                            ],
+                            "RequiredTargetCount": 4
+                        },
+                        "Context": {
+                            "PacifiedTargets": []
+                        },
+                        "ContextListeners": {
+                            "PacifiedTargets": {
+                                "type": "challengecounter",
+                                "count": "($.PacifiedTargets).Count",
+                                "total": "($.RequiredTargets).Count"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredTargets"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "PacifiedTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.PacifiedTargets).Count",
+                                                "($.RequiredTargets).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "856b2aa2-e224-48c3-b890-01fdf4dba6de"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"]
+                },
+                {
+                    "Id": "200b8286-1104-4a1e-9df5-705fb218954e",
+                    "Name": "CHALLENGEPACK_MAGNESIUM_POLICE_NAME",
+                    "ImageName": "images/challenges/Categories/PackMagnesium/Magnesium_Police.jpg",
+                    "Description": "CHALLENGEPACK_MAGNESIUM_POLICE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Constants": {
+                            "EligibleCops": [
+                                "27f42632-7c82-45b3-adbd-070db4289de3",
+                                "f8dc2a26-342e-471f-a683-f36b43485f23",
+                                "f63d8f4a-103a-4364-a542-9c4cc53c0773",
+                                "97e31849-2137-4138-94ef-f7e417b38dd5",
+                                "182a97da-9f67-427f-a6df-148a5ac84564",
+                                "e0632a9e-a9db-40d3-98b1-03b729f9b139",
+                                "7cc5baa5-087d-473e-9bc9-ae7b3e354cf5",
+                                "4694ae61-e3aa-4e00-988f-be878ad29490"
+                            ],
+                            "RequiredCops": 3
+                        },
+                        "Context": {
+                            "PacifiedCops": []
+                        },
+                        "ContextListeners": {
+                            "PacifiedCops": {
+                                "type": "challengecounter",
+                                "count": "($.PacifiedCops).Count",
+                                "total": "$.RequiredCops"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "Pacify": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.RepositoryId"
+                                                    ]
+                                                },
+                                                "in": "$.EligibleCops"
+                                            }
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "PacifiedCops",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.PacifiedCops).Count",
+                                                "$.RequiredCops"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Actions": {
+                                        "$remove": [
+                                            "PacifiedCops",
+                                            "$Value.DeadBody.RepositoryId"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                },
+                {
+                    "Id": "42ab49e5-3594-4012-a7a1-413b86fbd2de",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_RAKE_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Rake.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_RAKE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "81654161-7711-4985-8056-8651a381d3ca"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillMethodBroad",
+                                                    ""
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"]
+                },
+                {
+                    "Id": "e31b89c2-a7f1-4054-88e5-a9700f0b673c",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_PAYTHETOLL_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_PayTheToll.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_PAYTHETOLL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Paythetoll_Event": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                },
+                {
+                    "Id": "ecbd8cc1-3b1d-4473-ae1d-b963c999ab63",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_CAMERAS_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_cameras.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_CAMERAS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 2000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "Goal": 12
+                        },
+                        "Context": {
+                            "Count": 0
+                        },
+                        "ContextListeners": {
+                            "Count": {
+                                "type": "challengecounter",
+                                "count": "$.Count",
+                                "total": "$.Goal",
+                                "text": "UI_CHALLENGES_NORTHAMERICA_CAMERAS_NAME"
+                            }
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "CameraDestroyed",
+                                                "$Value.event"
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$inc": "Count"
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.Goal"]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "medium"]
+                },
+                {
+                    "Id": "f5fcbd68-92d0-4f48-9264-5408be419e6f",
+                    "Name": "UI_CHALLENGES_NORTHAMERICA_PAPER_PACIFY_NAME",
+                    "ImageName": "images/challenges/NORTHAMERICA/NORTHAMERICA_Paper_Pacify.jpg",
+                    "Description": "UI_CHALLENGES_NORTHAMERICA_PAPER_PACIFY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 1000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "LOCATION_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "location",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "EligibleTargets": [
+                                "672a7a52-a08a-45cd-a061-ced6a7b8d8c4",
+                                "b8f0bf6c-4826-4de2-a785-2d139967e09c"
+                            ]
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": ["$Value.IsTarget", true]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "a96cdbd8-9657-416a-87bf-d2ed21840794"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "feats", "easy"]
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+            "Image": "images/challenges/categories/targets/tile.jpg",
+            "Icon": "challenge_category_targets",
+            "CategoryId": "targets",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_PROFESSIONAL",
+            "Challenges": [
+                {
+                    "Id": "c9b984e2-7d3d-47ea-bf68-64ad8b8b31eb",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_VHOLES_KILLED_NAME",
+                    "ImageName": "images/challenges/Northamerica/GarterSnake_KillVholes.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_VHOLES_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "3cf8ef68-e6f3-466a-9299-de50e9f0a9bb"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "02d0d8df-3784-4c32-93c8-4dc3434d1a12",
+                    "Name": "UI_CHALLENGES_SKUNK_JANUS_KILLED_NAME",
+                    "ImageName": "images/actors/Skunk_Janus.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_JANUS_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "672a7a52-a08a-45cd-a061-ced6a7b8d8c4"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "b8070495-b078-454e-bc1c-71bdd73195cf",
+                    "Name": "UI_CHALLENGES_SKUNK_CASSIDY_KILLED_NAME",
+                    "ImageName": "images/actors/Skunk_Nolan_Cassidy.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_CASSIDY_KILLED_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PROFESSIONAL",
+                    "Icon": "challenge_category_targets",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "b8f0bf6c-4826-4de2-a785-2d139967e09c"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "targets"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+            "Image": "images/challenges/categories/classic/tile.jpg",
+            "Icon": "profile",
+            "CategoryId": "classic",
+            "Description": "",
+            "Challenges": [
+                {
+                    "Id": "0eaba6b2-14d2-4f16-b34e-b13190b7650f",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "7682093a-f604-492a-9198-ae3b55165f45",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "acfac6e4-3e98-4dac-a5dd-43155ce82f3d",
+                                "9aa98c98-2f2b-41c7-9ebe-7550bc90953d",
+                                "f978b895-f0a0-4a73-a9ed-9e06a653c679",
+                                "0eaba6b2-14d2-4f16-b34e-b13190b7650f"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "9aa98c98-2f2b-41c7-9ebe-7550bc90953d",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "acfac6e4-3e98-4dac-a5dd-43155ce82f3d",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "f978b895-f0a0-4a73-a9ed-9e06a653c679",
+                    "Name": "UI_CHALLENGES_GARTERSNAKE_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_GARTERSNAKE_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Constants": {
+                            "MissionTargets": [
+                                "3cf8ef68-e6f3-466a-9299-de50e9f0a9bb"
+                            ]
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["0b616e62-af0c-495b-82e3-b778e82b5912"]
+                    }
+                },
+                {
+                    "Id": "8955135e-6aaf-422f-b6bc-75d298d3acf0",
+                    "Name": "UI_CHALLENGES_SKUNK_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SILENT_ASSASSIN_SUIT_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "suitonly",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "a3204230-2eaf-4fbd-976d-448290a69a4a",
+                    "Name": "UI_CHALLENGES_SKUNK_SILENT_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SILENT_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "KilledTargets": [],
+                            "RecordingDestroyed": true,
+                            "LastAccidentTime": 0
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.KilledTargets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "AccidentBodyFound": {
+                                    "$set": ["LastAccidentTime", "$Timestamp"]
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "KilledTargets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "MurderedBodySeen": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsWitnessTarget",
+                                                true
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Witnesses",
+                                                "$Value.Witness"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsWitnessTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$.LastAccidentTime",
+                                                            "$Timestamp"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "a734efae-f670-4f89-9f3c-60abf29b03a4",
+                    "Name": "UI_CHALLENGES_SKUNK_SUIT_ONLY_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SUIT_ONLY_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "ContractStart": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.IsHitmanSuit",
+                                                false
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "classic", "difficulty_easy"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "b6caebc2-0768-4898-8c23-fa1d82be63f8",
+                    "Name": "UI_CHALLENGES_SKUNK_SNIPER_ASSASSIN_DIFFICULTY_EASY_NAME",
+                    "ImageName": "images/challenges/profile_challenges/classics_normal_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_SNIPER_ASSASSIN_DIFFICULTY_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Witnesses": [],
+                            "Targets": [],
+                            "RecordingDestroyed": true,
+                            "SniperKillSierraCar": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    true,
+                                                    "$.RecordingDestroyed"
+                                                ]
+                                            },
+                                            {
+                                                "$all": {
+                                                    "in": "$.Witnesses",
+                                                    "?": {
+                                                        "$any": {
+                                                            "in": "$.Targets",
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Witnesses": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Spotted": {
+                                    "Condition": {
+                                        "$any": {
+                                            "in": "$Value",
+                                            "?": {
+                                                "$pushunique": [
+                                                    "Witnesses",
+                                                    "$.#"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "SniperKillSierraCar": {
+                                    "$set": ["SniperKillSierraCar", true]
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$not": {
+                                                                "$contains": [
+                                                                    "$Value.KillItemCategory",
+                                                                    "sniperrifle"
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$or": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$eq": [
+                                                                            "$Value.RepositoryId",
+                                                                            "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$and": [
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$Value.RepositoryId",
+                                                                                "c0ab162c-1502-40d5-801f-c5471289d6b7"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "$eq": [
+                                                                                "$.SniperKillSierraCar",
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "$and": [
+                                                        {
+                                                            "$eq": [
+                                                                "$Value.IsTarget",
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$not": {
+                                                                "$eq": [
+                                                                    "$Value.KillContext",
+                                                                    1
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillContext",
+                                                        1
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "Targets",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": [
+                        "story",
+                        "hard",
+                        "sniper",
+                        "classic",
+                        "difficulty_easy"
+                    ],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                },
+                {
+                    "Id": "d89d62dd-1d38-470c-9206-7739b75ca5a0",
+                    "Name": "UI_CHALLENGES_SKUNK_BIG5_EASY_NAME",
+                    "ImageName": "Images/Challenges/profile_challenges/classics_location_normal.jpg",
+                    "Description": "UI_CHALLENGES_SKUNK_BIG5_EASY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_CLASSIC",
+                    "Icon": "profile",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": ["easy"],
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "a3204230-2eaf-4fbd-976d-448290a69a4a",
+                                "8955135e-6aaf-422f-b6bc-75d298d3acf0",
+                                "b6caebc2-0768-4898-8c23-fa1d82be63f8",
+                                "a734efae-f670-4f89-9f3c-60abf29b03a4"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "Scope": "hit",
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.CompletedChallenges"
+                                                    }
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["story", "hard", "difficulty_easy", "classic"],
+                    "InclusionData": {
+                        "ContractIds": ["82f55837-e26c-41bf-bc6e-fa97b7981fbc"]
+                    }
+                }
+            ]
+        },
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+            "Image": "images/challenges/categories/feats/tile.jpg",
+            "Icon": "arcademode",
+            "CategoryId": "arcade",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_ARCADE",
+            "Challenges": [
+                {
+                    "Id": "b0db75f2-ef62-4c41-86b8-e09a529fcb76",
+                    "Name": "UI_RASPBERRY_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Raspberry_Group.jpg",
+                    "Description": "UI_RASPBERRY_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["cab4293f-e359-419d-aa6f-83d91a158cf5"]
+                    }
+                },
+                {
+                    "Id": "b4843b11-57e2-4ba9-915a-9525c18786a5",
+                    "Name": "UI_PLANTAIN_COMPLETION_CHALLENGE_NAME",
+                    "ImageName": "images/contracts/arcade/Arcade_Plantain_Group.jpg",
+                    "Description": "UI_PLANTAIN_COMPLETION_CHALLENGE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ARCADE",
+                    "Icon": "arcademode",
+                    "LocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "ParentLocationId": "LOCATION_PARENT_NORTHAMERICA",
+                    "Type": "contract",
+                    "DifficultyLevels": [],
+                    "InclusionData": {
+                        "ContractIds": ["5081776a-86b6-4935-a83e-631a65ba8ee8"]
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
All challenge data were acquired with the `extract-challenge-data` script with no modifications.

**What works**
- Updated the season 1 challenges with some recently added ones.
- All destinations now have challenges shown in the Challenges tab on the location page.
- All contracts now have challenges shown in the Challenges tab on the planning page and in-game F1 page, including sniper ones.
- Players can complete challenges on sniper maps, and the completion data saves. (Tested with Psycho Daisies in The Last Yardbird)

**What might not work**
- I did not manually test every challenge and confirm that it works.
- Dartmoor Garden Show challenges are not working.
