### PR TITLE
Remove "contract xx not found" log output

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -670,7 +670,6 @@ export class Controller {
         if (openCtJson) {
             return fastClone(openCtJson)
         }
-        log(LogLevel.TRACE, `Contract ${id} not found!`)
         return undefined
     }
 


### PR DESCRIPTION
- It is too confusing and makes people think something is wrong when it thinks it cannot find escalations, but actually it's just a result of the absence of escalation groups.