### PR TITLE
Disable saving in contracts

### DIFF
--- a/components/contracts/contractRouting.ts
+++ b/components/contracts/contractRouting.ts
@@ -17,7 +17,13 @@
  */
 
 import { Router } from "express"
-import { fastClone, nilUuid, ServerVer, uuidRegex } from "../utils"
+import {
+    contractTypes,
+    fastClone,
+    nilUuid,
+    ServerVer,
+    uuidRegex,
+} from "../utils"
 import { json as jsonMiddleware } from "body-parser"
 import {
     enqueueEvent,
@@ -92,6 +98,11 @@ contractRoutingRouter.post(
             ...{
                 OpportunityData: getContractOpportunityData(req, contractData),
             },
+        }
+
+        // Edit usercreated contract data HERE
+        if (contractTypes.includes(contractData.Metadata.Type)) {
+            contractData.Data.EnableSaving = false
         }
 
         const contractSesh = {

--- a/components/eventHandler.ts
+++ b/components/eventHandler.ts
@@ -31,7 +31,7 @@ import {
     Seconds,
     ServerToClientEvent,
 } from "./types/types"
-import { extractToken, ServerVer } from "./utils"
+import { contractTypes, extractToken, ServerVer } from "./utils"
 import { json as jsonMiddleware } from "body-parser"
 import { log, LogLevel } from "./loggingInterop"
 import { getUserData, writeUserData } from "./databaseHandler"
@@ -236,11 +236,7 @@ export function newSession(
         throw new Error("no ct")
     }
 
-    if (
-        difficulty === 0 &&
-        (contract.Metadata.Type === "creation" ||
-            contract.Metadata.Type === "usercreated")
-    ) {
+    if (difficulty === 0 && contractTypes.includes(contract.Metadata.Type)) {
         log(
             LogLevel.DEBUG,
             `Difficulty not set for user created contract ${contractId}, setting to 2`,

--- a/components/utils.ts
+++ b/components/utils.ts
@@ -49,6 +49,8 @@ export const PEACOCKVERSTRING = HUMAN_VERSION
 export const uuidRegex =
     /^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$/
 
+export const contractTypes = ["featured", "usercreated", "creation"]
+
 export async function checkForUpdates(): Promise<void> {
     if (getFlag("updateChecking") === false) {
         return


### PR DESCRIPTION
- Fixes #114.
- Uses an array to store different contract types. Also changed @alex73630's previous fix on contract difficulty to use this array.