### PR TITLE
Fix inclusion data missing for global challenges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ plugins
 /*Plugin.*
 /resources/dynamic_resources_h1/REPO/006D6B8D26B0F442.REPO
 /resources/dynamic_resources_h1/REPO/006D6B8D26B0F442.REPO.meta
+
+logs

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -941,6 +941,7 @@ export class Controller {
                     Description: e.Challenge.Description,
                     Definition: e.Challenge.Definition,
                     Xp: e.Challenge.Xp,
+                    InclusionData: e.Challenge.InclusionData,
                 }
             })
 


### PR DESCRIPTION
Previously, inclusion data was missing for global challenges. This caused the server side to track all the global challenges for every contract. Now inclusion data is correctly stored.

Also added logs to .gitignore.