### PR TITLE
Fix all broken challenges in #22

### DIFF
--- a/THIRDPARTYNOTICES.txt
+++ b/THIRDPARTYNOTICES.txt
@@ -2264,8 +2264,43 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
+Name: safer-buffer
+Version: 2.1.2
+License: MIT
+Private: false
+Description: Modern Buffer API polyfill without footguns
+Repository: git+https://github.com/ChALkeR/safer-buffer.git
+Author: Nikita Skovoroda <chalkerx@gmail.com> (https://github.com/ChALkeR)
+License Copyright:
+===
+
+MIT License
+
+Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+---
+
 Name: iconv-lite
-Version: 0.6.3
+Version: 0.4.24
 License: MIT
 Private: false
 Description: Convert character encodings in pure javascript.
@@ -2401,7 +2436,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 ---
 
 Name: @peacockproject/statemachine-parser
-Version: 5.1.0
+Version: 5.2.0
 License: Apache-2.0
 Private: false
 Description: IOI state machine conditional parser.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "send": "patch:send@npm:0.18.0#.yarn/patches/send-npm-0.18.0-faadf6353f.patch"
     },
     "dependencies": {
-        "@peacockproject/statemachine-parser": "^5.1.0",
+        "@peacockproject/statemachine-parser": "^5.2.0",
         "@yarnpkg/fslib": "^3.0.0-rc.33",
         "@yarnpkg/libzip": "^3.0.0-rc.33",
         "atomically": "^1.7.0",

--- a/packaging/typedefs/package.json
+++ b/packaging/typedefs/package.json
@@ -14,7 +14,7 @@
         "reversion": "node ../versionTypedefsPackageJson.mjs"
     },
     "dependencies": {
-        "@peacockproject/statemachine-parser": "^5.1.0",
+        "@peacockproject/statemachine-parser": "^5.2.0",
         "@types/express": "^4.17.14",
         "@types/node": "^18.8.5",
         "atomically": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@peacockproject/core@workspace:packaging/typedefs"
   dependencies:
-    "@peacockproject/statemachine-parser": "npm:^5.1.0"
+    "@peacockproject/statemachine-parser": "npm:^5.2.0"
     "@types/express": "npm:^4.17.14"
     "@types/node": "npm:^18.8.5"
     atomically: "npm:^1.7.0"
@@ -406,7 +406,7 @@ __metadata:
   resolution: "@peacockproject/monorepo@workspace:."
   dependencies:
     "@mixer/parallel-prettier": "npm:^2.0.3"
-    "@peacockproject/statemachine-parser": "npm:^5.1.0"
+    "@peacockproject/statemachine-parser": "npm:^5.2.0"
     "@types/body-parser": "npm:1.19.2"
     "@types/express": "npm:^4.17.15"
     "@types/jsonwebtoken": "npm:^8.5.9"
@@ -459,10 +459,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@peacockproject/statemachine-parser@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@peacockproject/statemachine-parser@npm:5.1.0"
-  checksum: 4c4c90e6259ad7d3836638cc51fe13179467960b57d8b67af0282244779ad113b12fd86365b726babd0a96fdc13b02b8fb0d9e7082cd4b56f6967f90b69f3f12
+"@peacockproject/statemachine-parser@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@peacockproject/statemachine-parser@npm:5.2.0"
+  checksum: 753dacef0c447f39ab41d037b6de7446631c70e77b17d6670e52d5381685421213fd91bc2d5415acdcc6e1d6a93674f34ab3aed21427e23c5bcfdabf3649a08e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fixed all broken challenges currently on [the broken challenges list](https://github.com/thepeacockproject/Peacock/issues/22#issuecomment-1374396218) in #22.
  - The Chameleon was fixed by correctly storing and loading the challenge progression across sessions, for challenges with a scope of "profile" or "hit". 
  - The rest of the broken challenges were fixed by the new State Machine parser release. 
- All were confirmed via gameplay to be fixed and now have behaviors imitating those on the official server. 
