### PR TITLE
Fix the legacy contract downloader and improve options related to it

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -982,7 +982,11 @@ export class Controller {
         userId: string,
     ): Promise<MissionManifest | undefined> {
         const remoteService =
-            gameVersion === "h2" ? "pc2-service" : "pc-service"
+            gameVersion === "h3"
+                ? "hm3-service"
+                : gameVersion === "h2"
+                ? "pc2-service"
+                : "pc-service"
 
         const user = userAuths.get(userId)
 
@@ -1201,20 +1205,12 @@ export function contractIdToHitObject(
     }
 
     const subLocation = getSubLocationFromContract(contract, gameVersion)
-    let parentLocId = subLocation?.Properties?.ParentLocation
-    if (parentLocId === "LOCATION_PARENT_ICA_SHIP_FACILITY") {
-        parentLocId = "LOCATION_PARENT_ICA_FACILITY"
-    }
-
-    if (parentLocId === "LOCATION_PARENT_COASTALTOWN_EBOLA") {
-        parentLocId = "LOCATION_PARENT_COASTALTOWN"
-    }
 
     const parentLocation = getVersionedConfig<PeacockLocationsData>(
         "LocationsData",
         gameVersion,
         false,
-    ).parents[parentLocId]
+    ).parents[subLocation?.Properties?.ParentLocation]
 
     // failed to find the location, must be from a newer game
     if (!subLocation && (gameVersion === "h1" || gameVersion === "h2")) {

--- a/components/entitlementStrategies.ts
+++ b/components/entitlementStrategies.ts
@@ -74,6 +74,7 @@ export class IOIStrategy extends EntitlementStrategy {
     }
 
     override async get(userId: string) {
+        // Note: Relies on the "legacyContractDownloader" flag.
         if (!userAuths.has(userId)) {
             log(LogLevel.ERROR, `No data found for ${userId}.`)
             return []

--- a/components/flags.ts
+++ b/components/flags.ts
@@ -33,10 +33,6 @@ const defaultFlags: Flags = {
         desc: "For Discord Rich Presence, if set to false, the time playing the current level will be shown, and if set to true, the total time using Peacock will be shown.",
         default: false,
     },
-    officialAuthentication: {
-        desc: "Use official servers for contract downloading",
-        default: true,
-    },
     liveSplit: {
         desc: "Toggle LiveSplit support on or off",
         default: false,
@@ -94,7 +90,7 @@ const defaultFlags: Flags = {
         default: false,
     },
     legacyContractDownloader: {
-        desc: "Use the legacy contract downloader in H3 - only works for the platform you are playing on.",
+        desc: "When set to true, the official servers will be used for contract downloading in H3, which only works for the platform you are playing on. When false, the HITMAPS servers will be used instead. Note that this option only pertains to H3. Official servers will be used for H1 and H2 regardless of the value of this option.",
         default: false,
     },
 }

--- a/components/oauthToken.ts
+++ b/components/oauthToken.ts
@@ -104,10 +104,6 @@ export async function handleOauthToken(
 
     if (req.body.pId && !uuidRegex.test(req.body.pId)) {
         res.status(400).end() // pId is not a GUID
-        log(
-            LogLevel.ERROR,
-            `The pId ${JSON.stringify(req.body.pId)} is not a GUID.`,
-        )
         return
     }
 

--- a/components/oauthToken.ts
+++ b/components/oauthToken.ts
@@ -309,6 +309,7 @@ export async function handleOauthToken(
         }
 
         userData.Extensions.entP = await getEntitlements()
+
         if (
             Object.prototype.hasOwnProperty.call(
                 userData.Extensions,

--- a/components/oauthToken.ts
+++ b/components/oauthToken.ts
@@ -130,7 +130,7 @@ export async function handleOauthToken(
         )
         return
     }
-    console.log(external_appid)
+
     const isHitman3 =
         external_appid === "fghi4567xQOCheZIin0pazB47qGUvZw4" ||
         external_appid === STEAM_NAMESPACE_2021
@@ -185,7 +185,6 @@ export async function handleOauthToken(
         : external_appid === STEAM_NAMESPACE_2018
         ? "h2"
         : "h1"
-    console.log(gameVersion)
 
     if (!req.body.pId) {
         // if no profile id supplied
@@ -283,6 +282,7 @@ export async function handleOauthToken(
                     return []
                 }
             }
+
             if (gameVersion === "h2") {
                 return new SteamH2Strategy().get()
             }

--- a/components/oauthToken.ts
+++ b/components/oauthToken.ts
@@ -68,12 +68,6 @@ export async function handleOauthToken(
     if (req.body.grant_type === "external_steam") {
         if (!/^\d{1,20}$/.test(req.body.steam_userid)) {
             res.status(400).end() // invalid steam user id
-            log(
-                LogLevel.ERROR,
-                `Invalid steam user id ${JSON.stringify(
-                    req.body.steam_userid,
-                )}.`,
-            )
             return
         }
 
@@ -84,10 +78,6 @@ export async function handleOauthToken(
     } else if (req.body.grant_type === "external_epic") {
         if (!/^[\da-f]{32}$/.test(req.body.epic_userid)) {
             res.status(400).end() // invalid epic user id
-            log(
-                LogLevel.ERROR,
-                `Invalid epic user id ${JSON.stringify(req.body.epic_userid)}.`,
-            )
             return
         }
 
@@ -100,12 +90,6 @@ export async function handleOauthToken(
 
         if (!epic_token || !(epic_token.appid || epic_token.app)) {
             res.status(400).end() // invalid epic access token
-            log(
-                LogLevel.ERROR,
-                `Invalid epic access token ${JSON.stringify(
-                    req.body.access_token,
-                )}.`,
-            )
             return
         }
 
@@ -115,10 +99,6 @@ export async function handleOauthToken(
         external_users_folder = "epicids"
     } else {
         res.status(406).end() // unsupported auth method
-        log(
-            LogLevel.ERROR,
-            `Unsupported auth method ${JSON.stringify(req.body.grant_type)}.`,
-        )
         return
     }
 


### PR DESCRIPTION
- The `legacyContractDownloader` and `officialAuthentication` options toggle the same thing according to their descriptions. So, the latter is removed and the former is used in its stead.
- Fixed the legacy contract downloader for h3 by fixing the URL.
- Redid the logics regarding the contract downloaders such that 
  - H1 and H2 will always use the legacy contract downloader, regardless of the value of `legacyContractDownloader`, because this is the only downloader they can use.
  - H3 will use the legacy contract downloader if `legacyContractDownloader === true`, and the HITMAPS downloader otherwise. 
  - scpc will not use any downloader.
- Added a caveat for `userAuths` because it will only be non-empty if the legacy contract downloader is used.
- Removed redundant checks for location IDs because they no longer exist after #92.
