### PR TITLE
Remove disguises from inventory in h1 and h2

### DIFF
--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -112,6 +112,13 @@ export function createInventory(
                 return false
             }
 
+            if (
+                unlockContainer.Unlockable.Type === "disguise" &&
+                !unlockContainer.Unlockable.Properties.OrderIndex
+            ) {
+                return false
+            }
+
             if (gameVersion === "h1") {
                 return true
             }


### PR DESCRIPTION
- Fixes #113. 
- Does not affect suits in H3, as it has its own filters. 