### PR TITLE
Add Challenge completion and level completion percentage display

### DIFF
--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -226,11 +226,9 @@ export class ChallengeService extends ChallengeRegistry {
     /**
      * Get challenge lists sorted into groups.
      *
-     * @param locationId The parent location's ID.
      * @param filter The filter to use.
      */
     getGroupedChallengeLists(
-        locationId: string,
         filter: ChallengeFilterOptions,
     ): GroupIndexedChallengeLists {
         let challenges: [string, RegistryChallenge[]][] = []
@@ -285,7 +283,7 @@ export class ChallengeService extends ChallengeRegistry {
 
         assert.ok(contractParentLocation)
 
-        return this.getGroupedChallengeLists(contractParentLocation, {
+        return this.getGroupedChallengeLists({
             type: ChallengeFilterType.Contract,
             contractId: contractId,
             locationId: contract.Metadata.Location,
@@ -544,7 +542,7 @@ export class ChallengeService extends ChallengeRegistry {
             return []
         }
 
-        const forLocation = this.getGroupedChallengeLists(locationParentId, {
+        const forLocation = this.getGroupedChallengeLists({
             type: ChallengeFilterType.ParentLocation,
             locationParentId,
         })
@@ -747,6 +745,40 @@ export class ChallengeService extends ChallengeRegistry {
                 challenge.Type === "contract"
                     ? generateUserCentric(contract, userId, gameVersion)
                     : (null as unknown as undefined),
+        }
+    }
+
+    /**
+     * Counts the number of challenges and completed challenges in a GroupIndexedChallengeLists object.
+     * @param challengeLists A GroupIndexedChallengeLists object, holding some challenges to be counted
+     * @param userId The userId of the user to acquire completion information
+     * @param gameVersion The version of the game
+     * @returns An object with two properties: ChallengesCount and CompletedChallengesCount.
+     */
+    countTotalNCompletedChallenges(
+        challengeLists: GroupIndexedChallengeLists,
+        userId: string,
+        gameVersion: GameVersion,
+    ): { ChallengesCount: number; CompletedChallengesCount: number } {
+        let challengesCount = 0
+        let completedChallengesCount = 0
+        for (const groupId in challengeLists) {
+            const challenges = challengeLists[groupId]
+            const challengeProgressionData = challenges.map((challengeData) =>
+                this.getPersistentChallengeProgression(
+                    userId,
+                    challengeData.Id,
+                    gameVersion,
+                ),
+            )
+            challengesCount += challenges.length
+            completedChallengesCount += challengeProgressionData.filter(
+                (progressionData) => progressionData.Completed,
+            ).length
+        }
+        return {
+            ChallengesCount: challengesCount,
+            CompletedChallengesCount: completedChallengesCount,
         }
     }
 

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -82,6 +82,7 @@ import { brotliDecompress } from "zlib"
 import assert from "assert"
 import { Response } from "express"
 import { MissionEndRequestQuery } from "./types/gameSchemas"
+import { ChallengeFilterType } from "./candle/challengeHelpers"
 
 /**
  * An array of string arrays that contains the IDs of the featured contracts.
@@ -650,7 +651,7 @@ export class Controller {
         if (openCtJson) {
             return fastClone(openCtJson)
         }
-        log(LogLevel.WARN, `Contract ${id} not found!`)
+        log(LogLevel.TRACE, `Contract ${id} not found!`)
         return undefined
     }
 
@@ -1177,14 +1178,24 @@ export function contractIdToHitObject(
         log(LogLevel.ERROR, "No UC due to previous error?")
         return undefined
     }
+    const challenges = controller.challengeService.getGroupedChallengeLists({
+        type: ChallengeFilterType.ParentLocation,
+        locationParentId: parentLocation.Id,
+    })
+    const challengeCompletion =
+        controller.challengeService.countTotalNCompletedChallenges(
+            challenges,
+            userId,
+            gameVersion,
+        )
 
     return {
         Id: contract.Metadata.Id,
         UserCentricContract: userCentric,
         Location: parentLocation,
         SubLocation: subLocation,
-        ChallengesCompleted: 0,
-        ChallengesTotal: 0,
+        ChallengesCompleted: challengeCompletion.CompletedChallengesCount,
+        ChallengesTotal: challengeCompletion.ChallengesCount,
         LocationLevel: 1,
         LocationMaxLevel: 1,
         LocationCompletion: 0,

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -290,9 +290,9 @@ export async function missionEnd(
     const opportunities = contractData.Metadata.Opportunities
     const opportunityCount = opportunities ? opportunities.length : 0
     const opportunityCompleted = opportunities
-        ? opportunities.filter(function (ms) {
-              return ms in userData.Extensions.opportunityprogression
-          }).length
+        ? opportunities.filter((ms) => (
+              ms in userData.Extensions.opportunityprogression
+          )).length
         : 0
     const result = {
         MissionReward: {


### PR DESCRIPTION
- The "CHALLENGE COMPLETION" ratio and the "TOTAL COPMLETION" percentage now display the correct data at the bottom on the Destinations page, as well as on the page for each location. 
- The "number of challenges vs completed challenges" bar, "number of mission stories vs completed mission stories" bar, and completion percentage all display the correct data on the bottom right on the scoring page now.
- This PR is fully compatible with but does not depend on #77, including sniper missions.