### PR TITLE
Optimization: grouping challenges by parent locations

### DIFF
--- a/components/candle/challengeHelpers.ts
+++ b/components/candle/challengeHelpers.ts
@@ -67,7 +67,6 @@ export enum ChallengeFilterType {
     None = "None",
     Contract = "Contract",
     Contracts = "Contracts",
-    ParentLocation = "ParentLocation",
 }
 
 export type ChallengeFilterOptions =

--- a/components/candle/challengeHelpers.ts
+++ b/components/candle/challengeHelpers.ts
@@ -78,28 +78,28 @@ export type ChallengeFilterOptions =
           type: ChallengeFilterType.Contract
           contractId: string
           locationId: string
-          locationParentId: string
       }
     | {
           type: ChallengeFilterType.Contracts
           contractIds: string[]
           locationId: string
-          locationParentId: string
-      }
-    | {
-          type: ChallengeFilterType.ParentLocation
-          locationParentId: string
       }
 
+/**
+ * Judges whether a challenge should be included in the challenges list of a contract.
+ * @requires The challenge and the contract share the same parent location.
+ * @param contractId The id of the contract.
+ * @param locationId The sublocation ID of the challenge.
+ * @param challenge The challenge in question.
+ * @returns A boolean value, denoting the result.
+ */
 function isChallengeInContract(
     contractId: string,
     locationId: string,
-    locationParentId: string,
     challenge: RegistryChallenge,
-) {
+): boolean {
     assert.ok(contractId)
     assert.ok(locationId)
-    assert.ok(locationParentId)
     if (!challenge) {
         return false
     }
@@ -113,25 +113,23 @@ function isChallengeInContract(
         return true
     }
 
-    // is this for the current contract?
+    // Is this for the current contract?
     const isForContract = (challenge.InclusionData?.ContractIds || []).includes(
         contractId,
     )
 
-    // is this a location-wide challenge?
-    // "location" is more widely used, but "parentlocation" is used in ambrose and berlin, as well as some "Discover XX" challenges.
+    // Is this a location-wide challenge?
+    // "location" is more widely used, but "parentlocation" is used in Ambrose and Berlin, as well as some "Discover XX" challenges.
     const isForLocation =
         challenge.Type === "location" || challenge.Type === "parentlocation"
 
-    // is this for the current location?
+    // Is this for the current location?
     const isCurrentLocation =
-        // is this challenge for the current parent location?
-        challenge.ParentLocationId === locationParentId &&
-        // and, is this challenge's location one of these things:
-        // 1. the current sub-location, e.g. "LOCATION_COASTALTOWN_NIGHT". This is the most common.
-        // 2. the parent location (yup, that can happen), e.g. "LOCATION_PARENT_HOKKAIDO" in Discover Hokkaido
-        (challenge.LocationId === locationId ||
-            challenge.LocationId === locationParentId)
+        // Is this challenge's location one of these things:
+        // 1. The current sub-location, e.g. "LOCATION_COASTALTOWN_NIGHT". This is the most common.
+        // 2. The parent location (yup, that can happen), e.g. "LOCATION_PARENT_HOKKAIDO" in Discover Hokkaido.
+        challenge.LocationId === locationId ||
+        challenge.LocationId === challenge.ParentLocationId
 
     return isForContract || (isForLocation && isCurrentLocation)
 }
@@ -147,7 +145,6 @@ export function filterChallenge(
             return isChallengeInContract(
                 options.contractId,
                 options.locationId,
-                options.locationParentId,
                 challenge,
             )
         }
@@ -156,16 +153,9 @@ export function filterChallenge(
                 isChallengeInContract(
                     contractId,
                     options.locationId,
-                    options.locationParentId,
                     challenge,
                 ),
             )
         }
-        case ChallengeFilterType.ParentLocation:
-            assert.ok(options.locationParentId)
-
-            return (
-                (challenge?.ParentLocationId || "") === options.locationParentId
-            )
     }
 }

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -128,11 +128,17 @@ export abstract class ChallengeRegistry {
         return this.challenges.get(challengeId)
     }
 
+    /**
+     * Gets a challenge group by its parent location and group ID.
+     * @param groupId The group ID of the challenge group.
+     * @param location The parent location for this challenge group.
+     * @returns A `SavedChallengeGroup` if such a group exists, or `undefined` if not.
+     */
     getGroupByIdLoc(
         groupId: string,
         location: string,
     ): SavedChallengeGroup | undefined {
-        return this.groups.get(location).get(groupId)
+        return this.groups?.get(location)?.get(groupId)
     }
 
     getDependenciesForChallenge(challengeId: string): readonly string[] {
@@ -314,6 +320,7 @@ export class ChallengeService extends ChallengeRegistry {
                             : undefined
                     })
                     .filter(Boolean) as RegistryChallenge[]
+
                 challenges.push([groupId, [...groupChallenges]])
             }
         }

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -138,7 +138,7 @@ export abstract class ChallengeRegistry {
         groupId: string,
         location: string,
     ): SavedChallengeGroup | undefined {
-        return this.groups?.get(location)?.get(groupId)
+        return this.groups.get(location)?.get(groupId)
     }
 
     getDependenciesForChallenge(challengeId: string): readonly string[] {
@@ -300,7 +300,7 @@ export class ChallengeService extends ChallengeRegistry {
         let challenges: [string, RegistryChallenge[]][] = []
 
         for (const groupId of this.groups.get(location).keys()) {
-            const groupContents = this.groupContents.get(location).get(groupId)
+            const groupContents = this.groupContents.get(location)?.get(groupId)
             if (groupContents) {
                 let groupChallenges: RegistryChallenge[] | string[] = [
                     ...groupContents,

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -714,7 +714,7 @@ export class ChallengeService extends ChallengeRegistry {
      * @param userId The id of the user.
      * @param gameVersion The current game version.
      * @param location A location as an `Unlockable`. Might be a parent location or a sublocation, depending on `isDestination`.
-     * @param isDestination True if the challenge lists are for a destination.
+     * @param isDestination Will also get escalation challenges if set to true.
      * @returns An array of `CompiledChallengeTreeCategory` objects.
      */
     private reBatchIntoSwitchedData(
@@ -732,9 +732,7 @@ export class ChallengeService extends ChallengeRegistry {
         return entries.map(([groupId, challenges], index) => {
             const groupData = this.getGroupByIdLoc(
                 groupId,
-                isDestination
-                    ? location.Id
-                    : location.Properties.ParentLocation,
+                location.Properties.ParentLocation ?? location.Id,
             )
             const challengeProgressionData = challenges.map((challengeData) =>
                 this.getPersistentChallengeProgression(
@@ -746,15 +744,11 @@ export class ChallengeService extends ChallengeRegistry {
 
             const lastGroup = this.getGroupByIdLoc(
                 Object.keys(challengeLists)[index - 1],
-                isDestination
-                    ? location.Id
-                    : location.Properties.ParentLocation,
+                location.Properties.ParentLocation ?? location.Id,
             )
             const nextGroup = this.getGroupByIdLoc(
                 Object.keys(challengeLists)[index + 1],
-                isDestination
-                    ? location.Id
-                    : location.Properties.ParentLocation,
+                location.Properties.ParentLocation ?? location.Id,
             )
 
             const completion = generateCompletionData(

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -78,8 +78,13 @@ type GroupIndexedChallengeLists = {
  */
 export abstract class ChallengeRegistry {
     protected challenges: Map<string, RegistryChallenge> = new Map()
-    protected groups: Map<string, SavedChallengeGroup> = new Map()
-    protected groupContents: Map<string, Set<string>> = new Map()
+
+    /** A map of parentLocationIds to maps of groupIds to SavedChallengeGroup objects for this group of this parent location. */
+    protected groups: Map<string, Map<string, SavedChallengeGroup>> = new Map()
+
+    /** A map of parentLocationIds to maps of groupIds to sets of challenge Ids in this group of this parent location. */
+
+    protected groupContents: Map<string, Map<string, Set<string>>> = new Map()
     /**
      * A map of a challenge ID to a list of challenge IDs that it depends on.
      */
@@ -88,31 +93,46 @@ export abstract class ChallengeRegistry {
 
     protected constructor(protected readonly controller: Controller) {}
 
-    registerChallenge(challenge: RegistryChallenge, groupId: string): void {
+    registerChallenge(
+        challenge: RegistryChallenge,
+        groupId: string,
+        location: string,
+    ): void {
         challenge.inGroup = groupId
         this.challenges.set(challenge.Id, challenge)
 
-        if (!this.groupContents.has(groupId)) {
-            this.groupContents.set(groupId, new Set())
+        if (!this.groupContents.has(location)) {
+            this.groupContents.set(location, new Map())
         }
 
-        const set = this.groupContents.get(groupId)!
+        const locationMap = this.groupContents.get(location)!
+
+        if (!locationMap.has(groupId)) {
+            locationMap.set(groupId, new Set())
+        }
+
+        const set = locationMap.get(groupId)!
         set.add(challenge.Id)
-        this.groupContents.set(groupId, set)
 
         this.checkHeuristics(challenge)
     }
 
-    registerGroup(group: SavedChallengeGroup): void {
-        this.groups.set(group.CategoryId, group)
+    registerGroup(group: SavedChallengeGroup, location: string): void {
+        if (!this.groups.has(location)) {
+            this.groups.set(location, new Map())
+        }
+        this.groups.get(location).set(group.CategoryId, group)
     }
 
     getChallengeById(challengeId: string): RegistryChallenge | undefined {
         return this.challenges.get(challengeId)
     }
 
-    getGroupById(groupId: string): SavedChallengeGroup | undefined {
-        return this.groups.get(groupId)
+    getGroupByIdLoc(
+        groupId: string,
+        location: string,
+    ): SavedChallengeGroup | undefined {
+        return this.groups.get(location).get(groupId)
     }
 
     getDependenciesForChallenge(challengeId: string): readonly string[] {
@@ -260,23 +280,29 @@ export class ChallengeService extends ChallengeRegistry {
     }
 
     /**
-     * Get challenge lists sorted into groups.
+     * Filter all challenges in a parent location using a given filter, sort them into groups,
+     * and return them as a `GroupIndexedChallengeLists`.
      *
      * @param filter The filter to use.
+     * @param location The parent location whose challenges to get.
+     * @returns A GroupIndexedChallengeLists containing the resulting challenge groups.
      */
     getGroupedChallengeLists(
         filter: ChallengeFilterOptions,
+        location: string,
     ): GroupIndexedChallengeLists {
         let challenges: [string, RegistryChallenge[]][] = []
 
-        for (const groupId of this.groups.keys()) {
-            const groupContents = this.groupContents.get(groupId)
-
+        for (const groupId of this.groups.get(location).keys()) {
+            const groupContents = this.groupContents.get(location).get(groupId)
             if (groupContents) {
                 let groupChallenges: RegistryChallenge[] | string[] = [
                     ...groupContents,
                 ]
-
+                log(
+                    LogLevel.DEBUG,
+                    `Before filtering, challenge group ${groupId} has ${groupChallenges.length} challenges.`,
+                )
                 groupChallenges = groupChallenges
                     .map((challengeId) => {
                         const challenge = this.getChallengeById(challengeId)
@@ -291,7 +317,10 @@ export class ChallengeService extends ChallengeRegistry {
                             : undefined
                     })
                     .filter(Boolean) as RegistryChallenge[]
-
+                log(
+                    LogLevel.DEBUG,
+                    `After filtering, challenge group ${groupId} has ${groupChallenges.length} challenges.`,
+                )
                 challenges.push([groupId, [...groupChallenges]])
             }
         }
@@ -319,12 +348,15 @@ export class ChallengeService extends ChallengeRegistry {
 
         assert.ok(contractParentLocation)
 
-        return this.getGroupedChallengeLists({
-            type: ChallengeFilterType.Contract,
-            contractId: contractId,
-            locationId: contract.Metadata.Location,
-            locationParentId: contractParentLocation,
-        })
+        return this.getGroupedChallengeLists(
+            {
+                type: ChallengeFilterType.Contract,
+                contractId: contractId,
+                locationId: contract.Metadata.Location,
+                locationParentId: contractParentLocation,
+            },
+            contractParentLocation,
+        )
     }
 
     getChallengesForLocation(
@@ -350,12 +382,15 @@ export class ChallengeService extends ChallengeRegistry {
             contracts = []
         }
 
-        return this.getGroupedChallengeLists({
-            type: ChallengeFilterType.Contracts,
-            contractIds: contracts,
-            locationId: child,
-            locationParentId: parent,
-        })
+        return this.getGroupedChallengeLists(
+            {
+                type: ChallengeFilterType.Contracts,
+                contractIds: contracts,
+                locationId: child,
+                locationParentId: parent,
+            },
+            parent,
+        )
     }
 
     startContract(
@@ -621,10 +656,13 @@ export class ChallengeService extends ChallengeRegistry {
             return []
         }
 
-        const forLocation = this.getGroupedChallengeLists({
-            type: ChallengeFilterType.ParentLocation,
+        const forLocation = this.getGroupedChallengeLists(
+            {
+                type: ChallengeFilterType.ParentLocation,
+                locationParentId,
+            },
             locationParentId,
-        })
+        )
 
         return this.reBatchIntoSwitchedData(
             forLocation,
@@ -670,11 +708,20 @@ export class ChallengeService extends ChallengeRegistry {
         )
     }
 
+    /**
+     * Re-batch a `GroupIndexedChallengeLists` object into a `CompiledChallengeTreeCategory` array.
+     * @param challengeLists The challenge lists to use.
+     * @param userId The id of the user.
+     * @param gameVersion The current game version.
+     * @param location A location as an `Unlockable`. Might be a parent location or a sublocation, depending on `isDestination`.
+     * @param isDestination True if the challenge lists are for a destination.
+     * @returns An array of `CompiledChallengeTreeCategory` objects.
+     */
     private reBatchIntoSwitchedData(
         challengeLists: GroupIndexedChallengeLists,
         userId: string,
         gameVersion: GameVersion,
-        subLocation: Unlockable,
+        location: Unlockable,
         isDestination = false,
     ): CompiledChallengeTreeCategory[] {
         const entries = Object.entries(challengeLists)
@@ -683,7 +730,12 @@ export class ChallengeService extends ChallengeRegistry {
             : this.compileRegistryChallengeTreeData.bind(this)
 
         return entries.map(([groupId, challenges], index) => {
-            const groupData = this.getGroupById(groupId)
+            const groupData = this.getGroupByIdLoc(
+                groupId,
+                isDestination
+                    ? location.Id
+                    : location.Properties.ParentLocation,
+            )
             const challengeProgressionData = challenges.map((challengeData) =>
                 this.getPersistentChallengeProgression(
                     userId,
@@ -692,15 +744,21 @@ export class ChallengeService extends ChallengeRegistry {
                 ),
             )
 
-            const lastGroup = this.getGroupById(
+            const lastGroup = this.getGroupByIdLoc(
                 Object.keys(challengeLists)[index - 1],
+                isDestination
+                    ? location.Id
+                    : location.Properties.ParentLocation,
             )
-            const nextGroup = this.getGroupById(
+            const nextGroup = this.getGroupByIdLoc(
                 Object.keys(challengeLists)[index + 1],
+                isDestination
+                    ? location.Id
+                    : location.Properties.ParentLocation,
             )
 
             const completion = generateCompletionData(
-                subLocation?.Id,
+                location?.Id,
                 userId,
                 gameVersion,
             )
@@ -716,10 +774,10 @@ export class ChallengeService extends ChallengeRegistry {
                     (progressionData) => progressionData.Completed,
                 ).length,
                 CompletionData: completion,
-                Location: subLocation,
-                IsLocked: subLocation.Properties.IsLocked || false,
-                ImageLocked: subLocation.Properties.LockedIcon || "",
-                RequiredResources: subLocation.Properties.RequiredResources!,
+                Location: location,
+                IsLocked: location.Properties.IsLocked || false,
+                ImageLocked: location.Properties.LockedIcon || "",
+                RequiredResources: location.Properties.RequiredResources!,
                 SwitchData: {
                     Data: {
                         Challenges: this.mapSwitchChallenges(
@@ -778,7 +836,10 @@ export class ChallengeService extends ChallengeRegistry {
             IsLocked: challenge.IsLocked || false,
             HideProgression: false,
             CategoryName:
-                this.getGroupById(challenge.inGroup!)?.Name || "NOTFOUND",
+                this.getGroupByIdLoc(
+                    challenge.inGroup!,
+                    challenge.ParentLocationId,
+                )?.Name || "NOTFOUND",
             Icon: challenge.Icon,
             LocationId: challenge.LocationId,
             ParentLocationId: challenge.ParentLocationId,

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -299,10 +299,7 @@ export class ChallengeService extends ChallengeRegistry {
                 let groupChallenges: RegistryChallenge[] | string[] = [
                     ...groupContents,
                 ]
-                log(
-                    LogLevel.DEBUG,
-                    `Before filtering, challenge group ${groupId} has ${groupChallenges.length} challenges.`,
-                )
+
                 groupChallenges = groupChallenges
                     .map((challengeId) => {
                         const challenge = this.getChallengeById(challengeId)
@@ -317,10 +314,6 @@ export class ChallengeService extends ChallengeRegistry {
                             : undefined
                     })
                     .filter(Boolean) as RegistryChallenge[]
-                log(
-                    LogLevel.DEBUG,
-                    `After filtering, challenge group ${groupId} has ${groupChallenges.length} challenges.`,
-                )
                 challenges.push([groupId, [...groupChallenges]])
             }
         }
@@ -353,7 +346,6 @@ export class ChallengeService extends ChallengeRegistry {
                 type: ChallengeFilterType.Contract,
                 contractId: contractId,
                 locationId: contract.Metadata.Location,
-                locationParentId: contractParentLocation,
             },
             contractParentLocation,
         )
@@ -387,7 +379,6 @@ export class ChallengeService extends ChallengeRegistry {
                 type: ChallengeFilterType.Contracts,
                 contractIds: contracts,
                 locationId: child,
-                locationParentId: parent,
             },
             parent,
         )
@@ -658,8 +649,7 @@ export class ChallengeService extends ChallengeRegistry {
 
         const forLocation = this.getGroupedChallengeLists(
             {
-                type: ChallengeFilterType.ParentLocation,
-                locationParentId,
+                type: ChallengeFilterType.None,
             },
             locationParentId,
         )

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -1238,8 +1238,7 @@ export function contractIdToHitObject(
 
     const challenges = controller.challengeService.getGroupedChallengeLists(
         {
-            type: ChallengeFilterType.ParentLocation,
-            locationParentId: parentLocation?.Id,
+            type: ChallengeFilterType.None,
         },
         parentLocation?.Id,
     )

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -959,12 +959,13 @@ export class Controller {
                 continue
             }
 
-            this.challengeService.registerGroup(group)
+            this.challengeService.registerGroup(group, data.meta.Location)
 
             for (const challenge of group.Challenges) {
                 this.challengeService.registerChallenge(
                     challenge,
                     group.CategoryId,
+                    data.meta.Location,
                 )
             }
         }
@@ -1235,10 +1236,13 @@ export function contractIdToHitObject(
         return undefined
     }
 
-    const challenges = controller.challengeService.getGroupedChallengeLists({
-        type: ChallengeFilterType.ParentLocation,
-        locationParentId: parentLocation?.Id,
-    })
+    const challenges = controller.challengeService.getGroupedChallengeLists(
+        {
+            type: ChallengeFilterType.ParentLocation,
+            locationParentId: parentLocation?.Id,
+        },
+        parentLocation?.Id,
+    )
 
     const challengeCompletion =
         controller.challengeService.countTotalNCompletedChallenges(

--- a/components/menus/destinations.ts
+++ b/components/menus/destinations.ts
@@ -56,8 +56,7 @@ export function getDestinationCompletion(
     const userData = getUserData(req.jwt.unique_name, req.gameVersion)
     const challenges = controller.challengeService.getGroupedChallengeLists(
         {
-            type: ChallengeFilterType.ParentLocation,
-            locationParentId: parent.Id,
+            type: ChallengeFilterType.None,
         },
         parent.Id,
     )

--- a/components/menus/destinations.ts
+++ b/components/menus/destinations.ts
@@ -54,10 +54,13 @@ export function getDestinationCompletion(
     req: RequestWithJwt,
 ) {
     const userData = getUserData(req.jwt.unique_name, req.gameVersion)
-    const challenges = controller.challengeService.getGroupedChallengeLists({
-        type: ChallengeFilterType.ParentLocation,
-        locationParentId: parent.Id,
-    })
+    const challenges = controller.challengeService.getGroupedChallengeLists(
+        {
+            type: ChallengeFilterType.ParentLocation,
+            locationParentId: parent.Id,
+        },
+        parent.Id,
+    )
 
     if (parent.Opportunities === undefined) {
         parent.Opportunities = 0

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -272,10 +272,13 @@ export async function missionEnd(
     const location = contractData.Metadata.Location
     const parent = locations.children[location].Properties.ParentLocation
     const locationChallenges =
-        controller.challengeService.getGroupedChallengeLists({
-            type: ChallengeFilterType.ParentLocation,
-            locationParentId: parent,
-        })
+        controller.challengeService.getGroupedChallengeLists(
+            {
+                type: ChallengeFilterType.ParentLocation,
+                locationParentId: parent,
+            },
+            parent,
+        )
     const contractChallenges =
         controller.challengeService.getChallengesForContract(
             sessionDetails.contractId,

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -274,8 +274,7 @@ export async function missionEnd(
     const locationChallenges =
         controller.challengeService.getGroupedChallengeLists(
             {
-                type: ChallengeFilterType.ParentLocation,
-                locationParentId: parent,
+                type: ChallengeFilterType.None,
             },
             parent,
         )


### PR DESCRIPTION
## Problem:
Each time `getGroupedChallengeLists` is called, a filter is applied to **all** the challenges in the game. However, it is guaranteed that challenges will not appear in locations other than their own. This can be leveraged to speed things up. 
## Refactorization: 
Instead of being organized in a giant `Map<string, Set<string>>`, challenges are now grouped by parent location IDs and stored in a `Map<string, Map<string, Set<string>>>`, which uses a `parentLocationId` as the first index and a `groupId` as the second. Everything else is changed accordingly.

## Benchmarking:

Due to the nature of Peacock, benchmarking was difficult to automate. However, I timed the function that handles `/profiles/page/Hub` using the differences between `Date.now()` calls, and manually ran a few times to compare the performance of this implementation to the latest v6 code. All runs are cold starts and all time units are milliseconds. 
| refactored | 182 | 184 | 189 | 192 | 197 | Avg: 188.8 |
|:----------:|:---:|:---:|:---:|:---:|:---:|:----------:|
|     v6     | 242 | 289 | 256 | 301 | 240 | Avg: 265.6 |

This optimization roughly achieves a speedup of 1.40x on the `/profiles/page/Hub` handler, of which challenge data generation is but a small part. As lists of challenges need to be generated on-the-fly throughout the game, this optimization brings about considerable speedup.

## Breaking Changes:
- The types of `groups` and `groupContents` in `components/candle/challengeService.ts` have changed.
- The `ChallengeFilterOptions` and `ChallengeFilterType` type definitions have changed. 
- The function signatures of the following functions have changed:
  - `isChallengeInContract` in `components/candle/challengeHelpers.ts`
  - `registerChallenge` in `components/candle/challengeService.ts`
  - `registerGroup` in `components/candle/challengeService.ts`
  - `getGroupById` in `components/candle/challengeService.ts`
  - `getGroupedChallengeLists` in `components/candle/challengeService.ts`

