### PR TITLE
Remove duplicated items in the user's inventory

### DIFF
--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -86,7 +86,15 @@ export function createInventory(
     // ts-expect-error It cannot be undefined.
     const filtered: InventoryItem[] = allunlockables
         .map((unlockable) => {
-            if (brokenItems.includes(unlockable.Guid)) {
+            if (
+                brokenItems.includes(unlockable.Guid) ||
+                // Remove TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT
+                // Duplicate of TOKEN_OUTFIT_WET_SUIT, which is an unlock of The Mills Reverie challenge.
+                unlockable.Guid === "3a4bcbbf-d451-4853-8a85-649120e384df" ||
+                // Remove TOKEN_OUTFIT_COLORADO_HERO_RABIESSUIT
+                // Duplicate of TOKEN_OUTFIT_COLORADO_HERO_COLORADOSUIT.
+                unlockable.Guid === "e3234256-c061-48e6-b543-008d990affa1"
+            ) {
                 return undefined
             }
 
@@ -118,11 +126,6 @@ export function createInventory(
 
             const e = entP
             const { Id: id } = unlockContainer!.Unlockable
-
-            // Duplicate of TOKEN_OUTFIT_WET_SUIT, which is an unlock of The Mills Reverie challenge.
-            if (id === "TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT") {
-                return false
-            }
 
             if (!e) {
                 return false

--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -86,15 +86,7 @@ export function createInventory(
     // ts-expect-error It cannot be undefined.
     const filtered: InventoryItem[] = allunlockables
         .map((unlockable) => {
-            if (
-                brokenItems.includes(unlockable.Guid) ||
-                // Remove TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT
-                // Duplicate of TOKEN_OUTFIT_WET_SUIT, which is an unlock of The Mills Reverie challenge.
-                unlockable.Guid === "3a4bcbbf-d451-4853-8a85-649120e384df" ||
-                // Remove TOKEN_OUTFIT_COLORADO_HERO_RABIESSUIT
-                // Duplicate of TOKEN_OUTFIT_COLORADO_HERO_COLORADOSUIT.
-                unlockable.Guid === "e3234256-c061-48e6-b543-008d990affa1"
-            ) {
+            if (brokenItems.includes(unlockable.Guid)) {
                 return undefined
             }
 

--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -119,6 +119,11 @@ export function createInventory(
             const e = entP
             const { Id: id } = unlockContainer!.Unlockable
 
+            // Duplicate of TOKEN_OUTFIT_WET_SUIT, which is an unlock of The Mills Reverie challenge.
+            if (id === "TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT") {
+                return false
+            }
+
             if (!e) {
                 return false
             }

--- a/components/ownership.ts
+++ b/components/ownership.ts
@@ -224,6 +224,8 @@ export const brokenItems = [
     "051825b9-44f2-4b3d-8ab1-8d4a07393c76",
     // eiffel tower melee weapon
     "a8a8f0da-a69b-428d-b8c1-faf8660ec318",
+    // PROP_DEVICE_REMOTE_EXPLOSIVE_ANCESTRAL (doesn't exist as of 3.140)
+    "099afc37-609b-48c9-9278-d3389b45829b",
 ]
 
 /**

--- a/components/ownership.ts
+++ b/components/ownership.ts
@@ -226,6 +226,12 @@ export const brokenItems = [
     "a8a8f0da-a69b-428d-b8c1-faf8660ec318",
     // PROP_DEVICE_REMOTE_EXPLOSIVE_ANCESTRAL (doesn't exist as of 3.140)
     "099afc37-609b-48c9-9278-d3389b45829b",
+    // Remove TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT
+    // Duplicate of TOKEN_OUTFIT_WET_SUIT, which is an unlock of The Mills Reverie challenge.
+    "3a4bcbbf-d451-4853-8a85-649120e384df",
+    // Remove TOKEN_OUTFIT_COLORADO_HERO_RABIESSUIT
+    // Duplicate of TOKEN_OUTFIT_COLORADO_HERO_COLORADOSUIT.
+    "e3234256-c061-48e6-b543-008d990affa1",
 ]
 
 /**

--- a/components/ownership.ts
+++ b/components/ownership.ts
@@ -226,9 +226,9 @@ export const brokenItems = [
     "a8a8f0da-a69b-428d-b8c1-faf8660ec318",
     // PROP_DEVICE_REMOTE_EXPLOSIVE_ANCESTRAL (doesn't exist as of 3.140)
     "099afc37-609b-48c9-9278-d3389b45829b",
-    // Remove TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT
-    // Duplicate of TOKEN_OUTFIT_WET_SUIT, which is an unlock of The Mills Reverie challenge.
-    "3a4bcbbf-d451-4853-8a85-649120e384df",
+    // Remove TOKEN_OUTFIT_WET_SUIT, which is an unlock of The Mills Reverie challenge.
+    // Duplicate of TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT, which is the New Zealand default suit.
+    "c2834cc6-0c71-4785-a976-c93aceb4c528",
     // Remove TOKEN_OUTFIT_COLORADO_HERO_RABIESSUIT
     // Duplicate of TOKEN_OUTFIT_COLORADO_HERO_COLORADOSUIT.
     "e3234256-c061-48e6-b543-008d990affa1",


### PR DESCRIPTION
This PR fixes these duplicated items:
- The Ancestral Fountain Pen, mentioned in #106. 
- The Tactical Wet Suit in H2/H3. The cause is its two identical versions, one used as the default suit of Nightcall, and the other as the reward of The Mills Reverie. Only the latter appears in the inventory now.
- The Tactical Gear in H1/H2. It was loaded twice, once as `TOKEN_OUTFIT_COLORADO_HERO_COLORADOSUIT` and another time as `TOKEN_OUTFIT_COLORADO_HERO_RABIESSUIT`. Only the former appears in the inventory now.