### PR TITLE
Fix unwanted tiles on career -> challenges page 

### DIFF
--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -217,11 +217,10 @@ menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
     }
 
     for (const child in locations.children) {
-        // continue
-
         if (
             child === "LOCATION_ICA_FACILITY_ARRIVAL" ||
-            child === "LOCATION_HOKKAIDO_SHIM_MAMUSHI"
+            child === "LOCATION_HOKKAIDO_SHIM_MAMUSHI" ||
+            child.search("SNUG_") > 0
         ) {
             continue
         }


### PR DESCRIPTION
- Evergreen introduced a lot of sublocations with no challenges (e.g. `LOCATION_SNUG_PARIS_CRAPS`), which caused problems with the Career -> Challenges page.
- This PR improves the logic to leave these sublocations out when getting challenges for all locations.