### PR TITLE
adds a plugins folder when non is detected

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -517,6 +517,7 @@ function startServer(options: { hmr: boolean; pluginDevHost: boolean }): void {
     // make sure required folder structure is in place
     for (const dir of [
         "contractSessions",
+        "plugins",
         "userdata",
         "contracts",
         join("userdata", "epicids"),


### PR DESCRIPTION
like seriously why wasnt that added when we added the "plugins" folder feature