### PR TITLE
Support "Discover [Location]" challenges

### DIFF
--- a/components/databaseHandler.ts
+++ b/components/databaseHandler.ts
@@ -21,7 +21,6 @@ import { join } from "path"
 import type { ContractSession, GameVersion, UserProfile } from "./types/types"
 import { serializeSession, deserializeSession } from "./sessionSerialization"
 import { castUserProfile } from "./utils"
-import { getConfig } from "./configSwizzleManager"
 import { log, LogLevel } from "./loggingInterop"
 import { unlink, readdir } from "fs/promises"
 
@@ -95,14 +94,6 @@ export function getUserData(
     gameVersion: GameVersion,
 ): UserProfile {
     const data = asyncGuard.getProfile(`${userId}.${gameVersion}`)
-
-    // we may not have this profile
-    if (data?.Extensions?.gamepersistentdata?.PersistentBool) {
-        data.Extensions.gamepersistentdata.PersistentBool = {
-            ...data.Extensions.gamepersistentdata.PersistentBool,
-            ...getConfig("PersistentBools", true),
-        }
-    }
 
     //NOTE: ProfileLevel always starts at 1
     if (data?.Extensions?.progression?.PlayerProfileXP?.ProfileLevel === 0) {

--- a/components/flags.ts
+++ b/components/flags.ts
@@ -105,6 +105,10 @@ const defaultFlags: Flags = {
         desc: "When set to true, all Freelancer unlocks will always be available.",
         default: false,
     },
+    mapDiscoveryState: {
+        desc: 'Decides what to do with the discovery state of the maps. REVEALED will reset all map locations to discovered, CLOUDED will reset all maps to undiscovered, and KEEP will keep your current discovery state. Note that these actions will take effect every time you connect to Peacock. Your progress of the "Discover [Location]" challenges will not be affected by this option.',
+        default: "KEEP",
+    },
 }
 
 const OLD_FLAGS_FILE = "flags.json5"

--- a/components/utils.ts
+++ b/components/utils.ts
@@ -31,6 +31,7 @@ import axios, { AxiosError } from "axios"
 import { log, LogLevel } from "./loggingInterop"
 import { writeFileSync } from "fs"
 import { getFlag } from "./flags"
+import { getConfig } from "./configSwizzleManager"
 
 /**
  * True if the server is being run by the launcher, false otherwise.
@@ -282,6 +283,24 @@ export function castUserProfile(profile: UserProfile): UserProfile {
             MyHistory: "all",
             MyContracts: "all",
             MyPlaylist: "all",
+        }
+    }
+
+    if (j.Extensions?.gamepersistentdata?.PersistentBool) {
+        switch (getFlag("mapDiscoveryState")) {
+            case "REVEALED":
+                j.Extensions.gamepersistentdata.PersistentBool = {
+                    ...j.Extensions.gamepersistentdata.PersistentBool,
+                    ...getConfig("PersistentBools", true),
+                }
+                break
+            case "CLOUDED":
+                j.Extensions.gamepersistentdata.PersistentBool = {
+                    __Full:
+                        j.Extensions.gamepersistentdata.PersistentBool
+                            ?.__Full ?? {},
+                }
+                break
         }
     }
 


### PR DESCRIPTION
- Supports resetting map discovery so that Discover [Location]" challenges can be completed. Resolves #110.
- Added a flag to toggle map discovery states:
   - `REVEALED`: set all map locations as discovered. Provides a way to disable map discovery progression.
   - `CLOUDED`: set all map locations to undiscovered. Provides a way for existing players to reset map discovery without having to regenerate `userdata`.
   - `KEEP`: do not overwrite the current discovery state. The default option.
   - The users' progress of the "Discover [Location]" challenges will not be affected by toggling this option.
   - New users are defaulted to having no map location discoveries, and the flag toggled to `KEEP`.