### PR TITLE
Fix a UI detail for the Challenges tab on the planning page

### DIFF
--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -734,6 +734,7 @@ export class ChallengeService extends ChallengeRegistry {
         progression: ChallengeProgressionData,
         gameVersion: GameVersion,
         userId: string,
+        isDestination = false,
     ): CompiledChallengeTreeData {
         return {
             // GetChallengeTreeFor
@@ -746,7 +747,7 @@ export class ChallengeService extends ChallengeRegistry {
             },
             Drops: [],
             Completed: progression.Completed,
-            IsPlayable: challenge.IsPlayable || false,
+            IsPlayable: isDestination,
             IsLocked: challenge.IsLocked || false,
             HideProgression: false,
             CategoryName:
@@ -827,6 +828,7 @@ export class ChallengeService extends ChallengeRegistry {
                 progression,
                 gameVersion,
                 userId,
+                true, //isDestination
             ),
             UserCentricContract:
                 challenge.Type === "contract"


### PR DESCRIPTION
- Removes the link to the corresponding mission under challenge tiles for the CHALLENGES tab on the planning page, to match the behavior on official servers. This bug was mentioned in #90.
- The link was previously not bugging in H3 but bugging in H2 (see screenshot). However, it should not be shown at all for the planning page.
- Whether the link is shown on other pages or not is not affected.
![image](https://user-images.githubusercontent.com/118079569/215239667-9747dc47-c784-4615-97c1-236faef625d0.png)
