### PR TITLE
Remove unwanted contract creation tiles for H1 & H2

### DIFF
--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -286,7 +286,7 @@ menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
                 req.jwt.unique_name,
                 req.gameVersion,
             ),
-            LocationsData: createLocationsData(req.gameVersion),
+            LocationsData: createLocationsData(req.gameVersion, true),
             ProfileData: {
                 ChallengeData: {
                     Children: Object.values(career),
@@ -1492,7 +1492,7 @@ menuDataRouter.get("/contractsearchpage", (req: RequestWithJwt, res) => {
                 req.jwt.unique_name,
                 req.gameVersion,
             ),
-            LocationsData: createLocationsData(req.gameVersion),
+            LocationsData: createLocationsData(req.gameVersion, true),
             FilterData: getVersionedConfig(
                 "FilterData",
                 req.gameVersion,


### PR DESCRIPTION
- Fixes #118 
- Locations that don't support contract creation is no longer returned for:
  - `/Hub`, which returns a `LocationData` relied on by H1 & H2 to get the contract creation locations.
  - `/contractsearchpage`, which should not be concerned with any locations that don't support contract creation anyway