### PR TITLE
Fixed an issue where refresh_token was not properly served

### DIFF
--- a/components/oauthToken.ts
+++ b/components/oauthToken.ts
@@ -96,22 +96,7 @@ export async function handleOauthToken(
         external_platform = "epic"
         external_userid = req.body.epic_userid
         external_users_folder = "epicids"
-    } else {
-        res.status(406).end() // unsupported auth method
-        return
-    }
-
-    if (req.body.pId && !uuidRegex.test(req.body.pId)) {
-        res.status(400).end() // pId is not a GUID
-        return
-    }
-
-    const isHitman3 =
-        external_appid === "fghi4567xQOCheZIin0pazB47qGUvZw4" ||
-        external_appid === STEAM_NAMESPACE_2021
-
-    //#region Refresh tokens
-    if (req.body.grant_type === "refresh_token") {
+    } else if (req.body.grant_type === "refresh_token") {
         // send back the token from the request (re-signed so the timestamps update)
         extractToken(req) // init req.jwt
         // remove signOptions from existing jwt
@@ -145,8 +130,19 @@ export async function handleOauthToken(
         })
 
         return
+    } else {
+        res.status(406).end() // unsupported auth method
+        return
     }
-    //#endregion
+
+    if (req.body.pId && !uuidRegex.test(req.body.pId)) {
+        res.status(400).end() // pId is not a GUID
+        return
+    }
+
+    const isHitman3 =
+        external_appid === "fghi4567xQOCheZIin0pazB47qGUvZw4" ||
+        external_appid === STEAM_NAMESPACE_2021
 
     const gameVersion: GameVersion = isFrankenstein
         ? "scpc"

--- a/tests/helpers/testHelpers.ts
+++ b/tests/helpers/testHelpers.ts
@@ -2,13 +2,37 @@
 import type * as core from "express-serve-static-core"
 import { RequestWithJwt } from "../../components/types/types"
 import { Mock } from "vitest"
+import { sign } from "jsonwebtoken"
 
 export function asMock<T>(value: T): Mock {
     return value as Mock
 }
 
 export function mockRequestWithJwt(): RequestWithJwt<core.Query, any> {
-    return <RequestWithJwt<core.Query, any>>{}
+    const mockedRequest = <RequestWithJwt<core.Query, any>>{
+        headers: {},
+        header: (name: string) =>
+            mockedRequest.headers[name.toLowerCase()] as string,
+    }
+
+    return mockedRequest
+}
+
+export function mockRequestWithValidJwt(
+    pId: string,
+): RequestWithJwt<core.Query, any> {
+    const mockedRequest = mockRequestWithJwt()
+
+    const jwtToken = sign(
+        {
+            unique_name: pId,
+        },
+        "secret",
+    )
+
+    mockedRequest.headers.authorization = `Bearer ${jwtToken}`
+
+    return mockedRequest
 }
 
 export function mockResponse(): core.Response {


### PR DESCRIPTION
At some point the original JWT token will expire (even though we really don't care for the validity of the token) and the game desperately wants a new one. However, probably due to some refactors, this logic was in the wrong place.

Also added a test to make sure it can't break down again.