### PR TITLE
Added fallback for loadSession in case someone might have disconnected.

### DIFF
--- a/components/profileHandler.ts
+++ b/components/profileHandler.ts
@@ -829,8 +829,21 @@ async function loadSession(
     sessionData?: ContractSession,
 ): Promise<void> {
     if (!sessionData) {
-        sessionData = await getContractSession(token + "_" + sessionId)
+        try {
+            //First, try the loading the session from the filesystem.
+            sessionData = await getContractSession(token + "_" + sessionId)
+        } catch (e) {
+            //Otherwise, see if we still have this session in memory.
+            //This may be the currently active session, but we need a fallback of some sorts in case a player disconnected.
+            if (contractSessions.has(sessionId)) {
+                sessionData = contractSessions.get(sessionId)
+            } else {
+                //Rethrow the error
+                throw e
+            }
+        }
     }
+
     // Update challenge progression with the user's latest progression data
     for (const cid in sessionData.challengeContexts) {
         // Make sure the ChallengeProgression is available, otherwise loading might fail!


### PR DESCRIPTION
After investigating an issue from Discord (https://discord.com/channels/826809653181808651/1077036810082979974), the following behavior is observed:
- When a token expires, the game will request a new one (see hotfix #190).
- When this request fails, or something else entirely causes the game to think you are offline, the game will show the "reconnect popup" (and sometimes it will automatically do so!).
- If you click reconnect, you go through a full login flow (/config, /token, /GetProfile, etc).
- If you are in an active mission, the game will also called /Load.

This last one is a problem. The original version would only ever look for persisted sessions on the filesystem, however, this is not the case when you just lost connection for whatever reason (and restored it without restarting Peacock). This kind of leads into #165, but is for another day.

This fix will make sure it will always fallback to the contractSessions that may still be in memory.

This can have an unintended side effect when you try to load a save that is not persisted on the filesystem, but happens to be the exact one you are currently playing. This however is a highly unlikely scenario to occur and doesn't outweigh the benefits of this fix. Disconnecting and losing progress is annoying.