### PR TITLE
Implement the Challenges tab on the Career page

### DIFF
--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -587,6 +587,41 @@ export class ChallengeService extends ChallengeRegistry {
         )
     }
 
+    getChallengeDataForLocation(
+        locationId: string,
+        gameVersion: GameVersion,
+        userId: string,
+    ): CompiledChallengeTreeCategory[] {
+        const locationsData = getVersionedConfig<PeacockLocationsData>(
+            "LocationsData",
+            gameVersion,
+            false,
+        )
+
+        const locationData = locationsData.children[locationId]
+
+        if (!locationData) {
+            log(
+                LogLevel.WARN,
+                `Failed to get location data in CSERV [${locationId}]`,
+            )
+            return []
+        }
+
+        const forLocation = this.getChallengesForLocation(
+            locationId,
+            gameVersion,
+        )
+
+        return this.reBatchIntoSwitchedData(
+            forLocation,
+            userId,
+            gameVersion,
+            locationData,
+            true,
+        )
+    }
+
     private reBatchIntoSwitchedData(
         challengeLists: GroupIndexedChallengeLists,
         userId: string,

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -291,6 +291,37 @@ export class ChallengeService extends ChallengeRegistry {
         })
     }
 
+    getChallengesForLocation(
+        child: string,
+        gameVersion: GameVersion,
+    ): GroupIndexedChallengeLists {
+        const locations = getVersionedConfig<PeacockLocationsData>(
+            "LocationsData",
+            gameVersion,
+            true,
+        )
+        const parent = locations.children[child].Properties.ParentLocation
+        const location = locations.children[child]
+        assert.ok(location)
+
+        let contracts =
+            child === "LOCATION_AUSTRIA" ||
+            child === "LOCATION_SALTY_SEAGULL" ||
+            child === "LOCATION_CAGED_FALCON"
+                ? this.controller.missionsInLocations.sniper[child]
+                : this.controller.missionsInLocations[child]
+        if (!contracts) {
+            contracts = []
+        }
+
+        return this.getGroupedChallengeLists({
+            type: ChallengeFilterType.Contracts,
+            contractIds: contracts,
+            locationId: child,
+            locationParentId: parent,
+        })
+    }
+
     startContract(
         userId: string,
         sessionId: string,

--- a/components/configSwizzleManager.ts
+++ b/components/configSwizzleManager.ts
@@ -91,6 +91,7 @@ import FrankensteinMmMpTemplate from "../static/FrankensteinMmMpTemplate.json"
 import FrankensteinScoreOverviewTemplate from "../static/FrankensteinScoreOverviewTemplate.json"
 import FrankensteinPlanningTemplate from "../static/FrankensteinPlanningTemplate.json"
 import Videos from "../static/Videos.json"
+import ChallengeLocationTemplate from "../static/ChallengeLocationTemplate.json"
 import ContractSearchPageTemplate from "../static/ContractSearchPageTemplate.json"
 import ContractSearchResponseTemplate from "../static/ContractSearchResponseTemplate.json"
 import LegacyDebriefingChallengesTemplate from "../static/LegacyDebriefingChallengesTemplate.json"
@@ -183,6 +184,7 @@ const configs: Record<string, unknown> = {
     FrankensteinPlanningTemplate,
     FrankensteinScoreOverviewTemplate,
     Videos,
+    ChallengeLocationTemplate,
     ContractSearchPageTemplate,
     ContractSearchResponseTemplate,
     MasteryUnlockablesTemplate,

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -182,7 +182,12 @@ menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
         }
         const parent = locations.children[child].Properties.ParentLocation
         const location = locations.children[child]
-        let contracts = controller.missionsInLocations[child]
+        let contracts =
+            child === "LOCATION_AUSTRIA" ||
+            child === "LOCATION_SALTY_SEAGULL" ||
+            child === "LOCATION_CAGED_FALCON"
+                ? controller.missionsInLocations.sniper[child]
+                : controller.missionsInLocations[child]
         let completedChallengesCount = 0
         let challengesCount = 0
 

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -194,11 +194,15 @@ menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
     )
     const career = {
         // TODO: Add data on elusive challenges. They are not shown on the Career->Challenges page. What the client does with this information is unclear. They are not supported by Peacock as of v5.6.2.
-        ELUSIVES_UNSUPPORTED: {
-            Children: [],
-            Name: "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ELUSIVE",
-            Location: locations.parents["LOCATION_PARENT_ICA_FACILITY"],
-        },
+        ELUSIVES_UNSUPPORTED:
+            req.gameVersion === "h3"
+                ? {
+                      Children: [],
+                      Name: "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ELUSIVE",
+                      Location:
+                          locations.parents["LOCATION_PARENT_ICA_FACILITY"],
+                  }
+                : {},
     }
     for (const parent in locations.parents) {
         career[parent] = {

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -192,7 +192,14 @@ menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
         req.gameVersion,
         true,
     )
-    const career = {}
+    const career = {
+        // TODO: Add data on elusive challenges. They are not shown on the Career->Challenges page. What the client does with this information is unclear. They are not supported by Peacock as of v5.6.2.
+        ELUSIVES_UNSUPPORTED: {
+            Children: [],
+            Name: "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_ELUSIVE",
+            Location: locations.parents["LOCATION_PARENT_ICA_FACILITY"],
+        },
+    }
     for (const parent in locations.parents) {
         career[parent] = {
             Children: [],

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -138,6 +138,33 @@ menuDataRouter.get(
     "/dashboard/Dashboard_Category_Escalation/:subscriptionId/:type/:id/:mode",
     dashEscalations,
 )
+menuDataRouter.get(
+    "/ChallengeLocation",
+    (req: RequestWithJwt<{ locationId: string }>, res) => {
+        const location = getVersionedConfig<PeacockLocationsData>(
+            "LocationsData",
+            req.gameVersion,
+            true,
+        ).children[req.query.locationId]
+        res.json({
+            template: getVersionedConfig(
+                "ChallengeLocationTemplate",
+                req.gameVersion,
+                false,
+            ),
+            data: {
+                Name: location.DisplayNameLocKey,
+                Location: location,
+                Children:
+                    controller.challengeService.getChallengeDataForLocation(
+                        req.query.locationId,
+                        req.gameVersion,
+                        req.jwt.unique_name,
+                    ),
+            },
+        })
+    },
+)
 
 menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
     swapToBrowsingMenusStatus(req.gameVersion)
@@ -167,10 +194,11 @@ menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
     )
     const career = {}
     for (const parent in locations.parents) {
-        career[parent] = {}
-        career[parent].Children = []
-        career[parent].Location = locations.parents[parent]
-        career[parent].Name = locations.parents[parent].DisplayNameLocKey
+        career[parent] = {
+            Children: [],
+            Location: locations.parents[parent],
+            Name: locations.parents[parent].DisplayNameLocKey,
+        }
     }
     for (const child in locations.children) {
         if (

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -290,9 +290,9 @@ export async function missionEnd(
     const opportunities = contractData.Metadata.Opportunities
     const opportunityCount = opportunities ? opportunities.length : 0
     const opportunityCompleted = opportunities
-        ? opportunities.filter((ms) => (
-              ms in userData.Extensions.opportunityprogression
-          )).length
+        ? opportunities.filter(
+              (ms) => ms in userData.Extensions.opportunityprogression,
+          ).length
         : 0
     const result = {
         MissionReward: {

--- a/static/ChallengeLocationTemplate.json
+++ b/static/ChallengeLocationTemplate.json
@@ -1,0 +1,2144 @@
+{
+    "buttons": [
+        {
+            "actiontype": "accept",
+            "actionlabel": "$loc UI_BUTTON_PROMPTS_ACTION_SELECT"
+        },
+        {
+            "actiontype": "cancel",
+            "actionlabel": "$loc UI_BUTTON_PROMPTS_ACTION_BACK"
+        }
+    ],
+    "background": { "url": "$res $.Location.Properties.Icon" },
+    "onpageclosed": { "set-mastery-data": {} },
+    "body": {
+        "controller": "list",
+        "data": { "direction": "vertical" },
+        "children": [
+            {
+                "controller": "group",
+                "id": "headline_container",
+                "row": 4.25,
+                "col": 0,
+                "selectable": false,
+                "pressable": false,
+                "_comment": "the container that will hold the HeadlineElement. It will show info on whatever item is selected",
+                "children": {
+                    "id": "headline_element",
+                    "view": "menu3.basic.HeadlineElement"
+                }
+            },
+            { "controller": "list", "id": "category_container" },
+            {
+                "controller": "category",
+                "container": "category_container",
+                "view": "menu3.containers.ScrollingTabsContainer",
+                "direction": "horizontal",
+                "ncols": 10,
+                "data": {
+                    "direction": "horizontal",
+                    "buttonprompts": [
+                        {
+                            "actiontype": ["lb", "rb"],
+                            "actionlabel": "$loc UI_BUTTON_PROMPTS_BROWSE_CATEGORIES"
+                        }
+                    ],
+                    "topnavigation": {
+                        "title": "$loc UI_MENU_PAGE_PROFILE_CHALLENGES",
+                        "icon": "challenge"
+                    }
+                },
+                "children": {
+                    "$setpageargs": { "DifficultyLevelUnlocked": true },
+                    "view": "menu3.basic.CategoryElement",
+                    "id": "$formatstring challengelocation_difficulty_normal_tab",
+                    "data": {
+                        "header": "$loc UI_MENU_PAGE_PROFILE_CHALLENGES",
+                        "title": {
+                            "$if $.Location": {
+                                "$then": "$loc $formatstring UI_{$.Location.Id}_TITLE",
+                                "$else": "$loc $.Name"
+                            }
+                        },
+                        "icon": "challenge"
+                    },
+                    "children": {
+                        "$if $eq ($arraysize $.Children,0)": {
+                            "$then": {
+                                "$setup": {
+                                    "$set Title": "$loc UI_MENU_PAGE_NO_CHALLENGES_AVAILABLE",
+                                    "$in": {
+                                        "view": "menu3.basic.DefaultNoContentHeader",
+                                        "selectable": false,
+                                        "pressable": false,
+                                        "data": {
+                                            "header": "$.Header",
+                                            "title": "$.Title",
+                                            "typeicon": {
+                                                "$if $.Icon": {
+                                                    "$then": "$.Icon",
+                                                    "$else": "info"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "$else": [
+                                {
+                                    "controller": "list",
+                                    "id": "sub_category_container",
+                                    "row": 0.1,
+                                    "col": 0,
+                                    "_comment": "enable analog handling to allow the submenu to handle LT/RT",
+                                    "handleanalog": true,
+                                    "actions": {
+                                        "$if $not $arg _isingame": {
+                                            "$then": {
+                                                "on-add-child": {
+                                                    "show-background-layers": {
+                                                        "showMenuBackgroundFullOverlay": true
+                                                    }
+                                                },
+                                                "on-remove-child": {
+                                                    "show-background-layers": {
+                                                        "showMenuBackgroundFullOverlay": false
+                                                    }
+                                                },
+                                                "on-page-closed": {
+                                                    "show-background-layers": {
+                                                        "showMenuBackgroundFullOverlay": false
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "$setpageargs": {
+                                        "ShowPrevNextButtonPrompt": "$gt ($arraysize $.Children,1)"
+                                    },
+                                    "controller": "category",
+                                    "id": "sub_category_controller",
+                                    "container": "sub_category_container",
+                                    "view": "menu3.containers.ScrollingTabsContainer",
+                                    "direction": "horizontal",
+                                    "submenu-navigation": true,
+                                    "prevnextnav": true,
+                                    "ncols": 10,
+                                    "data": {
+                                        "direction": "horizontal",
+                                        "submenu": true
+                                    },
+                                    "children": {
+                                        "$each $.Children": {
+                                            "id": "$formatstring challenge_category_{$.Name}",
+                                            "view": "menu3.basic.SubCategoryElement",
+                                            "data": {
+                                                "$setup": {
+                                                    "$set totalcompleted": "$formatstring {$.CompletedChallengesCount, .f}",
+                                                    "$set totalcount": "$formatstring {$.ChallengesCount, .f}",
+                                                    "$in": {
+                                                        "title": "$formatstring {$loc $.Name}  {$.totalcompleted} / {$.totalcount}"
+                                                    }
+                                                }
+                                            },
+                                            "buttons": [
+                                                {
+                                                    "$if $arg ShowPrevNextButtonPrompt": {
+                                                        "$then": {
+                                                            "actiontype": "lt_rt",
+                                                            "actionlabel": "$loc UI_BUTTON_PROMPTS_ACTION_PREVNEXT_CATEGORY",
+                                                            "customplatform": {
+                                                                "platform": "key",
+                                                                "hide": true,
+                                                                "actiontype": "mouse_lmb"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "children": {
+                                                "$use $.SwitchData.Data": {
+                                                    "$if $eq ($arraysize $.Challenges,0)": {
+                                                        "$then": {
+                                                            "$setup": {
+                                                                "$set Title": "$loc UI_MENU_PAGE_NO_CHALLENGES_AVAILABLE",
+                                                                "$in": {
+                                                                    "view": "menu3.basic.DefaultNoContentHeader",
+                                                                    "selectable": false,
+                                                                    "pressable": false,
+                                                                    "data": {
+                                                                        "header": "$.Header",
+                                                                        "title": "$.Title",
+                                                                        "typeicon": {
+                                                                            "$if $.Icon": {
+                                                                                "$then": "$.Icon",
+                                                                                "$else": "info"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "$else": {
+                                                            "$merge": [
+                                                                {
+                                                                    "controller": "list",
+                                                                    "col": 3,
+                                                                    "row": 3,
+                                                                    "selectable": false,
+                                                                    "pressable": false,
+                                                                    "id": "detail_view_container",
+                                                                    "children": []
+                                                                },
+                                                                {
+                                                                    "controller": "context-selector",
+                                                                    "id": "context_selector_container",
+                                                                    "context-activation-input": "down",
+                                                                    "target": "$formatstring challenge_list_{$.CategoryData.Name}",
+                                                                    "target-context": "challenge_action_container",
+                                                                    "children": [
+                                                                        {
+                                                                            "controller": "filter",
+                                                                            "id": "$formatstring challenge_list_{$.CategoryData.Name}",
+                                                                            "view": "menu3.containers.ThumbnailScrollingListContainer",
+                                                                            "row": 1.0,
+                                                                            "nrows": 1,
+                                                                            "ncols": 10,
+                                                                            "height": 660,
+                                                                            "direction": "horizontal",
+                                                                            "data": {
+                                                                                "direction": "horizontal",
+                                                                                "hidescrollbar": true,
+                                                                                "masktopoffset": 70,
+                                                                                "maskleftoffset": 250,
+                                                                                "isleaf": true,
+                                                                                "treenav": true,
+                                                                                "hasprevious": "$.HasPrevious",
+                                                                                "hasnext": "$.HasNext",
+                                                                                "previousicon": "$.PreviousCategoryIcon",
+                                                                                "nexticon": "$.NextCategoryIcon",
+                                                                                "containeremptydata": {
+                                                                                    "title": "$loc $.CategoryData.Name",
+                                                                                    "totalcompleted": "$formatstring {$.CategoryData.CompletedChallengesCount, .0f}",
+                                                                                    "totalcount": "$formatstring {$.CategoryData.ChallengesCount, .0f}",
+                                                                                    "icon": "$.CategoryData.Icon",
+                                                                                    "image": "$res $.CategoryData.Image"
+                                                                                }
+                                                                            },
+                                                                            "actions": {
+                                                                                "on-filtered-list-empty": [
+                                                                                    {
+                                                                                        "replace-children": {
+                                                                                            "target": "detail_view_container",
+                                                                                            "children": {}
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "replace-children": {
+                                                                                            "target": "challenge_action_container",
+                                                                                            "children": null
+                                                                                        }
+                                                                                    }
+                                                                                ],
+                                                                                "on-filtered-list-not-empty": [
+                                                                                    {
+                                                                                        "replace-children": {
+                                                                                            "target": "headline_container",
+                                                                                            "children": {}
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "$if $not $arg DisableChallengesMasteryHandling": {
+                                                                                            "$then": {
+                                                                                                "set-mastery-data": {
+                                                                                                    "$setup": {
+                                                                                                        "$set ValidContractType": {
+                                                                                                            "$if $isnull $.Contract": {
+                                                                                                                "$then": true,
+                                                                                                                "$else": {
+                                                                                                                    "$switch $.Contract.Metadata.Type": [
+                                                                                                                        {
+                                                                                                                            "case": "usercreated",
+                                                                                                                            "return": false
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "featured",
+                                                                                                                            "return": false
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "default": true
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$set HideProgression": {
+                                                                                                            "$if $isnull $.CompletionData": {
+                                                                                                                "$then": "$.Data.LocationHideProgression",
+                                                                                                                "$else": "$.CompletionData.HideProgression"
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$set MasteryTitle": {
+                                                                                                            "$if $isnull $.CompletionData": {
+                                                                                                                "$then": "$formatstring {$.Data.LocationLevel,.0f}/{$.Data.LocationMaxLevel,.0f}",
+                                                                                                                "$else": "$formatstring {$.CompletionData.Level,.0f}/{$.CompletionData.MaxLevel,.0f}"
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$set MasteryCompletion": {
+                                                                                                            "$if $isnull $.CompletionData": {
+                                                                                                                "$then": "$.Data.LocationCompletion",
+                                                                                                                "$else": "$.CompletionData.Completion"
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$set MasteryXpLeft": {
+                                                                                                            "$if $isnull $.CompletionData": {
+                                                                                                                "$then": "$.Data.LocationXpLeft",
+                                                                                                                "$else": "$.CompletionData.XpLeft"
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$set NameLocalized": {
+                                                                                                            "$if $isnull $.CompletionData.Name": {
+                                                                                                                "$then": "$loc UI_MENU_PAGE_MASTERY_TITLE",
+                                                                                                                "$else": "$loc $.CompletionData.Name"
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$set IsLocationProgression": {
+                                                                                                            "$if": {
+                                                                                                                "$condition": {
+                                                                                                                    "$or": [
+                                                                                                                        "$isnull $.CompletionData",
+                                                                                                                        "$.CompletionData.IsLocationProgression"
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                "$then": true,
+                                                                                                                "$else": false
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$set ShowUnit": {
+                                                                                                            "$if $.IsLocationProgression": {
+                                                                                                                "$then": true,
+                                                                                                                "$else": false
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$in": {
+                                                                                                            "$if": {
+                                                                                                                "$condition": {
+                                                                                                                    "$and": [
+                                                                                                                        "$arg _isonline",
+                                                                                                                        "$not $.HideProgression",
+                                                                                                                        "$.ValidContractType"
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                "$then": {
+                                                                                                                    "masteryheader": "$.NameLocalized",
+                                                                                                                    "masterytitle": "$.MasteryTitle",
+                                                                                                                    "masterycompletion": "$.MasteryCompletion",
+                                                                                                                    "masteryxpleft": "$.MasteryXpLeft",
+                                                                                                                    "showUnit": "$.ShowUnit"
+                                                                                                                },
+                                                                                                                "$else": {}
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                ],
+                                                                                "on-remove-child": {
+                                                                                    "save-ui-options": "",
+                                                                                    "replace-children": {
+                                                                                        "target": "headline_container",
+                                                                                        "children": []
+                                                                                    }
+                                                                                },
+                                                                                "on-page-closed": {
+                                                                                    "save-ui-options": ""
+                                                                                }
+                                                                            },
+                                                                            "filter-option-id": "UI_OPTION_GAME_CHALLENGES_FILTER",
+                                                                            "filter-toggle-action": "action-y",
+                                                                            "filter-definitions": [
+                                                                                {
+                                                                                    "_comment": "no filter",
+                                                                                    "toggle-button-title": "$loc UI_MENU_PAGE_CHALLENGES_NOT_COMPLETED",
+                                                                                    "predicate": true,
+                                                                                    "default-filter": true
+                                                                                },
+                                                                                {
+                                                                                    "_comment": "show unfinished challenges",
+                                                                                    "toggle-button-title": "$loc UI_MENU_PAGE_CHALLENGES_COMPLETED",
+                                                                                    "predicate": {
+                                                                                        "$notransform": {
+                                                                                            "$if $.data.completed": {
+                                                                                                "$then": false,
+                                                                                                "$else": true
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "actions": {
+                                                                                        "$setup": {
+                                                                                            "$set HeadlineTitle": "UI_MENU_PAGE_NO_UNCOMPLETED_CHALLENGES_AVAILABLE",
+                                                                                            "$in": {
+                                                                                                "select": [
+                                                                                                    {
+                                                                                                        "replace-children": {
+                                                                                                            "target": "headline_container",
+                                                                                                            "children": {
+                                                                                                                "view": "menu3.basic.HeadlineElement",
+                                                                                                                "selectable": false,
+                                                                                                                "pressable": false,
+                                                                                                                "data": {
+                                                                                                                    "header": "",
+                                                                                                                    "title": {
+                                                                                                                        "$loc": {
+                                                                                                                            "key": "$.HeadlineTitle",
+                                                                                                                            "data": "$loc $.CategoryData.Name"
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "typeicon": "$.CategoryData.Icon",
+                                                                                                                    "multilinetitle": true
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "set-mastery-data": {
+                                                                                                            "$setup": {
+                                                                                                                "$set ValidContractType": {
+                                                                                                                    "$if $isnull $.Contract": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": {
+                                                                                                                            "$switch $.Contract.Metadata.Type": [
+                                                                                                                                {
+                                                                                                                                    "case": "usercreated",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "case": "featured",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "default": true
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set HideProgression": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationHideProgression",
+                                                                                                                        "$else": "$.CompletionData.HideProgression"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryTitle": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$formatstring {$.Data.LocationLevel,.0f}/{$.Data.LocationMaxLevel,.0f}",
+                                                                                                                        "$else": "$formatstring {$.CompletionData.Level,.0f}/{$.CompletionData.MaxLevel,.0f}"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryCompletion": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationCompletion",
+                                                                                                                        "$else": "$.CompletionData.Completion"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryXpLeft": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationXpLeft",
+                                                                                                                        "$else": "$.CompletionData.XpLeft"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set NameLocalized": {
+                                                                                                                    "$if $isnull $.CompletionData.Name": {
+                                                                                                                        "$then": "$loc UI_MENU_PAGE_MASTERY_TITLE",
+                                                                                                                        "$else": "$loc $.CompletionData.Name"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set IsLocationProgression": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$or": [
+                                                                                                                                "$isnull $.CompletionData",
+                                                                                                                                "$.CompletionData.IsLocationProgression"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set ShowUnit": {
+                                                                                                                    "$if $.IsLocationProgression": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$in": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$and": [
+                                                                                                                                "$arg _isonline",
+                                                                                                                                "$not $.HideProgression",
+                                                                                                                                "$.ValidContractType"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": {
+                                                                                                                            "masteryheader": "$.NameLocalized",
+                                                                                                                            "masterytitle": "$.MasteryTitle",
+                                                                                                                            "masterycompletion": "$.MasteryCompletion",
+                                                                                                                            "masteryxpleft": "$.MasteryXpLeft",
+                                                                                                                            "showUnit": "$.ShowUnit"
+                                                                                                                        },
+                                                                                                                        "$else": {}
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                ],
+                                                                                                "on-filtered-list-empty": [
+                                                                                                    {
+                                                                                                        "replace-children": {
+                                                                                                            "target": "headline_container",
+                                                                                                            "children": {
+                                                                                                                "view": "menu3.basic.HeadlineElement",
+                                                                                                                "selectable": false,
+                                                                                                                "pressable": false,
+                                                                                                                "data": {
+                                                                                                                    "header": "",
+                                                                                                                    "title": {
+                                                                                                                        "$loc": {
+                                                                                                                            "key": "$.HeadlineTitle",
+                                                                                                                            "data": "$loc $.CategoryData.Name"
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "typeicon": "$.CategoryData.Icon",
+                                                                                                                    "multilinetitle": true
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "set-mastery-data": {
+                                                                                                            "$setup": {
+                                                                                                                "$set ValidContractType": {
+                                                                                                                    "$if $isnull $.Contract": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": {
+                                                                                                                            "$switch $.Contract.Metadata.Type": [
+                                                                                                                                {
+                                                                                                                                    "case": "usercreated",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "case": "featured",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "default": true
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set HideProgression": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationHideProgression",
+                                                                                                                        "$else": "$.CompletionData.HideProgression"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryTitle": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$formatstring {$.Data.LocationLevel,.0f}/{$.Data.LocationMaxLevel,.0f}",
+                                                                                                                        "$else": "$formatstring {$.CompletionData.Level,.0f}/{$.CompletionData.MaxLevel,.0f}"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryCompletion": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationCompletion",
+                                                                                                                        "$else": "$.CompletionData.Completion"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryXpLeft": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationXpLeft",
+                                                                                                                        "$else": "$.CompletionData.XpLeft"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set NameLocalized": {
+                                                                                                                    "$if $isnull $.CompletionData.Name": {
+                                                                                                                        "$then": "$loc UI_MENU_PAGE_MASTERY_TITLE",
+                                                                                                                        "$else": "$loc $.CompletionData.Name"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set IsLocationProgression": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$or": [
+                                                                                                                                "$isnull $.CompletionData",
+                                                                                                                                "$.CompletionData.IsLocationProgression"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set ShowUnit": {
+                                                                                                                    "$if $.IsLocationProgression": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$in": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$and": [
+                                                                                                                                "$arg _isonline",
+                                                                                                                                "$not $.HideProgression",
+                                                                                                                                "$.ValidContractType"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": {
+                                                                                                                            "masteryheader": "$.NameLocalized",
+                                                                                                                            "masterytitle": "$.MasteryTitle",
+                                                                                                                            "masterycompletion": "$.MasteryCompletion",
+                                                                                                                            "masteryxpleft": "$.MasteryXpLeft",
+                                                                                                                            "showUnit": "$.ShowUnit"
+                                                                                                                        },
+                                                                                                                        "$else": {}
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "_comment": "show completed challenges",
+                                                                                    "toggle-button-title": "$loc UI_MENU_PAGE_NO_FILTER",
+                                                                                    "predicate": {
+                                                                                        "$notransform": {
+                                                                                            "$if $.data.completed": {
+                                                                                                "$then": true,
+                                                                                                "$else": false
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "actions": {
+                                                                                        "$setup": {
+                                                                                            "$set HeadlineTitle": "UI_MENU_PAGE_NO_COMPLETED_CHALLENGES_AVAILABLE",
+                                                                                            "$in": {
+                                                                                                "select": [
+                                                                                                    {
+                                                                                                        "replace-children": {
+                                                                                                            "target": "headline_container",
+                                                                                                            "children": {
+                                                                                                                "view": "menu3.basic.HeadlineElement",
+                                                                                                                "selectable": false,
+                                                                                                                "pressable": false,
+                                                                                                                "data": {
+                                                                                                                    "header": "",
+                                                                                                                    "title": {
+                                                                                                                        "$loc": {
+                                                                                                                            "key": "$.HeadlineTitle",
+                                                                                                                            "data": "$loc $.CategoryData.Name"
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "typeicon": "$.CategoryData.Icon",
+                                                                                                                    "multilinetitle": true
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "set-mastery-data": {
+                                                                                                            "$setup": {
+                                                                                                                "$set ValidContractType": {
+                                                                                                                    "$if $isnull $.Contract": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": {
+                                                                                                                            "$switch $.Contract.Metadata.Type": [
+                                                                                                                                {
+                                                                                                                                    "case": "usercreated",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "case": "featured",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "default": true
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set HideProgression": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationHideProgression",
+                                                                                                                        "$else": "$.CompletionData.HideProgression"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryTitle": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$formatstring {$.Data.LocationLevel,.0f}/{$.Data.LocationMaxLevel,.0f}",
+                                                                                                                        "$else": "$formatstring {$.CompletionData.Level,.0f}/{$.CompletionData.MaxLevel,.0f}"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryCompletion": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationCompletion",
+                                                                                                                        "$else": "$.CompletionData.Completion"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryXpLeft": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationXpLeft",
+                                                                                                                        "$else": "$.CompletionData.XpLeft"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set NameLocalized": {
+                                                                                                                    "$if $isnull $.CompletionData.Name": {
+                                                                                                                        "$then": "$loc UI_MENU_PAGE_MASTERY_TITLE",
+                                                                                                                        "$else": "$loc $.CompletionData.Name"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set IsLocationProgression": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$or": [
+                                                                                                                                "$isnull $.CompletionData",
+                                                                                                                                "$.CompletionData.IsLocationProgression"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set ShowUnit": {
+                                                                                                                    "$if $.IsLocationProgression": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$in": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$and": [
+                                                                                                                                "$arg _isonline",
+                                                                                                                                "$not $.HideProgression",
+                                                                                                                                "$.ValidContractType"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": {
+                                                                                                                            "masteryheader": "$.NameLocalized",
+                                                                                                                            "masterytitle": "$.MasteryTitle",
+                                                                                                                            "masterycompletion": "$.MasteryCompletion",
+                                                                                                                            "masteryxpleft": "$.MasteryXpLeft",
+                                                                                                                            "showUnit": "$.ShowUnit"
+                                                                                                                        },
+                                                                                                                        "$else": {}
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                ],
+                                                                                                "on-filtered-list-empty": [
+                                                                                                    {
+                                                                                                        "replace-children": {
+                                                                                                            "target": "headline_container",
+                                                                                                            "children": {
+                                                                                                                "view": "menu3.basic.HeadlineElement",
+                                                                                                                "selectable": false,
+                                                                                                                "pressable": false,
+                                                                                                                "data": {
+                                                                                                                    "header": "",
+                                                                                                                    "title": {
+                                                                                                                        "$loc": {
+                                                                                                                            "key": "$.HeadlineTitle",
+                                                                                                                            "data": "$loc $.CategoryData.Name"
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "typeicon": "$.CategoryData.Icon",
+                                                                                                                    "multilinetitle": true
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "set-mastery-data": {
+                                                                                                            "$setup": {
+                                                                                                                "$set ValidContractType": {
+                                                                                                                    "$if $isnull $.Contract": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": {
+                                                                                                                            "$switch $.Contract.Metadata.Type": [
+                                                                                                                                {
+                                                                                                                                    "case": "usercreated",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "case": "featured",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "default": true
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set HideProgression": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationHideProgression",
+                                                                                                                        "$else": "$.CompletionData.HideProgression"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryTitle": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$formatstring {$.Data.LocationLevel,.0f}/{$.Data.LocationMaxLevel,.0f}",
+                                                                                                                        "$else": "$formatstring {$.CompletionData.Level,.0f}/{$.CompletionData.MaxLevel,.0f}"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryCompletion": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationCompletion",
+                                                                                                                        "$else": "$.CompletionData.Completion"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryXpLeft": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationXpLeft",
+                                                                                                                        "$else": "$.CompletionData.XpLeft"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set NameLocalized": {
+                                                                                                                    "$if $isnull $.CompletionData.Name": {
+                                                                                                                        "$then": "$loc UI_MENU_PAGE_MASTERY_TITLE",
+                                                                                                                        "$else": "$loc $.CompletionData.Name"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set IsLocationProgression": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$or": [
+                                                                                                                                "$isnull $.CompletionData",
+                                                                                                                                "$.CompletionData.IsLocationProgression"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set ShowUnit": {
+                                                                                                                    "$if $.IsLocationProgression": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$in": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$and": [
+                                                                                                                                "$arg _isonline",
+                                                                                                                                "$not $.HideProgression",
+                                                                                                                                "$.ValidContractType"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": {
+                                                                                                                            "masteryheader": "$.NameLocalized",
+                                                                                                                            "masterytitle": "$.MasteryTitle",
+                                                                                                                            "masterycompletion": "$.MasteryCompletion",
+                                                                                                                            "masteryxpleft": "$.MasteryXpLeft",
+                                                                                                                            "showUnit": "$.ShowUnit"
+                                                                                                                        },
+                                                                                                                        "$else": {}
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "children": {
+                                                                                "$each $.Challenges": {
+                                                                                    "view": "menu3.basic.ThumbnailItemTile",
+                                                                                    "id": "$formatstring challengeItem_{$.Name}",
+                                                                                    "nrows": 1,
+                                                                                    "ncols": 1,
+                                                                                    "pressable": false,
+                                                                                    "data": {
+                                                                                        "ondemand": true,
+                                                                                        "showningame": {
+                                                                                            "$if $arg _isingame": {
+                                                                                                "$then": true,
+                                                                                                "$else": false
+                                                                                            }
+                                                                                        },
+                                                                                        "image": "$res $.ImageName",
+                                                                                        "completed": "$.Completed",
+                                                                                        "desaturateNotComplete": true,
+                                                                                        "icon": {
+                                                                                            "$if $.Completed": {
+                                                                                                "$then": "check"
+                                                                                            }
+                                                                                        },
+                                                                                        "icon2": {
+                                                                                            "$if $gt ($arraysize $.DifficultyLevels,0)": {
+                                                                                                "$then": {
+                                                                                                    "$setup": {
+                                                                                                        "$set DifficultyLevelsOrdered": {
+                                                                                                            "$orderby": {
+                                                                                                                "from": "$.DifficultyLevels",
+                                                                                                                "by": "",
+                                                                                                                "order": [
+                                                                                                                    "easy",
+                                                                                                                    "normal",
+                                                                                                                    "hard"
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$in": {
+                                                                                                            "$switch $.DifficultyLevelsOrdered[0]": [
+                                                                                                                {
+                                                                                                                    "case": "easy",
+                                                                                                                    "return": "difficultyeasy"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "case": "normal",
+                                                                                                                    "return": "difficultynormal"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "case": "hard",
+                                                                                                                    "return": "difficultyhard"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "default": null
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "actions": {
+                                                                                        "select": [
+                                                                                            {
+                                                                                                "replace-children": {
+                                                                                                    "target": "detail_view_container",
+                                                                                                    "children": {
+                                                                                                        "selectable": false,
+                                                                                                        "children": {
+                                                                                                            "$if $.Completed": {
+                                                                                                                "$then": {
+                                                                                                                    "view": "menu3.ChallengeDetailTile",
+                                                                                                                    "selectable": false,
+                                                                                                                    "pressable": false,
+                                                                                                                    "data": {
+                                                                                                                        "header": "$loc $.CategoryName",
+                                                                                                                        "title": "$loc $.Name",
+                                                                                                                        "icon": "$.Icon",
+                                                                                                                        "description": "$loc $.Description",
+                                                                                                                        "rewardsTitle": "$loc UI_MENU_PAGE_PROFILE_CHALLENGES_DETAILS_REWARDS",
+                                                                                                                        "unlocks": {
+                                                                                                                            "$each $.Drops": {
+                                                                                                                                "$setup": {
+                                                                                                                                    "$set Item": "$item $.",
+                                                                                                                                    "$in": {
+                                                                                                                                        "name": "$.Item.name",
+                                                                                                                                        "image": "$.Item.image",
+                                                                                                                                        "rarity": "$.Item.rarity",
+                                                                                                                                        "perks": "$($repository $.Item.repositoryid).Perks",
+                                                                                                                                        "multiplier": "$.Item.multiplier"
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        },
+                                                                                                                        "isnew": "$.IsNew",
+                                                                                                                        "status": {
+                                                                                                                            "$if $.Completed": {
+                                                                                                                                "$then": "$loc UI_MENU_PAGE_PROFILE_CHALLENGE_ACCOMPLISHED",
+                                                                                                                                "$else": "$loc UI_MENU_PAGE_PROFILE_CHALLENGE_NOT_ACCOMPLISHED"
+                                                                                                                            }
+                                                                                                                        },
+                                                                                                                        "completed": "$.Completed",
+                                                                                                                        "statusdate": "",
+                                                                                                                        "disablerewards": "$.HideProgression",
+                                                                                                                        "rewards": [
+                                                                                                                            {
+                                                                                                                                "name": "$loc UI_PERFORMANCE_MASTERY_XP",
+                                                                                                                                "amount": "$.Rewards.MasteryXP"
+                                                                                                                            }
+                                                                                                                        ],
+                                                                                                                        "progress": "$.ChallengeProgress"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$else": {
+                                                                                                                    "$if $eq ($queryoption UI_OPTION_GAME_AID_CHALLENGEDESCRIPTION,2)": {
+                                                                                                                        "$then": {
+                                                                                                                            "view": "menu3.ChallengeDetailTile",
+                                                                                                                            "selectable": false,
+                                                                                                                            "pressable": false,
+                                                                                                                            "data": {
+                                                                                                                                "header": "",
+                                                                                                                                "title": "",
+                                                                                                                                "description": "$loc UI_MENU_PAGE_CHALLENGES_VERBOSITY_WARNING",
+                                                                                                                                "rewardsTitle": "$loc UI_MENU_PAGE_PROFILE_CHALLENGES_DETAILS_REWARDS",
+                                                                                                                                "unlocks": {
+                                                                                                                                    "$each $.Drops": {
+                                                                                                                                        "$setup": {
+                                                                                                                                            "$set Item": "$item $.",
+                                                                                                                                            "$in": {
+                                                                                                                                                "name": "$.Item.name",
+                                                                                                                                                "image": "$.Item.image",
+                                                                                                                                                "rarity": "$.Item.rarity",
+                                                                                                                                                "perks": "$($repository $.Item.repositoryid).Perks",
+                                                                                                                                                "multiplier": "$.Item.multiplier"
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                },
+                                                                                                                                "isnew": "$.IsNew",
+                                                                                                                                "status": "$loc UI_MENU_PAGE_PROFILE_CHALLENGE_NOT_ACCOMPLISHED",
+                                                                                                                                "completed": false,
+                                                                                                                                "statusdate": "",
+                                                                                                                                "disablerewards": "$.HideProgression",
+                                                                                                                                "rewards": [
+                                                                                                                                    {
+                                                                                                                                        "name": "$loc UI_PERFORMANCE_MASTERY_XP",
+                                                                                                                                        "amount": "$.Rewards.MasteryXP"
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        },
+                                                                                                                        "$else": {
+                                                                                                                            "$if $eq ($queryoption UI_OPTION_GAME_AID_CHALLENGEDESCRIPTION,1)": {
+                                                                                                                                "$then": {
+                                                                                                                                    "view": "menu3.ChallengeDetailTile",
+                                                                                                                                    "selectable": false,
+                                                                                                                                    "pressable": false,
+                                                                                                                                    "data": {
+                                                                                                                                        "header": "$loc $.CategoryName",
+                                                                                                                                        "title": "$loc $.Name",
+                                                                                                                                        "icon": "$.Icon",
+                                                                                                                                        "description": "$loc UI_MENU_PAGE_CHALLENGES_VERBOSITY_WARNING",
+                                                                                                                                        "rewardsTitle": "$loc UI_MENU_PAGE_PROFILE_CHALLENGES_DETAILS_REWARDS",
+                                                                                                                                        "unlocks": {
+                                                                                                                                            "$each $.Drops": {
+                                                                                                                                                "$setup": {
+                                                                                                                                                    "$set Item": "$item $.",
+                                                                                                                                                    "$in": {
+                                                                                                                                                        "name": "$.Item.name",
+                                                                                                                                                        "image": "$.Item.image",
+                                                                                                                                                        "rarity": "$.Item.rarity",
+                                                                                                                                                        "perks": "$($repository $.Item.repositoryid).Perks",
+                                                                                                                                                        "multiplier": "$.Item.multiplier"
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        },
+                                                                                                                                        "isnew": "$.IsNew",
+                                                                                                                                        "status": "$loc UI_MENU_PAGE_PROFILE_CHALLENGE_NOT_ACCOMPLISHED",
+                                                                                                                                        "completed": false,
+                                                                                                                                        "statusdate": "",
+                                                                                                                                        "disablerewards": "$.HideProgression",
+                                                                                                                                        "rewards": [
+                                                                                                                                            {
+                                                                                                                                                "name": "$loc UI_PERFORMANCE_MASTERY_XP",
+                                                                                                                                                "amount": "$.Rewards.MasteryXP"
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                },
+                                                                                                                                "$else": {
+                                                                                                                                    "view": "menu3.ChallengeDetailTile",
+                                                                                                                                    "selectable": false,
+                                                                                                                                    "pressable": false,
+                                                                                                                                    "data": {
+                                                                                                                                        "header": "$loc $.CategoryName",
+                                                                                                                                        "title": "$loc $.Name",
+                                                                                                                                        "icon": "$.Icon",
+                                                                                                                                        "description": "$loc $.Description",
+                                                                                                                                        "rewardsTitle": "$loc UI_MENU_PAGE_PROFILE_CHALLENGES_DETAILS_REWARDS",
+                                                                                                                                        "unlocks": {
+                                                                                                                                            "$each $.Drops": {
+                                                                                                                                                "$setup": {
+                                                                                                                                                    "$set Item": "$item $.",
+                                                                                                                                                    "$in": {
+                                                                                                                                                        "name": "$.Item.name",
+                                                                                                                                                        "image": "$.Item.image",
+                                                                                                                                                        "rarity": "$.Item.rarity",
+                                                                                                                                                        "perks": "$($repository $.Item.repositoryid).Perks",
+                                                                                                                                                        "multiplier": "$.Item.multiplier"
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        },
+                                                                                                                                        "isnew": "$.IsNew",
+                                                                                                                                        "status": {
+                                                                                                                                            "$if $.Completed": {
+                                                                                                                                                "$then": "$loc UI_MENU_PAGE_PROFILE_CHALLENGE_ACCOMPLISHED",
+                                                                                                                                                "$else": "$loc UI_MENU_PAGE_PROFILE_CHALLENGE_NOT_ACCOMPLISHED"
+                                                                                                                                            }
+                                                                                                                                        },
+                                                                                                                                        "completed": "$.Completed",
+                                                                                                                                        "statusdate": "",
+                                                                                                                                        "disablerewards": "$.HideProgression",
+                                                                                                                                        "rewards": [
+                                                                                                                                            {
+                                                                                                                                                "name": "$loc UI_PERFORMANCE_MASTERY_XP",
+                                                                                                                                                "amount": "$.Rewards.MasteryXP"
+                                                                                                                                            }
+                                                                                                                                        ],
+                                                                                                                                        "progress": "$.ChallengeProgress"
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "$if $not $arg DisableChallengesMasteryHandling": {
+                                                                                                    "$then": {
+                                                                                                        "set-mastery-data": {
+                                                                                                            "$setup": {
+                                                                                                                "$set ValidContractType": {
+                                                                                                                    "$if $isnull $.Contract": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": {
+                                                                                                                            "$switch $.Contract.Metadata.Type": [
+                                                                                                                                {
+                                                                                                                                    "case": "usercreated",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "case": "featured",
+                                                                                                                                    "return": false
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "default": true
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set HideProgression": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationHideProgression",
+                                                                                                                        "$else": "$.CompletionData.HideProgression"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryTitle": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$formatstring {$.Data.LocationLevel,.0f}/{$.Data.LocationMaxLevel,.0f}",
+                                                                                                                        "$else": "$formatstring {$.CompletionData.Level,.0f}/{$.CompletionData.MaxLevel,.0f}"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryCompletion": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationCompletion",
+                                                                                                                        "$else": "$.CompletionData.Completion"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set MasteryXpLeft": {
+                                                                                                                    "$if $isnull $.CompletionData": {
+                                                                                                                        "$then": "$.Data.LocationXpLeft",
+                                                                                                                        "$else": "$.CompletionData.XpLeft"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set NameLocalized": {
+                                                                                                                    "$if $isnull $.CompletionData.Name": {
+                                                                                                                        "$then": "$loc UI_MENU_PAGE_MASTERY_TITLE",
+                                                                                                                        "$else": "$loc $.CompletionData.Name"
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set IsLocationProgression": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$or": [
+                                                                                                                                "$isnull $.CompletionData",
+                                                                                                                                "$.CompletionData.IsLocationProgression"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$set ShowUnit": {
+                                                                                                                    "$if $.IsLocationProgression": {
+                                                                                                                        "$then": true,
+                                                                                                                        "$else": false
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "$in": {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$and": [
+                                                                                                                                "$arg _isonline",
+                                                                                                                                "$not $.HideProgression",
+                                                                                                                                "$.ValidContractType"
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": {
+                                                                                                                            "masteryheader": "$.NameLocalized",
+                                                                                                                            "masterytitle": "$.MasteryTitle",
+                                                                                                                            "masterycompletion": "$.MasteryCompletion",
+                                                                                                                            "masteryxpleft": "$.MasteryXpLeft",
+                                                                                                                            "showUnit": "$.ShowUnit"
+                                                                                                                        },
+                                                                                                                        "$else": {}
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        ],
+                                                                                        "select-changed": {
+                                                                                            "replace-children": {
+                                                                                                "target": "challenge_action_container",
+                                                                                                "children": {
+                                                                                                    "$if": {
+                                                                                                        "$condition": {
+                                                                                                            "$and": [
+                                                                                                                "$.IsPlayable",
+                                                                                                                {
+                                                                                                                    "$if": {
+                                                                                                                        "$condition": {
+                                                                                                                            "$and": [
+                                                                                                                                "$timeexpired $.UserCentricContract.Contract.Metadata.PlayableUntil",
+                                                                                                                                {
+                                                                                                                                    "$equal": [
+                                                                                                                                        "elusive",
+                                                                                                                                        "$.UserCentricContract.Contract.Metadata.Type"
+                                                                                                                                    ]
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        },
+                                                                                                                        "$then": false,
+                                                                                                                        "$else": true
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "$then": {
+                                                                                                            "view": "menu3.basic.ChallengeActionButton",
+                                                                                                            "pressable": {
+                                                                                                                "$switch $.Type": [
+                                                                                                                    {
+                                                                                                                        "case": "global",
+                                                                                                                        "return": false
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "default": {
+                                                                                                                            "$use $.UserCentricContract": {
+                                                                                                                                "$switch $.Contract.Metadata.Type": [
+                                                                                                                                    {
+                                                                                                                                        "case": "usercreated",
+                                                                                                                                        "return": {
+                                                                                                                                            "$if $($arg _ugcrestricted)": {
+                                                                                                                                                "$then": false,
+                                                                                                                                                "$else": true
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "default": true
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            "data": {
+                                                                                                                "header": {
+                                                                                                                    "$switch $.Type": [
+                                                                                                                        {
+                                                                                                                            "case": "global",
+                                                                                                                            "return": "$loc UI_MENU_PAGE_CHALLENGE_HEADER_GLOBAL"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "contract",
+                                                                                                                            "return": {
+                                                                                                                                "$switch $.UserCentricContract.Contract.Metadata.Type": [
+                                                                                                                                    {
+                                                                                                                                        "case": "campaign",
+                                                                                                                                        "return": "$loc $.UserCentricContract.Contract.Metadata.GroupTitle"
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "case": "flashback",
+                                                                                                                                        "return": {
+                                                                                                                                            "$use $.UserCentricContract": {
+                                                                                                                                                "$if": {
+                                                                                                                                                    "$condition": {
+                                                                                                                                                        "$and": [
+                                                                                                                                                            "$eqs ($.Contract.Metadata.Type,flashback)",
+                                                                                                                                                            "$not $.Data.IsFreeDLC"
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    "$then": {
+                                                                                                                                                        "$if $not $stringvalid $.Contract.Metadata.Subtype": {
+                                                                                                                                                            "$then": "$loc UI_CONTRACT_HEADER_SEASONAL",
+                                                                                                                                                            "$else": "$loc $formatstring UI_CONTRACT_HEADER_{$.Contract.Metadata.Subtype}"
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    "$else": "$loc $formatstring UI_CONTRACT_HEADER_{$.Contract.Metadata.Type}"
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "case": "sniper",
+                                                                                                                                        "return": "$loc $formatstring UI_CONTRACT_HEADER_SNIPER"
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "default": "$loc $formatstring UI_MENU_PAGE_CHALLENGE_HEADER_{$.UserCentricContract.Contract.Metadata.Type}"
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "location",
+                                                                                                                            "return": "$loc UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "parentlocation",
+                                                                                                                            "return": "$loc UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "default": "$loc UI_MENU_PAGE_CHALLENGE_HEADER_CHALLENGE"
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                "title": {
+                                                                                                                    "$switch $.Type": [
+                                                                                                                        {
+                                                                                                                            "case": "global",
+                                                                                                                            "return": "$loc UI_MENU_PAGE_CHALLENGE_TITLE_GLOBAL"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "contract",
+                                                                                                                            "return": "$loc $.UserCentricContract.Contract.Metadata.Title"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "location",
+                                                                                                                            "return": "$loc $formatstring UI_{$.LocationId}_TITLE"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "parentlocation",
+                                                                                                                            "return": "$loc $formatstring UI_{$.ParentLocationId}_CITY"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "default": "$loc $.Name"
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                "icon": {
+                                                                                                                    "$switch $.Type": [
+                                                                                                                        {
+                                                                                                                            "case": "contract",
+                                                                                                                            "return": "mission"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "location",
+                                                                                                                            "return": "location"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "case": "parentlocation",
+                                                                                                                            "return": "location"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "default": "challenge"
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            },
+                                                                                                            "stateproviders": [
+                                                                                                                {
+                                                                                                                    "type": "contractavailability",
+                                                                                                                    "contract": "$.UserCentricContract.Contract"
+                                                                                                                }
+                                                                                                            ],
+                                                                                                            "actions": {
+                                                                                                                "$if": {
+                                                                                                                    "$condition": {
+                                                                                                                        "$or": [
+                                                                                                                            "$eqs ($.Type,parentlocation)",
+                                                                                                                            "$eqs ($.Type,location)"
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    "$then": {
+                                                                                                                        "accept": {
+                                                                                                                            "$switch $arg _pagename": [
+                                                                                                                                {
+                                                                                                                                    "case": "destination",
+                                                                                                                                    "return": [
+                                                                                                                                        {
+                                                                                                                                            "set-selected": {
+                                                                                                                                                "target": "destination_mission_tab"
+                                                                                                                                            }
+                                                                                                                                        },
+                                                                                                                                        {
+                                                                                                                                            "set-selected": {
+                                                                                                                                                "target": "$formatstring {$.LocationId}_container"
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    ]
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "default": {
+                                                                                                                                        "push-menu-context": {
+                                                                                                                                            "onpageopened": {
+                                                                                                                                                "set-selected": {
+                                                                                                                                                    "target": "$formatstring {$.LocationId}_container"
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        },
+                                                                                                                                        "link": {
+                                                                                                                                            "page": "destination",
+                                                                                                                                            "args": {
+                                                                                                                                                "locationId": "$.ParentLocationId",
+                                                                                                                                                "url": "destination",
+                                                                                                                                                "args": {
+                                                                                                                                                    "locationId": "$.ParentLocationId"
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "$else": {
+                                                                                                                        "$switch $.Type": [
+                                                                                                                            {
+                                                                                                                                "case": "global",
+                                                                                                                                "return": {}
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "default": {
+                                                                                                                                    "$use $.UserCentricContract": {
+                                                                                                                                        "$mergeobjects": [
+                                                                                                                                            {
+                                                                                                                                                "on-content-unknown": {
+                                                                                                                                                    "_comment": "No DLC could be found containing contract",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "show-modal": {
+                                                                                                                                                                "config": {
+                                                                                                                                                                    "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                    "buttons": [
+                                                                                                                                                                        "$loc UI_DIALOG_OK"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "data": {
+                                                                                                                                                                        "title": "$loc UI_CONTENT_UNKNOWN_DLC_TITLE",
+                                                                                                                                                                        "description": "$loc UI_CONTENT_UNKNOWN_DLC_TEXT"
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "onbutton": []
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                },
+                                                                                                                                                "on-content-not-owned": {
+                                                                                                                                                    "_comment": "DLC is not owned",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "show-modal": {
+                                                                                                                                                                "config": {
+                                                                                                                                                                    "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                    "buttons": [
+                                                                                                                                                                        "$loc UI_DIALOG_OK"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "data": {
+                                                                                                                                                                        "title": "$loc UI_CONTENT_UNKNOWN_DLC_TITLE",
+                                                                                                                                                                        "description": "$loc UI_CONTENT_UNKNOWN_DLC_TEXT"
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "onbutton": []
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                },
+                                                                                                                                                "on-content-not-installed": {
+                                                                                                                                                    "_comment": "DLC owned but not installed",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "show-modal": {
+                                                                                                                                                                "config": {
+                                                                                                                                                                    "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                    "buttons": [
+                                                                                                                                                                        "$loc UI_DIALOG_OK"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "data": {
+                                                                                                                                                                        "title": "$loc UI_CONTENT_UNKNOWN_DLC_TITLE",
+                                                                                                                                                                        "description": "$loc UI_CONTENT_UNKNOWN_DLC_TEXT"
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "onbutton": []
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                },
+                                                                                                                                                "on-content-downloading": {
+                                                                                                                                                    "_comment": "DLC owned and currently downloading",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "show-modal": {
+                                                                                                                                                                "config": {
+                                                                                                                                                                    "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                    "buttons": [
+                                                                                                                                                                        "$loc UI_DIALOG_OK"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "data": {
+                                                                                                                                                                        "title": "$loc UI_CONTENT_UNKNOWN_DLC_TITLE",
+                                                                                                                                                                        "description": "$loc UI_CONTENT_UNKNOWN_DLC_TEXT"
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "onbutton": []
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                },
+                                                                                                                                                "on-content-update-required": {
+                                                                                                                                                    "_comment": "DLC owned and update is required",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "show-modal": {
+                                                                                                                                                                "config": {
+                                                                                                                                                                    "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                    "buttons": [
+                                                                                                                                                                        "$loc UI_DIALOG_OK"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "data": {
+                                                                                                                                                                        "title": "$loc UI_CONTENT_UNKNOWN_DLC_TITLE",
+                                                                                                                                                                        "description": "$loc UI_CONTENT_UNKNOWN_DLC_TEXT"
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "onbutton": []
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                },
+                                                                                                                                                "on-content-installing": {
+                                                                                                                                                    "_comment": "DLC owned and currently installing",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "show-modal": {
+                                                                                                                                                                "config": {
+                                                                                                                                                                    "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                    "buttons": [
+                                                                                                                                                                        "$loc UI_DIALOG_OK"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "data": {
+                                                                                                                                                                        "title": "$loc UI_CONTENT_UNKNOWN_DLC_TITLE",
+                                                                                                                                                                        "description": "$loc UI_CONTENT_UNKNOWN_DLC_TEXT"
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "onbutton": []
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                },
+                                                                                                                                                "on-entitlement-missing": {
+                                                                                                                                                    "_comment": "Entitlement missing",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "show-modal": {
+                                                                                                                                                                "config": {
+                                                                                                                                                                    "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                    "buttons": [
+                                                                                                                                                                        "$loc UI_DIALOG_OK"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "data": {
+                                                                                                                                                                        "title": "$loc UI_CONTENT_UNKNOWN_DLC_TITLE",
+                                                                                                                                                                        "description": "$loc UI_CONTENT_UNKNOWN_DLC_TEXT"
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "onbutton": []
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "on-content-available": {
+                                                                                                                                                    "_comment": "Contract is ready to be played",
+                                                                                                                                                    "alter-actions": {
+                                                                                                                                                        "path": "accept",
+                                                                                                                                                        "value": {
+                                                                                                                                                            "$if": {
+                                                                                                                                                                "$condition": {
+                                                                                                                                                                    "$and": [
+                                                                                                                                                                        "$.Data.IsLocked",
+                                                                                                                                                                        {
+                                                                                                                                                                            "$or": [
+                                                                                                                                                                                "$isnull $.lockoverride",
+                                                                                                                                                                                "$.lockoverride"
+                                                                                                                                                                            ]
+                                                                                                                                                                        }
+                                                                                                                                                                    ]
+                                                                                                                                                                },
+                                                                                                                                                                "$then": {
+                                                                                                                                                                    "show-modal": {
+                                                                                                                                                                        "config": {
+                                                                                                                                                                            "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                            "buttons": [
+                                                                                                                                                                                "$loc UI_DIALOG_CONFIRM",
+                                                                                                                                                                                {
+                                                                                                                                                                                    "label": "$loc UI_DIALOG_CANCEL",
+                                                                                                                                                                                    "type": "cancel"
+                                                                                                                                                                                }
+                                                                                                                                                                            ],
+                                                                                                                                                                            "data": {
+                                                                                                                                                                                "title": "$loc UI_LOCKED_CONTENT_DIALOGUE_TITLE",
+                                                                                                                                                                                "description": {
+                                                                                                                                                                                    "$switch $.Contract.Metadata.Type": [
+                                                                                                                                                                                        {
+                                                                                                                                                                                            "case": "orbis",
+                                                                                                                                                                                            "return": "$loc UI_LOCKED_CONTENT_DIALOGUE_TEXT_SARAJEVO6"
+                                                                                                                                                                                        },
+                                                                                                                                                                                        {
+                                                                                                                                                                                            "default": "$loc UI_LOCKED_CONTENT_DIALOGUE_TEXT"
+                                                                                                                                                                                        }
+                                                                                                                                                                                    ]
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        },
+                                                                                                                                                                        "onbutton": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "trigger-action": {
+                                                                                                                                                                                    "name": "on-goto-planning"
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                },
+                                                                                                                                                                "$else": {
+                                                                                                                                                                    "trigger-action": {
+                                                                                                                                                                        "name": "on-goto-planning"
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                },
+                                                                                                                                                "on-goto-planning": {
+                                                                                                                                                    "$switch $.Contract.Metadata.Type": [
+                                                                                                                                                        {
+                                                                                                                                                            "case": "creation",
+                                                                                                                                                            "return": {
+                                                                                                                                                                "link": {
+                                                                                                                                                                    "page": "contractcreation_planning",
+                                                                                                                                                                    "args": {
+                                                                                                                                                                        "url": "contractcreation/planning",
+                                                                                                                                                                        "args": {
+                                                                                                                                                                            "location": "$.Contract.Metadata.Location",
+                                                                                                                                                                            "contractCreationIdOverwrite": "$.Contract.Metadata.Id"
+                                                                                                                                                                        },
+                                                                                                                                                                        "contractid": "$.Contract.Metadata.Id"
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        },
+                                                                                                                                                        {
+                                                                                                                                                            "default": {
+                                                                                                                                                                "$if": {
+                                                                                                                                                                    "$condition": {
+                                                                                                                                                                        "$isfreeprologueuser": ""
+                                                                                                                                                                    },
+                                                                                                                                                                    "$then": {
+                                                                                                                                                                        "$if $.fspdashboardcontract": {
+                                                                                                                                                                            "$then": {
+                                                                                                                                                                                "clear-contract-menu-context": {},
+                                                                                                                                                                                "set-contract-loading-screen-data": {
+                                                                                                                                                                                    "contract": "$.Contract"
+                                                                                                                                                                                },
+                                                                                                                                                                                "start-contract": {
+                                                                                                                                                                                    "contractid": "$.fspdashboardcontract.contractid"
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            "$else": {
+                                                                                                                                                                                "is-playable": {
+                                                                                                                                                                                    "playableSince": "$.Contract.Metadata.PlayableSince",
+                                                                                                                                                                                    "on-success": {
+                                                                                                                                                                                        "$merge": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "$if": {
+                                                                                                                                                                                                    "$condition": {
+                                                                                                                                                                                                        "$and": [
+                                                                                                                                                                                                            "$eqs ($.Contract.Metadata.Type,placeholder)",
+                                                                                                                                                                                                            "$.Data.LastPlayedAt",
+                                                                                                                                                                                                            "$.Data.EscalationCompleted"
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    "$then": [
+                                                                                                                                                                                                        {
+                                                                                                                                                                                                            "alter-history": {
+                                                                                                                                                                                                                "target": "destination",
+                                                                                                                                                                                                                "force-no-cache": true
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        {
+                                                                                                                                                                                                            "alter-history": {
+                                                                                                                                                                                                                "target": "hub",
+                                                                                                                                                                                                                "force-no-cache": true
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    ],
+                                                                                                                                                                                                    "$else": null
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "$switch $.Contract.Metadata.BriefingVideo": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "case": null,
+                                                                                                                                                                                                        "return": {
+                                                                                                                                                                                                            "link": {
+                                                                                                                                                                                                                "page": {
+                                                                                                                                                                                                                    "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                        "$then": "planning_multiplayer",
+                                                                                                                                                                                                                        "$else": "planning"
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "isMultiplayer": {
+                                                                                                                                                                                                                    "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                        "$then": true,
+                                                                                                                                                                                                                        "$else": false
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "args": {
+                                                                                                                                                                                                                    "url": "planning",
+                                                                                                                                                                                                                    "args": {
+                                                                                                                                                                                                                        "contractid": "$.Contract.Metadata.Id",
+                                                                                                                                                                                                                        "resetescalation": {
+                                                                                                                                                                                                                            "$if": {
+                                                                                                                                                                                                                                "$condition": {
+                                                                                                                                                                                                                                    "$and": [
+                                                                                                                                                                                                                                        "$eqs ($.Contract.Metadata.Type,placeholder)",
+                                                                                                                                                                                                                                        "$.Data.LastPlayedAt",
+                                                                                                                                                                                                                                        "$.Data.EscalationCompleted"
+                                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "$then": true,
+                                                                                                                                                                                                                                "$else": false
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                    "contractid": "$.Contract.Metadata.Id"
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "default": {
+                                                                                                                                                                                                            "link": {
+                                                                                                                                                                                                                "page": "video",
+                                                                                                                                                                                                                "addtohistory": false,
+                                                                                                                                                                                                                "args": {
+                                                                                                                                                                                                                    "videoid": "$.Contract.Metadata.BriefingVideo",
+                                                                                                                                                                                                                    "mountrootresources": "$formatstring [{$.Contract.Metadata.ScenePath}].entitytemplate",
+                                                                                                                                                                                                                    "skipifshown": true,
+                                                                                                                                                                                                                    "EngineMode": "$.EngineMode",
+                                                                                                                                                                                                                    "link": {
+                                                                                                                                                                                                                        "page": {
+                                                                                                                                                                                                                            "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                                "$then": "planning_multiplayer",
+                                                                                                                                                                                                                                "$else": "planning"
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "isMultiplayer": {
+                                                                                                                                                                                                                            "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                                "$then": true,
+                                                                                                                                                                                                                                "$else": false
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "args": {
+                                                                                                                                                                                                                            "url": "planning",
+                                                                                                                                                                                                                            "args": {
+                                                                                                                                                                                                                                "contractid": "$.Contract.Metadata.Id",
+                                                                                                                                                                                                                                "resetescalation": {
+                                                                                                                                                                                                                                    "$if": {
+                                                                                                                                                                                                                                        "$condition": {
+                                                                                                                                                                                                                                            "$and": [
+                                                                                                                                                                                                                                                "$eqs ($.Contract.Metadata.Type,placeholder)",
+                                                                                                                                                                                                                                                "$.Data.LastPlayedAt",
+                                                                                                                                                                                                                                                "$.Data.EscalationCompleted"
+                                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                                        "$then": true,
+                                                                                                                                                                                                                                        "$else": false
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            },
+                                                                                                                                                                                                                            "contractid": "$.Contract.Metadata.Id"
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    "on-failure-too-early": {
+                                                                                                                                                                                        "$if": {
+                                                                                                                                                                                            "$condition": {
+                                                                                                                                                                                                "$and": [
+                                                                                                                                                                                                    "$eqs ($.Contract.Metadata.Type,elusive)",
+                                                                                                                                                                                                    "$stringvalid $.Data.ElusiveContractState",
+                                                                                                                                                                                                    "$stringvalid $.Data.LastPlayedAt",
+                                                                                                                                                                                                    "$lt ($converttimetonumber $.Data.LastPlayedAt,$converttimetonumber $.Contract.Metadata.PlayableSince)"
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            "$then": {
+                                                                                                                                                                                                "show-modal": {
+                                                                                                                                                                                                    "config": {
+                                                                                                                                                                                                        "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                                                        "buttons": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "label": "$loc UI_DIALOG_CONFIRM_TITLE",
+                                                                                                                                                                                                                "type": "cancel"
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ],
+                                                                                                                                                                                                        "data": {
+                                                                                                                                                                                                            "title": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_ET",
+                                                                                                                                                                                                            "description": "$loc UI_MENU_ERROR_STARTING_ELUSIVE_CONTRACT_NOT_PLAYABLE_YET_PREVIOUSLY_PLAYED_DESCRIPTION"
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            "$else": {
+                                                                                                                                                                                                "show-modal": {
+                                                                                                                                                                                                    "config": {
+                                                                                                                                                                                                        "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                                                        "buttons": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "label": "$loc UI_DIALOG_CONFIRM_TITLE",
+                                                                                                                                                                                                                "type": "cancel"
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ],
+                                                                                                                                                                                                        "data": {
+                                                                                                                                                                                                            "title": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_ET",
+                                                                                                                                                                                                            "description": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_NOT_PLAYABLE_YET_DESCRIPTION_ET",
+                                                                                                                                                                                                            "_comment": "HACK: use typeoverride to make the buttons work",
+                                                                                                                                                                                                            "typeoverride": "online"
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    "on-failure-too-late": {
+                                                                                                                                                                                        "_comment": "this is never reached, because we don't set playabelUntil above - by design",
+                                                                                                                                                                                        "show-modal": {
+                                                                                                                                                                                            "config": {
+                                                                                                                                                                                                "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                                                "buttons": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "label": "$loc UI_DIALOG_CONFIRM_TITLE",
+                                                                                                                                                                                                        "type": "cancel"
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ],
+                                                                                                                                                                                                "data": {
+                                                                                                                                                                                                    "title": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_ET",
+                                                                                                                                                                                                    "description": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_NOT_PLAYABLE_ANYMORE_DESCRIPTION_ET"
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    "$else": {
+                                                                                                                                                                        "is-playable": {
+                                                                                                                                                                            "playableSince": "$.Contract.Metadata.PlayableSince",
+                                                                                                                                                                            "on-success": {
+                                                                                                                                                                                "$merge": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "$if": {
+                                                                                                                                                                                            "$condition": {
+                                                                                                                                                                                                "$and": [
+                                                                                                                                                                                                    "$eqs ($.Contract.Metadata.Type,placeholder)",
+                                                                                                                                                                                                    "$.Data.LastPlayedAt",
+                                                                                                                                                                                                    "$.Data.EscalationCompleted"
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            "$then": [
+                                                                                                                                                                                                {
+                                                                                                                                                                                                    "alter-history": {
+                                                                                                                                                                                                        "target": "destination",
+                                                                                                                                                                                                        "force-no-cache": true
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                },
+                                                                                                                                                                                                {
+                                                                                                                                                                                                    "alter-history": {
+                                                                                                                                                                                                        "target": "hub",
+                                                                                                                                                                                                        "force-no-cache": true
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            ],
+                                                                                                                                                                                            "$else": null
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "$switch $.Contract.Metadata.BriefingVideo": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "case": null,
+                                                                                                                                                                                                "return": {
+                                                                                                                                                                                                    "link": {
+                                                                                                                                                                                                        "page": {
+                                                                                                                                                                                                            "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                "$then": "planning_multiplayer",
+                                                                                                                                                                                                                "$else": "planning"
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "isMultiplayer": {
+                                                                                                                                                                                                            "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                "$then": true,
+                                                                                                                                                                                                                "$else": false
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "args": {
+                                                                                                                                                                                                            "url": "planning",
+                                                                                                                                                                                                            "args": {
+                                                                                                                                                                                                                "contractid": "$.Contract.Metadata.Id",
+                                                                                                                                                                                                                "resetescalation": {
+                                                                                                                                                                                                                    "$if": {
+                                                                                                                                                                                                                        "$condition": {
+                                                                                                                                                                                                                            "$and": [
+                                                                                                                                                                                                                                "$eqs ($.Contract.Metadata.Type,placeholder)",
+                                                                                                                                                                                                                                "$.Data.LastPlayedAt",
+                                                                                                                                                                                                                                "$.Data.EscalationCompleted"
+                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "$then": true,
+                                                                                                                                                                                                                        "$else": false
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            "contractid": "$.Contract.Metadata.Id"
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "default": {
+                                                                                                                                                                                                    "link": {
+                                                                                                                                                                                                        "page": "video",
+                                                                                                                                                                                                        "addtohistory": false,
+                                                                                                                                                                                                        "args": {
+                                                                                                                                                                                                            "videoid": "$.Contract.Metadata.BriefingVideo",
+                                                                                                                                                                                                            "mountrootresources": "$formatstring [{$.Contract.Metadata.ScenePath}].entitytemplate",
+                                                                                                                                                                                                            "skipifshown": true,
+                                                                                                                                                                                                            "EngineMode": "$.EngineMode",
+                                                                                                                                                                                                            "link": {
+                                                                                                                                                                                                                "page": {
+                                                                                                                                                                                                                    "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                        "$then": "planning_multiplayer",
+                                                                                                                                                                                                                        "$else": "planning"
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "isMultiplayer": {
+                                                                                                                                                                                                                    "$if $eqs ($.EngineMode,multiplayer)": {
+                                                                                                                                                                                                                        "$then": true,
+                                                                                                                                                                                                                        "$else": false
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "args": {
+                                                                                                                                                                                                                    "url": "planning",
+                                                                                                                                                                                                                    "args": {
+                                                                                                                                                                                                                        "contractid": "$.Contract.Metadata.Id",
+                                                                                                                                                                                                                        "resetescalation": {
+                                                                                                                                                                                                                            "$if": {
+                                                                                                                                                                                                                                "$condition": {
+                                                                                                                                                                                                                                    "$and": [
+                                                                                                                                                                                                                                        "$eqs ($.Contract.Metadata.Type,placeholder)",
+                                                                                                                                                                                                                                        "$.Data.LastPlayedAt",
+                                                                                                                                                                                                                                        "$.Data.EscalationCompleted"
+                                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "$then": true,
+                                                                                                                                                                                                                                "$else": false
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    },
+                                                                                                                                                                                                                    "contractid": "$.Contract.Metadata.Id"
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            "on-failure-too-early": {
+                                                                                                                                                                                "$if": {
+                                                                                                                                                                                    "$condition": {
+                                                                                                                                                                                        "$and": [
+                                                                                                                                                                                            "$eqs ($.Contract.Metadata.Type,elusive)",
+                                                                                                                                                                                            "$stringvalid $.Data.ElusiveContractState",
+                                                                                                                                                                                            "$stringvalid $.Data.LastPlayedAt",
+                                                                                                                                                                                            "$lt ($converttimetonumber $.Data.LastPlayedAt,$converttimetonumber $.Contract.Metadata.PlayableSince)"
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    "$then": {
+                                                                                                                                                                                        "show-modal": {
+                                                                                                                                                                                            "config": {
+                                                                                                                                                                                                "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                                                "buttons": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "label": "$loc UI_DIALOG_CONFIRM_TITLE",
+                                                                                                                                                                                                        "type": "cancel"
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ],
+                                                                                                                                                                                                "data": {
+                                                                                                                                                                                                    "title": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_ET",
+                                                                                                                                                                                                    "description": "$loc UI_MENU_ERROR_STARTING_ELUSIVE_CONTRACT_NOT_PLAYABLE_YET_PREVIOUSLY_PLAYED_DESCRIPTION"
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    "$else": {
+                                                                                                                                                                                        "show-modal": {
+                                                                                                                                                                                            "config": {
+                                                                                                                                                                                                "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                                                "buttons": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "label": "$loc UI_DIALOG_CONFIRM_TITLE",
+                                                                                                                                                                                                        "type": "cancel"
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ],
+                                                                                                                                                                                                "data": {
+                                                                                                                                                                                                    "title": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_ET",
+                                                                                                                                                                                                    "description": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_NOT_PLAYABLE_YET_DESCRIPTION_ET",
+                                                                                                                                                                                                    "_comment": "HACK: use typeoverride to make the buttons work",
+                                                                                                                                                                                                    "typeoverride": "online"
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            "on-failure-too-late": {
+                                                                                                                                                                                "_comment": "this is never reached, because we don't set playabelUntil above - by design",
+                                                                                                                                                                                "show-modal": {
+                                                                                                                                                                                    "config": {
+                                                                                                                                                                                        "view": "menu3.modal.ModalDialogGeneric",
+                                                                                                                                                                                        "buttons": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "label": "$loc UI_DIALOG_CONFIRM_TITLE",
+                                                                                                                                                                                                "type": "cancel"
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ],
+                                                                                                                                                                                        "data": {
+                                                                                                                                                                                            "title": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_ET",
+                                                                                                                                                                                            "description": "$loc UI_MENU_PAGE_PLANNING_ELEMENT_LOADOUT_ERROR_STARTING_CONTRACT_NOT_PLAYABLE_ANYMORE_DESCRIPTION_ET"
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    ]
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "$else": null
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        },
+                                                                                        "deselect": {
+                                                                                            "$if $not $arg DisableChallengesMasteryHandling": {
+                                                                                                "$then": {
+                                                                                                    "set-mastery-data": {}
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "buttons": [
+                                                                                        {
+                                                                                            "$if $arg ShowPrevNextButtonPrompt": {
+                                                                                                "$then": {
+                                                                                                    "actiontype": "lt_rt",
+                                                                                                    "actionlabel": "$loc UI_BUTTON_PROMPTS_ACTION_PREVNEXT_CATEGORY",
+                                                                                                    "customplatform": {
+                                                                                                        "platform": "key",
+                                                                                                        "hide": true,
+                                                                                                        "actiontype": "mouse_lmb"
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "controller": "group",
+                                                                            "id": "challenge_action_container",
+                                                                            "_comment": "contains the action button if available for selected element",
+                                                                            "row": 4.05,
+                                                                            "nrows": "0.5",
+                                                                            "ncols": "1",
+                                                                            "children": []
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- When clicking on the Challenges tab on the Career page, location tiles will correctly be shown just like on official.
- When clicking on said tiles, corresponding challenges will correctly be shown. 
- This PR is fully compatible with but does not depend on #77, including sniper missions. 
- #78 also affects this PR, such that no challenges pertaining to escalation missions work, including the Dartmoor Garden Show. 