### PR TITLE
Get the latest entitlements for user upon authentication

### DIFF
--- a/components/entitlementStrategies.ts
+++ b/components/entitlementStrategies.ts
@@ -16,7 +16,7 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { AxiosResponse } from "axios"
+import { AxiosError, AxiosResponse } from "axios"
 import { log, LogLevel } from "./loggingInterop"
 import { userAuths } from "./officialServerAuth"
 import {
@@ -93,11 +93,20 @@ export class IOIStrategy extends EntitlementStrategy {
                     issuerId: this.issuerId,
                 },
             )
-        } catch (AxiosError) {
-            log(
-                LogLevel.ERROR,
-                `Failed to get entitlements from Steam: got ${AxiosError.response.status} ${AxiosError.response.statusText}`,
-            )
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                log(
+                    LogLevel.ERROR,
+                    `Failed to get entitlements from Steam: got ${error.response.status} ${error.response.statusText}.`,
+                )
+            } else {
+                log(
+                    LogLevel.ERROR,
+                    `Failed to get entitlements from Steam: ${JSON.stringify(
+                        error,
+                    )}.`,
+                )
+            }
         }
 
         return resp?.data || []

--- a/components/oauthToken.ts
+++ b/components/oauthToken.ts
@@ -297,9 +297,25 @@ export async function handleOauthToken(
         return []
     }
 
-    userData.Extensions.entP = await getEntitlements()
-
-    writeNewUserData(req.body.pId, userData, gameVersion)
+    const newEntP = await getEntitlements()
+    if (newEntP.length === 0) {
+        if (userData.Extensions.entP) {
+            log(
+                LogLevel.WARN,
+                `Error getting latest entitlement data for user ${req.body.pId}. Recently acquired DLCs might not be displayed!`,
+            )
+        } else {
+            log(
+                LogLevel.ERROR,
+                `Error getting entitlement data for new user ${req.body.pId}!`,
+            )
+            userData.Extensions.entP = newEntP
+            writeNewUserData(req.body.pId, userData, gameVersion)
+        }
+    } else {
+        userData.Extensions.entP = newEntP
+        writeNewUserData(req.body.pId, userData, gameVersion)
+    }
 
     // Format here follows steam_external, Epic jwt has some different fields
     const userinfo = {

--- a/components/oauthToken.ts
+++ b/components/oauthToken.ts
@@ -224,11 +224,13 @@ export async function handleOauthToken(
         await authContainer._initiallyAuthenticate(req)
     }
 
-    if (getUserData(req.body.pId, gameVersion) === undefined) {
+    let userData = getUserData(req.body.pId, gameVersion)
+
+    if (userData === undefined) {
         // User does not exist, create new profile from default:
         log(LogLevel.DEBUG, `Create new profile ${req.body.pId}`)
 
-        const userData = getVersionedConfig(
+        userData = getVersionedConfig(
             "UserDefault",
             gameVersion,
             true,
@@ -242,50 +244,6 @@ export async function handleOauthToken(
             userData.EpicId = req.body.epic_userid
         }
 
-        // eslint-disable-next-line no-inner-declarations
-        async function getEntitlements(): Promise<string[]> {
-            if (isFrankenstein) {
-                return new SteamScpcStrategy().get()
-            }
-
-            if (gameVersion === "h1") {
-                if (external_platform === "steam") {
-                    return new SteamH1Strategy().get()
-                } else if (external_platform === "epic") {
-                    return new EpicH1Strategy().get()
-                } else {
-                    log(LogLevel.ERROR, "Unsupported platform.")
-                    return []
-                }
-            }
-
-            if (gameVersion === "h2") {
-                return new SteamH2Strategy().get()
-            }
-
-            if (gameVersion === "h3") {
-                if (external_platform === "epic") {
-                    return await new EpicH3Strategy().get(
-                        req.body.access_token,
-                        req.body.epic_userid,
-                    )
-                } else if (external_platform === "steam") {
-                    return await new IOIStrategy(
-                        gameVersion,
-                        STEAM_NAMESPACE_2021,
-                    ).get(req.body.pId)
-                } else {
-                    log(LogLevel.ERROR, "Unsupported platform.")
-                    return []
-                }
-            }
-
-            log(LogLevel.ERROR, "Unsupported platform.")
-            return []
-        }
-
-        userData.Extensions.entP = await getEntitlements()
-
         if (
             Object.prototype.hasOwnProperty.call(
                 userData.Extensions,
@@ -295,9 +253,53 @@ export async function handleOauthToken(
             // @ts-expect-error No longer in the typedefs.
             delete userData.Extensions.inventory
         }
-
-        writeNewUserData(req.body.pId, userData, gameVersion)
     }
+
+    // eslint-disable-next-line no-inner-declarations
+    async function getEntitlements(): Promise<string[]> {
+        if (isFrankenstein) {
+            return new SteamScpcStrategy().get()
+        }
+
+        if (gameVersion === "h1") {
+            if (external_platform === "steam") {
+                return new SteamH1Strategy().get()
+            } else if (external_platform === "epic") {
+                return new EpicH1Strategy().get()
+            } else {
+                log(LogLevel.ERROR, "Unsupported platform.")
+                return []
+            }
+        }
+
+        if (gameVersion === "h2") {
+            return new SteamH2Strategy().get()
+        }
+
+        if (gameVersion === "h3") {
+            if (external_platform === "epic") {
+                return await new EpicH3Strategy().get(
+                    req.body.access_token,
+                    req.body.epic_userid,
+                )
+            } else if (external_platform === "steam") {
+                return await new IOIStrategy(
+                    gameVersion,
+                    STEAM_NAMESPACE_2021,
+                ).get(req.body.pId)
+            } else {
+                log(LogLevel.ERROR, "Unsupported platform.")
+                return []
+            }
+        }
+
+        log(LogLevel.ERROR, "Unsupported platform.")
+        return []
+    }
+
+    userData.Extensions.entP = await getEntitlements()
+
+    writeNewUserData(req.body.pId, userData, gameVersion)
 
     // Format here follows steam_external, Epic jwt has some different fields
     const userinfo = {

--- a/components/platformEntitlements.ts
+++ b/components/platformEntitlements.ts
@@ -153,6 +153,7 @@ export function getPlatformEntitlements(
  * @param epicUid The user's Epic ID.
  * @param epicAuth The user's Epic authentication token.
  * @see https://dev.epicgames.com/docs/services/en-US/WebAPIRef/EcomWebAPI/index.html
+ * @returns A string array with the user's entitlements, or an empty array if failed to acquire entitlements.
  */
 export async function getEpicEntitlements(
     namespace: string,
@@ -172,15 +173,28 @@ export async function getEpicEntitlements(
             .map((e) => `${namespace}:${e}`)
             .join(`&nsCatalogItemId=`)}`
 
-        return (await axios(url, v)).data as NamespaceEntitlementEpic[]
+        let result: NamespaceEntitlementEpic[] = undefined
+
+        try {
+            result = (await axios(url, v)).data as NamespaceEntitlementEpic[]
+        } catch (AxiosError) {
+            log(
+                LogLevel.ERROR,
+                `Failed to get entitlements from Epic: got ${AxiosError.response.status} ${AxiosError.response.statusText}`,
+            )
+        }
+
+        return result
     }
 
     const actuallyOwned = new Set<string>()
     const res = await getEnts(H3_EPIC_ENTITLEMENTS)
 
-    for (const ent of res) {
-        if (ent.owned) {
-            actuallyOwned.add(ent.itemId)
+    if (res) {
+        for (const ent of res) {
+            if (ent.owned) {
+                actuallyOwned.add(ent.itemId)
+            }
         }
     }
 

--- a/components/platformEntitlements.ts
+++ b/components/platformEntitlements.ts
@@ -173,7 +173,7 @@ export async function getEpicEntitlements(
             .map((e) => `${namespace}:${e}`)
             .join(`&nsCatalogItemId=`)}`
 
-        let result: NamespaceEntitlementEpic[] = undefined
+        let result: NamespaceEntitlementEpic[] | undefined = undefined
 
         try {
             result = (await axios(url, v)).data as NamespaceEntitlementEpic[]

--- a/components/platformEntitlements.ts
+++ b/components/platformEntitlements.ts
@@ -173,7 +173,7 @@ export async function getEpicEntitlements(
             .map((e) => `${namespace}:${e}`)
             .join(`&nsCatalogItemId=`)}`
 
-        let result: NamespaceEntitlementEpic[] | undefined = undefined
+        let result: NamespaceEntitlementEpic[] = []
 
         try {
             result = (await axios(url, v)).data as NamespaceEntitlementEpic[]

--- a/components/platformEntitlements.ts
+++ b/components/platformEntitlements.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Response } from "express"
-import axios from "axios"
+import axios, { AxiosError } from "axios"
 import type { NamespaceEntitlementEpic, RequestWithJwt } from "./types/types"
 import { getUserData } from "./databaseHandler"
 import { log, LogLevel } from "./loggingInterop"
@@ -177,11 +177,20 @@ export async function getEpicEntitlements(
 
         try {
             result = (await axios(url, v)).data as NamespaceEntitlementEpic[]
-        } catch (AxiosError) {
-            log(
-                LogLevel.ERROR,
-                `Failed to get entitlements from Epic: got ${AxiosError.response.status} ${AxiosError.response.statusText}`,
-            )
+        } catch (error) {
+            if (error instanceof AxiosError) {
+                log(
+                    LogLevel.ERROR,
+                    `Failed to get entitlements from Epic: got ${error.response.status} ${error.response.statusText}.`,
+                )
+            } else {
+                log(
+                    LogLevel.ERROR,
+                    `Failed to get entitlements from Epic: ${JSON.stringify(
+                        error,
+                    )}.`,
+                )
+            }
         }
 
         return result

--- a/components/utils.ts
+++ b/components/utils.ts
@@ -120,7 +120,6 @@ export function castUserProfile(profile: UserProfile): UserProfile {
     let dirty = false
 
     for (const item of [
-        "entP",
         "PeacockEscalations",
         "PeacockFavoriteContracts",
         "PeacockCompletedEscalations",
@@ -136,14 +135,6 @@ export function castUserProfile(profile: UserProfile): UserProfile {
                 LogLevel.WARN,
                 `Attempting to repair the profile automatically...`,
             )
-
-            if (item === "entP") {
-                log(
-                    LogLevel.ERROR,
-                    "Can't repair this issue, please let us know in the Discord!",
-                )
-                process.exit(1)
-            }
 
             if (item === "PeacockEscalations") {
                 j.Extensions.PeacockEscalations = {}


### PR DESCRIPTION
- Fixes #119.
- Possibly also fixes #105, which is related to outdated entitlements.
-  Added error try-catch blocks for Steam & Epic `getEntitlement` functions to detect failure scenarios.
- Tries to get the user's latest entitlements every time the user authenticates.
  - Upon success, overwrites the user's entitlement array.
  - Upon failure, 
    - For an old user, falls back to the previously stored entitlement array;
    - For a new user, stores an empty array as the entitlements.
- `castUserProfile` in `util.ts` no longer reports a missing entitlement array, since it is elsewhere handled.
- Tested on both Epic and Steam, for both new users and old users, with both succeeding and failing entitlement requests, and both up-to-date and outdated entitlement arrays. All yielded expected behaviors.
  - Failing entitlement requests were simulated by accessing a wrong URL, resulting in a 404 Not Found error.