### PR TITLE
Fix completion data generation function

### DIFF
--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -112,7 +112,7 @@ export class MasteryService {
             XpLeft: nextLevelXp - locationData.Xp,
             Id: masteryData.Id,
             SubLocationId: subLocationId,
-            HideProgression: false,
+            HideProgression: masteryData.HideProgression || false,
             IsLocationProgression: true,
             Name: undefined,
         }
@@ -130,6 +130,10 @@ export class MasteryService {
         //Get the mastery data
         const masteryData: MasteryPackage =
             this.masteryData.get(locationParentId)
+
+        if (masteryData.Drops.length === 0) {
+            return []
+        }
 
         //Put all Ids into a set for quick lookup
         const dropIdSet = new Set(masteryData.Drops.map((drop) => drop.Id))

--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -66,6 +66,7 @@ export class MasteryService {
 
     getCompletionData(
         locationParentId: string,
+        subLocationId: string,
         gameVersion: GameVersion,
         userId: string,
     ): CompletionData {
@@ -110,7 +111,7 @@ export class MasteryService {
             Completion: locationData.Xp / nextLevelXp,
             XpLeft: nextLevelXp - locationData.Xp,
             Id: masteryData.Id,
-            SubLocationId: masteryData.Id,
+            SubLocationId: subLocationId,
             HideProgression: false,
             IsLocationProgression: true,
             Name: undefined,
@@ -147,6 +148,7 @@ export class MasteryService {
 
         //Map all the data into a new structure
         const completionData = this.getCompletionData(
+            locationParentId,
             locationParentId,
             gameVersion,
             userId,

--- a/components/contracts/dataGen.ts
+++ b/components/contracts/dataGen.ts
@@ -95,7 +95,8 @@ export function generateCompletionData(
     subLocationId: string,
     userId: string,
     gameVersion: GameVersion,
-    isParentLocation = false,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _isParentLocation = false,
 ): CompletionData {
     const subLocation = getSubLocationByName(subLocationId, gameVersion)
 
@@ -103,67 +104,33 @@ export function generateCompletionData(
         ? subLocation.Properties?.ParentLocation
         : subLocationId
 
-    let completionData = controller.masteryService.getCompletionData(
+    const completionData = controller.masteryService.getCompletionData(
         locationId,
-        subLocationId,
+        subLocation?.Id,
         gameVersion,
         userId,
     )
 
     if (!completionData) {
-        if (locationId === "LOCATION_PARENT_ICA_FACILITY") {
-            // Note that ICA facility has a whopping FOUR levels of mastery, but it's hidden.
-            // On official servers this data would also progress as the player finishes corresponding challenges,
-            // but we can leave it static for now since it has no observable effects.
-            completionData = {
-                Level: 1,
-                MaxLevel: 4,
-                XP: 0,
-                Completion: 0.0,
-                XpLeft: 6000,
-                Id: locationId,
-                SubLocationId: subLocation?.Id,
-                HideProgression: true,
-                IsLocationProgression: true,
-                Name: null,
-            }
-        } else if (
-            locationId === "LOCATION_PARENT_AUSTRIA" ||
-            locationId === "LOCATION_PARENT_SALTY" ||
-            locationId === "LOCATION_PARENT_CAGED"
-        ) {
-            completionData = {
-                Level: 1,
-                MaxLevel: 1,
-                XP: 0,
-                Completion: 1.0,
-                XpLeft: 0,
-                Id: locationId,
-                SubLocationId: subLocation?.Id,
-                HideProgression: true,
-                IsLocationProgression: true,
-                Name: null,
-            }
-        } else {
-            log(
-                LogLevel.DEBUG,
-                `Could not get CompletionData for location ${locationId}`,
-            )
+        log(
+            LogLevel.DEBUG,
+            `Could not get CompletionData for location ${locationId}`,
+        )
 
-            completionData = {
-                Level: 20,
-                MaxLevel: 20,
-                XP: 0,
-                Completion: 1,
-                XpLeft: 0,
-                Id: locationId,
-                SubLocationId: subLocation?.Id,
-                HideProgression: false,
-                IsLocationProgression: true,
-                Name: null,
-            }
+        return {
+            Level: 1,
+            MaxLevel: 1,
+            XP: 0,
+            Completion: 1.0,
+            XpLeft: 0,
+            Id: locationId,
+            SubLocationId: subLocation?.Id,
+            HideProgression: true,
+            IsLocationProgression: true,
+            Name: null,
         }
     }
+
     return completionData
 }
 

--- a/components/contracts/dataGen.ts
+++ b/components/contracts/dataGen.ts
@@ -103,32 +103,67 @@ export function generateCompletionData(
         ? subLocation.Properties?.ParentLocation
         : subLocationId
 
-    const completionData = controller.masteryService.getCompletionData(
+    let completionData = controller.masteryService.getCompletionData(
         locationId,
+        subLocationId,
         gameVersion,
         userId,
     )
 
     if (!completionData) {
-        log(
-            LogLevel.DEBUG,
-            `Could not get CompletionData for location ${locationId}`,
-        )
+        if (locationId === "LOCATION_PARENT_ICA_FACILITY") {
+            // Note that ICA facility has a whopping FOUR levels of mastery, but it's hidden.
+            // On official servers this data would also progress as the player finishes corresponding challenges,
+            // but we can leave it static for now since it has no observable effects.
+            completionData = {
+                Level: 1,
+                MaxLevel: 4,
+                XP: 0,
+                Completion: 0.0,
+                XpLeft: 6000,
+                Id: locationId,
+                SubLocationId: subLocation?.Id,
+                HideProgression: true,
+                IsLocationProgression: true,
+                Name: null,
+            }
+        } else if (
+            locationId === "LOCATION_PARENT_AUSTRIA" ||
+            locationId === "LOCATION_PARENT_SALTY" ||
+            locationId === "LOCATION_PARENT_CAGED"
+        ) {
+            completionData = {
+                Level: 1,
+                MaxLevel: 1,
+                XP: 0,
+                Completion: 1.0,
+                XpLeft: 0,
+                Id: locationId,
+                SubLocationId: subLocation?.Id,
+                HideProgression: true,
+                IsLocationProgression: true,
+                Name: null,
+            }
+        } else {
+            log(
+                LogLevel.DEBUG,
+                `Could not get CompletionData for location ${locationId}`,
+            )
 
-        return {
-            Level: 20,
-            MaxLevel: 20,
-            XP: 0,
-            Completion: 1,
-            XpLeft: 0,
-            Id: locationId,
-            SubLocationId: subLocation?.Id,
-            HideProgression: false,
-            IsLocationProgression: true,
-            Name: null,
+            completionData = {
+                Level: 20,
+                MaxLevel: 20,
+                XP: 0,
+                Completion: 1,
+                XpLeft: 0,
+                Id: locationId,
+                SubLocationId: subLocation?.Id,
+                HideProgression: false,
+                IsLocationProgression: true,
+                Name: null,
+            }
         }
     }
-
     return completionData
 }
 

--- a/components/types/mastery.ts
+++ b/components/types/mastery.ts
@@ -11,6 +11,7 @@ export interface MasteryDataTemplate {
 export interface MasteryPackage {
     Id: string
     MaxLevel?: number
+    HideProgression?: boolean
     Drops: {
         Id: string
         Level: number

--- a/contractdata/FACILITY/_FACILITY_MASTERY.json
+++ b/contractdata/FACILITY/_FACILITY_MASTERY.json
@@ -1,0 +1,6 @@
+{
+    "Id": "LOCATION_PARENT_ICA_FACILITY",
+    "MaxLevel": 4,
+    "HideProgression": true,
+    "Drops": []
+}


### PR DESCRIPTION
The new `generateCompletionData` function in #30 returns the **parent location ID** in the `SubLocationId` field in its return value, which is not correct. It causes `'UI_LOCATION_PARENT_XXX_TEXT'` to appear in the mission end screen, among other places.  This PR restores the behavior that the **sublocation ID** should be in that field for most if not all purposes other than mastery. It also prevents location progression data from appearing in the bottom right for the sniper levels and the ICA facility, which is the correct behavior on official servers.