### PR TITLE
Favorite contracts rework

### DIFF
--- a/components/contracts/dataGen.ts
+++ b/components/contracts/dataGen.ts
@@ -189,6 +189,12 @@ export function generateUserCentric(
                     ? undefined
                     : new Date(played[id]?.LastPlayedAt).toISOString(),
             // relevant for contracts
+            // Favorite contracts
+            PlaylistData: {
+                IsAdded:
+                    userData.Extensions?.PeacockFavoriteContracts?.includes(id),
+                AddedTime: "0001-01-01T00:00:00Z",
+            },
             Completed: played[id] === undefined ? false : played[id]?.Completed,
             LocationId: subLocation.Id,
             ParentLocationId: subLocation.Properties.ParentLocation!,

--- a/components/contracts/hitsCategoryService.ts
+++ b/components/contracts/hitsCategoryService.ts
@@ -223,9 +223,10 @@ export class HitsCategoryService {
         )
         controller.storeIdToPublicId(hits.map((hit) => hit.UserCentricContract))
 
-        // Fix completion status for retrieved contracts
+        // Fix completion and favorite status for retrieved contracts
         const userProfile = getUserData(userId, gameVersion)
         const played = userProfile?.Extensions.PeacockPlayedContracts
+        const favorites = userProfile?.Extensions.PeacockFavoriteContracts
 
         hits.forEach((hit) => {
             if (Object.keys(played).includes(hit.Id)) {
@@ -240,6 +241,9 @@ export class HitsCategoryService {
                 delete hit.UserCentricContract.Data.LastPlayedAt
                 hit.UserCentricContract.Data.Completed = false
             }
+
+            hit.UserCentricContract.Data.PlaylistData.IsAdded =
+                favorites.includes(hit.Id)
         })
 
         return resp.data.data

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -80,7 +80,11 @@ import {
 } from "./menus/playnext"
 import { randomUUID } from "crypto"
 import { planningView } from "./menus/planning"
-import { directRoute, withLookupDialog } from "./menus/favoriteContracts"
+import {
+    deleteMultiple,
+    directRoute,
+    withLookupDialog,
+} from "./menus/favoriteContracts"
 import { swapToBrowsingMenusStatus } from "./discordRp"
 import axios from "axios"
 import { getFlag } from "./flags"
@@ -1859,8 +1863,14 @@ menuDataRouter.get(
 
 menuDataRouter.get(
     // this one is sane Kappa
-    "/contractplaylist/addordelete/{contractId}",
+    "/contractplaylist/addordelete/:contractId",
     directRoute,
+)
+
+menuDataRouter.post(
+    "/contractplaylist/deletemultiple",
+    jsonMiddleware(),
+    deleteMultiple,
 )
 
 menuDataRouter.get("/GetPlayerProfileXpData", (req: RequestWithJwt, res) => {

--- a/components/menus/favoriteContracts.ts
+++ b/components/menus/favoriteContracts.ts
@@ -66,6 +66,13 @@ export function withLookupDialog(
         false,
     ).find((entry) => entry.Id === contract.Metadata.Location)
 
+    // Must toggle before generating the user centric contract.
+    const flag = toggleFavorite(
+        req.jwt.unique_name,
+        req.query.contractId,
+        req.gameVersion,
+    )
+
     const result: Result = {
         template: lookupFavoriteTemplate,
         data: {
@@ -77,13 +84,8 @@ export function withLookupDialog(
                 req.gameVersion,
             ),
         },
+        ...(flag && { AddedSuccessfully: true }),
     }
-
-    result.data.AddedSuccessfully = toggleFavorite(
-        req.jwt.unique_name,
-        req.query.contractId,
-        req.gameVersion,
-    )
 
     res.json(result)
 }

--- a/components/menus/favoriteContracts.ts
+++ b/components/menus/favoriteContracts.ts
@@ -149,3 +149,34 @@ export function directRoute(req: RequestWithJwt, res: Response): void {
         },
     })
 }
+
+/**
+ * Takes an array of contract IDs and deletes them from the user's favorites.
+ * @param req The request.
+ * @param res The response.
+ */
+export function deleteMultiple(
+    req: RequestWithJwt<{ mode?: string }, string[]>,
+    res: Response,
+): void {
+    const userProfile = getUserData(req.jwt.unique_name, req.gameVersion)
+
+    // Perform some verification
+    const success = req.body?.every((id) =>
+        userProfile.Extensions.PeacockFavoriteContracts.includes(id),
+    )
+
+    if (success) {
+        req.body?.forEach((id) =>
+            toggleFavorite(req.jwt.unique_name, id, req.gameVersion),
+        )
+    }
+
+    res.json({
+        template: null,
+        data: {
+            ContractIds: req.body,
+            Success: success,
+        },
+    })
+}

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -659,6 +659,12 @@ export interface UserCentricContract {
         ElusiveContractState: string
         LastPlayedAt?: string
         IsFeatured?: boolean
+        // For favorite contracts
+        PlaylistData?: {
+            IsAdded: boolean
+            // Not sure if this is important
+            AddedTime: string
+        }
         Completed?: boolean
         LocationId: string
         ParentLocationId: string


### PR DESCRIPTION
Resolves #101 by completing all listed tasks.

Currently only supports favoriting contracts that have their jsons stored locally, in case the contract definition is not found when starting a contract from the My Favorites page.