### PR TITLE
Fixed typo in condition for 'No Firearms' secondary task

### DIFF
--- a/static/EvergreenGameChangerProperties.json
+++ b/static/EvergreenGameChangerProperties.json
@@ -9418,7 +9418,7 @@
                             "FirstMissedShot": {
                                 "Transition": "Failure"
                             },
-                            "FirstNonHeadshot": {
+                            "FirstNonHeadShot": {
                                 "Transition": "Failure"
                             },
                             "Kill": {


### PR DESCRIPTION
I think failing one task, but not the other, is not an intended behavior. Since Dartgun is not a **Fire**arm, it should not fail at all.