### PR TITLE
Added support for statistics under the Player Profile menu

### DIFF
--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -17,6 +17,7 @@
  */
 
 import type {
+    ChallengeCompletion,
     ChallengeProgressionData,
     ChallengeTreeWaterfallState,
     ClientToServerEvent,
@@ -551,8 +552,6 @@ export class ChallengeService extends ChallengeRegistry {
             true,
         )
         const parent = locations.children[child].Properties.ParentLocation
-        const location = locations.children[child]
-        assert.ok(location)
 
         let contracts = isSniperLocation(child)
             ? this.controller.missionsInLocations.sniper[child]
@@ -1213,7 +1212,7 @@ export class ChallengeService extends ChallengeRegistry {
         challengeLists: GroupIndexedChallengeLists,
         userId: string,
         gameVersion: GameVersion,
-    ): { ChallengesCount: number; CompletedChallengesCount: number } {
+    ): ChallengeCompletion {
         const userData = getUserData(userId, gameVersion)
 
         userData.Extensions.ChallengeProgression ??= {}
@@ -1235,6 +1234,7 @@ export class ChallengeService extends ChallengeRegistry {
         return {
             ChallengesCount: challengesCount,
             CompletedChallengesCount: completedChallengesCount,
+            CompletionPercent: completedChallengesCount / challengesCount,
         }
     }
 

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -42,6 +42,7 @@ import {
     getDestinationCompletion,
 } from "./menus/destinations"
 import type {
+    ChallengeCategoryCompletion,
     CommonSelectScreenConfig,
     ContractSearchResult,
     GameVersion,
@@ -240,7 +241,7 @@ menuDataRouter.get("/Hub", (req: RequestWithJwt, res) => {
         if (
             child === "LOCATION_ICA_FACILITY_ARRIVAL" ||
             child === "LOCATION_HOKKAIDO_SHIM_MAMUSHI" ||
-            child.search("SNUG_") > 0
+            child.includes("SNUG_")
         ) {
             continue
         }
@@ -961,7 +962,7 @@ menuDataRouter.get(
             data: {
                 Location: {},
                 MissionData: {
-                    ...getDestinationCompletion(locationData, req),
+                    ...getDestinationCompletion(locationData, undefined, req),
                     ...{ SubLocationMissionsData: [] },
                 },
                 ChallengeData: {
@@ -1828,12 +1829,81 @@ menuDataRouter.post(
     createLoadSaveMiddleware("SaveMenuTemplate"),
 )
 
-//TODO: Add statistics
 menuDataRouter.get("/PlayerProfile", (req: RequestWithJwt, res) => {
     const playerProfilePage = getConfig<PlayerProfileView>(
         "PlayerProfilePage",
         true,
     )
+
+    const locationData = getVersionedConfig<PeacockLocationsData>(
+        "LocationsData",
+        req.gameVersion,
+        false,
+    )
+
+    playerProfilePage.data.SubLocationData = []
+
+    for (const subLocationKey in locationData.children) {
+        //Ewww...
+        if (
+            subLocationKey === "LOCATION_ICA_FACILITY_ARRIVAL" ||
+            subLocationKey === "LOCATION_HOKKAIDO_SHIM_MAMUSHI" ||
+            subLocationKey.includes("SNUG_")
+        ) {
+            continue
+        }
+
+        const subLocation = locationData.children[subLocationKey]
+        const parentLocation =
+            locationData.parents[subLocation.Properties.ParentLocation]
+
+        const completionData = generateCompletionData(
+            subLocation.Id,
+            req.jwt.unique_name,
+            req.gameVersion,
+        )
+
+        //TODO: Make getDestinationCompletion do something like this.
+        const challenges = controller.challengeService.getChallengesForLocation(
+            subLocation.Id,
+            req.gameVersion,
+        )
+
+        const challengeCategoryCompletion: ChallengeCategoryCompletion[] = []
+
+        for (const challengeGroup in challenges) {
+            const challengeCompletion =
+                controller.challengeService.countTotalNCompletedChallenges(
+                    {
+                        challengeGroup: challenges[challengeGroup],
+                    },
+                    req.jwt.unique_name,
+                    req.gameVersion,
+                )
+
+            challengeCategoryCompletion.push({
+                Name: challenges[challengeGroup][0].CategoryName,
+                ...challengeCompletion,
+            })
+        }
+
+        const destinationCompletion = getDestinationCompletion(
+            parentLocation,
+            subLocation,
+            req,
+        )
+
+        playerProfilePage.data.SubLocationData.push({
+            ParentLocation: parentLocation,
+            Location: subLocation,
+            CompletionData: completionData,
+            ChallengeCategoryCompletion: challengeCategoryCompletion,
+            ChallengeCompletion: destinationCompletion.ChallengeCompletion,
+            OpportunityStatistics: destinationCompletion.OpportunityStatistics,
+            LocationCompletionPercent:
+                destinationCompletion.LocationCompletionPercent,
+        })
+    }
 
     const userProfile = getUserData(req.jwt.unique_name, req.gameVersion)
     playerProfilePage.data.PlayerProfileXp.Total =

--- a/components/menus/destinations.ts
+++ b/components/menus/destinations.ts
@@ -22,6 +22,7 @@ import type {
     GameLocationsData,
     GameVersion,
     MissionStory,
+    OpportunityStatistics,
     PeacockLocationsData,
     RequestWithJwt,
     Unlockable,
@@ -37,10 +38,7 @@ type GameFacingDestination = {
         CompletedChallengesCount: number
     }
     CompletionData: CompletionData
-    OpportunityStatistics: {
-        Count: number
-        Completed: number
-    }
+    OpportunityStatistics: OpportunityStatistics
     LocationCompletionPercent: number
     Location: Unlockable
 }
@@ -51,6 +49,7 @@ const missionStories = getConfig<Record<string, MissionStory>>(
 
 export function getDestinationCompletion(
     parent: Unlockable,
+    child: Unlockable | undefined,
     req: RequestWithJwt,
 ) {
     const userData = getUserData(req.jwt.unique_name, req.gameVersion)
@@ -62,16 +61,15 @@ export function getDestinationCompletion(
         req.gameVersion,
     )
 
-    if (parent.Opportunities === undefined) {
-        parent.Opportunities = 0
-    }
+    const opportunities = Object.values(missionStories)
+        .filter((e) =>
+            child ? e.SubLocation === child.Id : e.Location === parent.Id,
+        )
+        .map((e) => e.CommonRepositoryId)
 
     let opportunityCompletedCount = 0
     for (const ms in userData.Extensions.opportunityprogression) {
-        if (
-            Object.keys(missionStories).includes(ms) &&
-            missionStories[ms].Location === parent.Id
-        ) {
+        if (opportunities.includes(ms)) {
             opportunityCompletedCount++
         }
     }
@@ -85,14 +83,14 @@ export function getDestinationCompletion(
     return {
         ChallengeCompletion: challengeCompletion,
         OpportunityStatistics: {
-            Count: parent.Opportunities,
+            Count: opportunities.length,
             Completed: opportunityCompletedCount,
         },
         LocationCompletionPercent: getCompletionPercent(
             challengeCompletion.CompletedChallengesCount,
             challengeCompletion.ChallengesCount,
             opportunityCompletedCount,
-            parent.Opportunities,
+            opportunities.length,
         ),
         Location: parent,
     }
@@ -136,7 +134,7 @@ export function destinationsMenu(req: RequestWithJwt): GameFacingDestination[] {
             "UI_LOCATION_PARENT_" + destination.substring(16) + "_NAME"
 
         const template: GameFacingDestination = {
-            ...getDestinationCompletion(parent, req),
+            ...getDestinationCompletion(parent, undefined, req),
             ...{
                 CompletionData: generateCompletionData(
                     destination,

--- a/components/types/score.ts
+++ b/components/types/score.ts
@@ -1,5 +1,11 @@
 import { Playstyle, ScoringBonus, ScoringHeadline } from "./scoring"
-import { CompletionData, Seconds, Unlockable } from "./types"
+import {
+    ChallengeCompletion,
+    CompletionData,
+    OpportunityStatistics,
+    Seconds,
+    Unlockable,
+} from "./types"
 
 export interface CalculateXpResult {
     completedChallenges: MissionEndChallenge[]
@@ -95,18 +101,9 @@ export interface MissionEndResponse {
             Name: string
         }
         CompletionData: CompletionData
-        ChallengeCompletion: {
-            ChallengesCount: number
-            CompletedChallengesCount: number
-        }
-        ContractChallengeCompletion: {
-            ChallengesCount: number
-            CompletedChallengesCount: number
-        }
-        OpportunityStatistics: {
-            Count: number
-            Completed: number
-        }
+        ChallengeCompletion: ChallengeCompletion
+        ContractChallengeCompletion: ChallengeCompletion
+        OpportunityStatistics: OpportunityStatistics
         LocationCompletionPercent: number
     }
     ScoreOverview: {

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -369,12 +369,22 @@ export interface MissionStory {
     Summary: string
     Briefing: string
     Location: string
+    SubLocation: string
     Image: string
 }
 
 export interface PlayerProfileView {
     template: unknown
     data: {
+        SubLocationData: {
+            ParentLocation: Unlockable
+            Location: Unlockable
+            CompletionData: CompletionData
+            ChallengeCategoryCompletion: ChallengeCategoryCompletion[]
+            ChallengeCompletion: ChallengeCompletion
+            OpportunityStatistics: OpportunityStatistics
+            LocationCompletionPercent: number
+        }[]
         PlayerProfileXp: {
             Total: number
             Level: number
@@ -392,6 +402,21 @@ export interface PlayerProfileView {
             }[]
         }
     }
+}
+
+export interface ChallengeCompletion {
+    ChallengesCount: number
+    CompletedChallengesCount: number
+    CompletionPercent?: number
+}
+
+export interface ChallengeCategoryCompletion extends ChallengeCompletion {
+    Name: string
+}
+
+export interface OpportunityStatistics {
+    Count: number
+    Completed: number
 }
 
 export interface ContractHistory {
@@ -521,7 +546,6 @@ export interface NamespaceEntitlementEpic {
  */
 export interface Unlockable {
     Id: string
-    Opportunities?: number
     DisplayNameLocKey: string
     GameAsset: string | null
     Guid: string

--- a/static/LocationsData.json
+++ b/static/LocationsData.json
@@ -2,7 +2,6 @@
     "parents": {
         "LOCATION_PARENT_ICA_FACILITY": {
             "Id": "LOCATION_PARENT_ICA_FACILITY",
-            "Opportunities": 4,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -35,7 +34,6 @@
         },
         "LOCATION_PARENT_PARIS": {
             "Id": "LOCATION_PARENT_PARIS",
-            "Opportunities": 8,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -69,7 +67,6 @@
         },
         "LOCATION_PARENT_COASTALTOWN": {
             "Id": "LOCATION_PARENT_COASTALTOWN",
-            "Opportunities": 19,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -102,7 +99,6 @@
         },
         "LOCATION_PARENT_MARRAKECH": {
             "Id": "LOCATION_PARENT_MARRAKECH",
-            "Opportunities": 12,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -135,7 +131,6 @@
         },
         "LOCATION_PARENT_BANGKOK": {
             "Id": "LOCATION_PARENT_BANGKOK",
-            "Opportunities": 8,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -170,7 +165,6 @@
         },
         "LOCATION_PARENT_COLORADO": {
             "Id": "LOCATION_PARENT_COLORADO",
-            "Opportunities": 6,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -205,7 +199,6 @@
         },
         "LOCATION_PARENT_HOKKAIDO": {
             "Id": "LOCATION_PARENT_HOKKAIDO",
-            "Opportunities": 7,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -276,7 +269,6 @@
         },
         "LOCATION_PARENT_MIAMI": {
             "Id": "LOCATION_PARENT_MIAMI",
-            "Opportunities": 7,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -314,7 +306,6 @@
         },
         "LOCATION_PARENT_COLOMBIA": {
             "Id": "LOCATION_PARENT_COLOMBIA",
-            "Opportunities": 7,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -351,7 +342,6 @@
         },
         "LOCATION_PARENT_MUMBAI": {
             "Id": "LOCATION_PARENT_MUMBAI",
-            "Opportunities": 7,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -388,7 +378,6 @@
         },
         "LOCATION_PARENT_NORTHAMERICA": {
             "Id": "LOCATION_PARENT_NORTHAMERICA",
-            "Opportunities": 7,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -422,7 +411,6 @@
         },
         "LOCATION_PARENT_NORTHSEA": {
             "Id": "LOCATION_PARENT_NORTHSEA",
-            "Opportunities": 6,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -456,7 +444,6 @@
         },
         "LOCATION_PARENT_GREEDY": {
             "Id": "LOCATION_PARENT_GREEDY",
-            "Opportunities": 5,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -493,7 +480,6 @@
         },
         "LOCATION_PARENT_OPULENT": {
             "Id": "LOCATION_PARENT_OPULENT",
-            "Opportunities": 5,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -530,7 +516,6 @@
         },
         "LOCATION_PARENT_GOLDEN": {
             "Id": "LOCATION_PARENT_GOLDEN",
-            "Opportunities": 3,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -587,7 +572,6 @@
             "Rarity": null,
             "DisplayNameLocKey": "UI_LOCATION_PARENT_ANCESTRAL_NAME",
             "Id": "LOCATION_PARENT_ANCESTRAL",
-            "Opportunities": 3,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -639,7 +623,6 @@
         },
         "LOCATION_PARENT_WET": {
             "Id": "LOCATION_PARENT_WET",
-            "Opportunities": 3,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,
@@ -676,7 +659,6 @@
         },
         "LOCATION_PARENT_ELEGANT": {
             "Id": "LOCATION_PARENT_ELEGANT",
-            "Opportunities": 3,
             "Type": "location",
             "Subtype": "location",
             "GameAsset": null,

--- a/static/MissionStories.json
+++ b/static/MissionStories.json
@@ -7,6 +7,7 @@
         "Summary": "op3007_kruger_002",
         "Briefing": "op3007_kruger_003",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/undercover_model.jpg"
     },
     "728ff71e-395d-4a00-8065-305a43a92105": {
@@ -17,6 +18,7 @@
         "Summary": "op3008_cocktail_002",
         "Briefing": "op3008_cocktail_003",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/a_drink_to_die_for.jpg"
     },
     "0a051691-d391-47f9-aad6-6d2807b3bb69": {
@@ -27,6 +29,7 @@
         "Summary": "op3002_decker_002",
         "Briefing": "op3002_decker_003",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/a_private_meeting.jpg"
     },
     "468177b2-fa0a-41f5-b510-80fcd142ed6f": {
@@ -37,6 +40,7 @@
         "Summary": "op3005_auctionlaptop_002",
         "Briefing": "op3005_auctionlaptop_003",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/a_quick_break.jpg"
     },
     "2e79a8f1-4498-41c8-9784-d48173d61b0a": {
@@ -47,6 +51,7 @@
         "Summary": "op3009_interview_002",
         "Briefing": "op3009_interview_003",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/a_rare_scoop.jpg"
     },
     "6175fbd2-84f5-4c7f-a677-f61990b3a0fd": {
@@ -57,6 +62,7 @@
         "Summary": "op3003_sheikh_summarry",
         "Briefing": "op3003_sheikh_briefing",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/guest_of_honor.jpg"
     },
     "e8c68134-b552-4f48-a51f-7039f36381b1": {
@@ -67,6 +73,7 @@
         "Summary": "op3001_lightrig_002",
         "Briefing": "op3001_lightrig_003",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/lights_out.jpg"
     },
     "e6cb331f-82b1-4023-b037-21da954babbc": {
@@ -77,6 +84,7 @@
         "Summary": "op3006_fireworks_002",
         "Briefing": "op3006_fireworks_003",
         "Location": "LOCATION_PARENT_PARIS",
+        "SubLocation": "LOCATION_PARIS",
         "Image": "images/opportunities/paris/out_with_a_bang.jpg"
     },
     "3f6dea78-b0c4-4f29-961d-f7bb097b8be4": {
@@ -87,6 +95,7 @@
         "Summary": "op1007_romance_002",
         "Briefing": "op1007_romance_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/by_candlelight.jpg"
     },
     "ecf76aeb-d4b0-4b3b-8768-f209aff09476": {
@@ -97,6 +106,7 @@
         "Summary": "op1001_therapy_002",
         "Briefing": "op1001_therapy_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/catharsis.jpg"
     },
     "a725db5d-2564-4325-b38b-914426fff324": {
@@ -107,6 +117,7 @@
         "Summary": "op1010_biohazard_002",
         "Briefing": "op1010_biohazard_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/hostile_environment.jpg"
     },
     "d6bb64d2-5c4d-497e-8c23-ce36a4dffd16": {
@@ -117,6 +128,7 @@
         "Summary": "op1004_dna_002",
         "Briefing": "op1004_dna_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/memento.jpg"
     },
     "088e9238-6c4b-4644-934c-1d959706be2c": {
@@ -127,6 +139,7 @@
         "Summary": "op1005_morgue_002",
         "Briefing": "op1005_morgue_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/absolution.jpg"
     },
     "f43fe0cb-9be7-4c3a-a0a3-c7e19f8e0f3e": {
@@ -137,6 +150,7 @@
         "Summary": "op1003_thedetective_002",
         "Briefing": "op1003_thedetective_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/a_case_most_peculiar.jpg"
     },
     "2d9530dd-843c-48d5-8964-2e67aa5d368f": {
@@ -147,6 +161,7 @@
         "Summary": "op1006_ghost_002",
         "Briefing": "op1006_ghost_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/beyond_the_grave.jpg"
     },
     "1eef2ba3-8139-46c3-b05b-018aa0d30d95": {
@@ -157,6 +172,7 @@
         "Summary": "op1002_grave_002",
         "Briefing": "op1002_grave_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/the_good_son.jpg"
     },
     "0d24fffc-849c-4759-a86b-d8eebae95c4e": {
@@ -167,6 +183,7 @@
         "Summary": "op1008_video_002",
         "Briefing": "op1008_video_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/memory_lane.jpg"
     },
     "27e773ad-ab9c-42a3-9e70-cde433b6f497": {
@@ -177,6 +194,7 @@
         "Summary": "op1009_motherscooking_002",
         "Briefing": "op1009_motherscooking_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN",
         "Image": "images/opportunities/octopus/first_day_on_the_job.jpg"
     },
     "6063b035-c9a1-4716-b727-1fc2d6b7b2d4": {
@@ -187,6 +205,7 @@
         "Summary": "opp_evac_description",
         "Briefing": "opp_evac_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_evacatschool.jpg"
     },
     "970d8f1a-51d7-444b-b702-b6dbdb18ce0d": {
@@ -197,6 +216,7 @@
         "Summary": "opp_headmaster_description",
         "Briefing": "opp_headmaster_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_headmasterdoor.jpg"
     },
     "1e6f7cb5-ed86-44f5-8747-e29dd8bc851d": {
@@ -207,6 +227,7 @@
         "Summary": "opp_massage_description",
         "Briefing": "opp_massage_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_massage.jpg"
     },
     "d0748978-1dca-4789-b560-13825e91388d": {
@@ -217,6 +238,7 @@
         "Summary": "opp_interview_description",
         "Briefing": "opp_interview_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_theinterview.jpg"
     },
     "fc96fa9f-969d-4224-9d11-e407cc8eb52f": {
@@ -227,6 +249,7 @@
         "Summary": "opp_printer_description",
         "Briefing": "opp_printer_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_printingpress.jpg"
     },
     "99d7d44f-05f5-4619-a42e-0aa2faaf397e": {
@@ -237,6 +260,7 @@
         "Summary": "opp_tunnel2_description",
         "Briefing": "opp_tunnel2_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_neutralground_part2.jpg"
     },
     "01033dcf-279b-4f72-8b27-300ce8e1b916": {
@@ -247,6 +271,7 @@
         "Summary": "opp_tunnel1_description",
         "Briefing": "opp_tunnel1_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_neutralground.jpg"
     },
     "80b6de08-1414-45f0-89ea-3024f0882049": {
@@ -257,6 +282,7 @@
         "Summary": "opp_prisoner_description",
         "Briefing": "opp_prisoner_flavor",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH",
         "Image": "images/opportunities/marrakesh/spider/marrakesh_opportunity_prisoner.jpg"
     },
     "b5b2e67f-c45d-4566-be2e-fa523d27d9b3": {
@@ -267,6 +293,7 @@
         "Summary": "opp4007_tuktuk_description",
         "Briefing": "opp4007_tuktuk_briefing",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/tuk_tuk.jpg"
     },
     "4c5c691a-4a8f-4a7c-a2eb-dbc21b8e47ea": {
@@ -277,6 +304,7 @@
         "Summary": "opp4008_housekeeping_009",
         "Briefing": "opp4008_housekeeping_description",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/roomservice.jpg"
     },
     "99b2cd4e-e992-40f1-9337-e37c10604c85": {
@@ -287,6 +315,7 @@
         "Summary": "opp4003_audition_description",
         "Briefing": "opp4003_audition_briefing",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/audition.jpg"
     },
     "d3469688-944c-4c05-8b9a-e1f2683ab3fd": {
@@ -297,6 +326,7 @@
         "Summary": "opp4005_evidence_description",
         "Briefing": "opp4005_evidence_briefing",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/evidence.jpg"
     },
     "00e5fe81-36c2-4ecc-8617-8144d2c07a0b": {
@@ -307,6 +337,7 @@
         "Summary": "opp4001_description",
         "Briefing": "opp4001_briefing",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/microphone.jpg"
     },
     "854a505e-c730-47f4-8772-44547dc2959c": {
@@ -317,6 +348,7 @@
         "Summary": "opp4004_exterminator_description",
         "Briefing": "opp4004_exterminator_briefing",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/exterminate.jpg"
     },
     "22bfb850-16b9-45f1-8245-adff232ef702": {
@@ -327,6 +359,7 @@
         "Summary": "opp4002_birthday_description",
         "Briefing": "opp4002_birthday_briefing",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/its_my_party.jpg"
     },
     "7bb9a180-766a-4d8d-ae41-0c43f92865e7": {
@@ -337,6 +370,7 @@
         "Summary": "opp4006_meeting_description",
         "Briefing": "opp4006_meeting_briefing",
         "Location": "LOCATION_PARENT_BANGKOK",
+        "SubLocation": "LOCATION_BANGKOK",
         "Image": "images/opportunities/tiger/meeting.jpg"
     },
     "897fde3b-0c85-4bc6-be5f-1ca3f14a3ade": {
@@ -347,6 +381,7 @@
         "Summary": "opp8001_limo_description",
         "Briefing": "opp8001_limo_briefing",
         "Location": "LOCATION_PARENT_COLORADO",
+        "SubLocation": "LOCATION_COLORADO",
         "Image": "images/opportunities/colorado/colorado_point_man.jpg"
     },
     "fee557d9-c03b-4af8-871a-7d01d9c7567a": {
@@ -357,6 +392,7 @@
         "Summary": "opp8005_phonecall_description",
         "Briefing": "opp8005_phonecall_briefing",
         "Location": "LOCATION_PARENT_COLORADO",
+        "SubLocation": "LOCATION_COLORADO",
         "Image": "images/opportunities/colorado/colorado_the_audition.jpg"
     },
     "e1f64d61-0152-4c17-8ffb-e26d683cd412": {
@@ -367,6 +403,7 @@
         "Summary": "opp8002_hostage_description",
         "Briefing": "opp8002_hostage_briefing",
         "Location": "LOCATION_PARENT_COLORADO",
+        "SubLocation": "LOCATION_COLORADO",
         "Image": "images/opportunities/colorado/colorado_tongue_tied.jpg"
     },
     "476124df-11c1-4369-ad51-ded30e34e337": {
@@ -377,6 +414,7 @@
         "Summary": "opp8003_hallucination_description",
         "Briefing": "opp8003_hallucination_briefing",
         "Location": "LOCATION_PARENT_COLORADO",
+        "SubLocation": "LOCATION_COLORADO",
         "Image": "images/opportunities/colorado/colorado_unclean.jpg"
     },
     "28c82b4b-c7b3-44f0-8639-48fb31fb1e06": {
@@ -387,6 +425,7 @@
         "Summary": "opp8004_watch_description",
         "Briefing": "opp8004_watch_briefing",
         "Location": "LOCATION_PARENT_COLORADO",
+        "SubLocation": "LOCATION_COLORADO",
         "Image": "images/opportunities/colorado/colorado_doomsday_watch.jpg"
     },
     "5649e47c-2c71-4226-a6c3-2f9767e6191f": {
@@ -397,6 +436,7 @@
         "Summary": "opp8006_breach_description",
         "Briefing": "opp8006_breach_briefing",
         "Location": "LOCATION_PARENT_COLORADO",
+        "SubLocation": "LOCATION_COLORADO",
         "Image": "images/opportunities/colorado/colorado_overpowered.jpg"
     },
     "b3a982f1-2773-4a97-8492-614b897a8f98": {
@@ -407,6 +447,7 @@
         "Summary": "2000_opportunity_heart_description",
         "Briefing": "2000_opportunity_heart_flavour",
         "Location": "LOCATION_PARENT_HOKKAIDO",
+        "SubLocation": "LOCATION_HOKKAIDO",
         "Image": "images/opportunities/hokkaido/hokkaido_opp_donorheart.jpg"
     },
     "d2e5bf2d-b6cd-474f-88b1-6aa0c7e641c3": {
@@ -417,6 +458,7 @@
         "Summary": "2000_opportunity_facialpatient_description",
         "Briefing": "2000_opportunity_facialpatient_flavour",
         "Location": "LOCATION_PARENT_HOKKAIDO",
+        "SubLocation": "LOCATION_HOKKAIDO",
         "Image": "images/opportunities/hokkaido/hokkaido_opp_facialpatient.jpg"
     },
     "63471c19-f174-42f7-a4a4-099c6f71c6af": {
@@ -427,6 +469,7 @@
         "Summary": "2000_opportunity_fugufish_description",
         "Briefing": "2000_opportunity_fugufish_flavour",
         "Location": "LOCATION_PARENT_HOKKAIDO",
+        "SubLocation": "LOCATION_HOKKAIDO",
         "Image": "images/opportunities/hokkaido/hokkaido_opp_fugufish.jpg"
     },
     "15af2544-833e-459e-9de9-39c109b6f732": {
@@ -437,6 +480,7 @@
         "Summary": "2000_opportunity_kaimainframe_description",
         "Briefing": "2000_opportunity_kaimainframe_flavour",
         "Location": "LOCATION_PARENT_HOKKAIDO",
+        "SubLocation": "LOCATION_HOKKAIDO",
         "Image": "images/opportunities/hokkaido/hokkaido_opp_kaimainframe.jpg"
     },
     "dd0ef769-afd7-4754-8058-0677b958d91a": {
@@ -447,6 +491,7 @@
         "Summary": "2000_opportunity_malpractice_decription",
         "Briefing": "2000_opportunity_malpractice_flavour",
         "Location": "LOCATION_PARENT_HOKKAIDO",
+        "SubLocation": "LOCATION_HOKKAIDO",
         "Image": "images/opportunities/hokkaido/hokkaido_opp_malpractice.jpg"
     },
     "d52590af-3728-4996-b441-b05a777e4642": {
@@ -457,6 +502,7 @@
         "Summary": "2000_opportunity_smoking_description",
         "Briefing": "2000_opportunity_smoking_flavour",
         "Location": "LOCATION_PARENT_HOKKAIDO",
+        "SubLocation": "LOCATION_HOKKAIDO",
         "Image": "images/opportunities/hokkaido/hokkaido_opp_nosmoking.jpg"
     },
     "a8e32356-493e-4f13-a6b7-910f995d9f0d": {
@@ -467,6 +513,7 @@
         "Summary": "2000_opportunity_yoga_description",
         "Briefing": "2000_opportunity_yoga_flavour",
         "Location": "LOCATION_PARENT_HOKKAIDO",
+        "SubLocation": "LOCATION_HOKKAIDO",
         "Image": "images/opportunities/hokkaido/hokkaido_opp_yoga.jpg"
     },
     "7f5ba93a-7011-4194-94c1-8413d8adb22e": {
@@ -477,6 +524,7 @@
         "Summary": "opp21002_android_description",
         "Briefing": "opp21002_android_flavor",
         "Location": "LOCATION_PARENT_MIAMI",
+        "SubLocation": "LOCATION_MIAMI",
         "Image": "images/opportunities/miami/miami_opp_thenewarmy.jpg"
     },
     "b57c90e2-4f18-44e7-a2e9-4d950f519246": {
@@ -487,6 +535,7 @@
         "Summary": "opp21004_blackmail_description",
         "Briefing": "opp21004_blackmail_flavor",
         "Location": "LOCATION_PARENT_MIAMI",
+        "SubLocation": "LOCATION_MIAMI",
         "Image": "images/opportunities/miami/miami_opp_prettyinpink.jpg"
     },
     "604e9a0c-db5c-4468-a7cd-fd0db2cab902": {
@@ -497,6 +546,7 @@
         "Summary": "opp21003_carexpo_description",
         "Briefing": "opp21003_carexpo_flavor",
         "Location": "LOCATION_PARENT_MIAMI",
+        "SubLocation": "LOCATION_MIAMI",
         "Image": "images/opportunities/miami/miami_opp_carexpo.jpg"
     },
     "21c55940-a7d5-4c6f-9a76-7434e6aa0f82": {
@@ -507,6 +557,7 @@
         "Summary": "opp21005_podium_description",
         "Briefing": "opp21005_podium_flavor",
         "Location": "LOCATION_PARENT_MIAMI",
+        "SubLocation": "LOCATION_MIAMI",
         "Image": "images/opportunities/miami/miami_opp_triumph.jpg"
     },
     "97568c11-92bc-47d1-af0d-531fc138b1e4": {
@@ -517,6 +568,7 @@
         "Summary": "opp21007_floridaman_description",
         "Briefing": "opp21007_floridaman_flavor",
         "Location": "LOCATION_PARENT_MIAMI",
+        "SubLocation": "LOCATION_MIAMI",
         "Image": "images/opportunities/miami/miami_opp_themunchies.jpg"
     },
     "5d9f606b-0390-4942-81f3-3b98e5e85985": {
@@ -527,6 +579,7 @@
         "Summary": "opp21001_pitstop_description",
         "Briefing": "opp21001_pitstop_flavor",
         "Location": "LOCATION_PARENT_MIAMI",
+        "SubLocation": "LOCATION_MIAMI",
         "Image": "images/opportunities/miami/miami_opp_pitstop.jpg"
     },
     "0be63e06-94ad-42b2-841a-a79664c45bc9": {
@@ -537,6 +590,7 @@
         "Summary": "opp21006_checkup_description",
         "Briefing": "opp21006_checkup_flavor",
         "Location": "LOCATION_PARENT_MIAMI",
+        "SubLocation": "LOCATION_MIAMI",
         "Image": "images/opportunities/miami/miami_opp_intravenous.jpg"
     },
     "4372cdbf-f56a-440e-b06d-f076ba2c33d7": {
@@ -547,6 +601,7 @@
         "Summary": "opp23005_heartofstone_description",
         "Briefing": "opp23005_heartofstone_flavor",
         "Location": "LOCATION_PARENT_COLOMBIA",
+        "SubLocation": "LOCATION_COLOMBIA",
         "Image": "images/opportunities/colombia/colombia_opp_heartofstone.jpg"
     },
     "fccf719c-94b9-43b8-acb1-60f494743622": {
@@ -557,6 +612,7 @@
         "Summary": "opp23006_submarine_description",
         "Briefing": "opp23006_submarine_flavor",
         "Location": "LOCATION_PARENT_COLOMBIA",
+        "SubLocation": "LOCATION_COLOMBIA",
         "Image": "images/opportunities/colombia/colombia_opp_submarine.jpg"
     },
     "2874aa47-abcb-44e3-9706-f58112f7ee65": {
@@ -567,6 +623,7 @@
         "Summary": "opp23002_deadlyart_description",
         "Briefing": "opp23002_deadlyart_flavor",
         "Location": "LOCATION_PARENT_COLOMBIA",
+        "SubLocation": "LOCATION_COLOMBIA",
         "Image": "images/opportunities/colombia/colombia_opp_deadlyart.jpg"
     },
     "0c0c243f-8a43-4e6c-aee3-6d167ae31d7a": {
@@ -577,6 +634,7 @@
         "Summary": "opp23003_halfbaked_description",
         "Briefing": "opp23003_halfbaked_flavor",
         "Location": "LOCATION_PARENT_COLOMBIA",
+        "SubLocation": "LOCATION_COLOMBIA",
         "Image": "images/opportunities/colombia/colombia_opp_halfbaked.jpg"
     },
     "7c2f850f-e804-45bf-88c2-e5483d976d9a": {
@@ -587,6 +645,7 @@
         "Summary": "opp23001_backpacker_description",
         "Briefing": "opp23001_backpacker_flavor",
         "Location": "LOCATION_PARENT_COLOMBIA",
+        "SubLocation": "LOCATION_COLOMBIA",
         "Image": "images/opportunities/colombia/colombia_opp_backpacker.jpg"
     },
     "3ddbfc15-7a59-423e-834a-822cfaf6c507": {
@@ -597,6 +656,7 @@
         "Summary": "opp23007_undyinglove_description",
         "Briefing": "opp23007_undyinglove_flavor",
         "Location": "LOCATION_PARENT_COLOMBIA",
+        "SubLocation": "LOCATION_COLOMBIA",
         "Image": "images/opportunities/colombia/colombia_opp_undyinglove.jpg"
     },
     "792d42bb-742e-4fee-81cf-10554f68c34d": {
@@ -607,6 +667,7 @@
         "Summary": "opp23004_hallowedground_description",
         "Briefing": "opp23004_hallowedground_flavor",
         "Location": "LOCATION_PARENT_COLOMBIA",
+        "SubLocation": "LOCATION_COLOMBIA",
         "Image": "images/opportunities/colombia/colombia_opp_hallowedground.jpg"
     },
     "172cbd1d-3877-4309-97bd-bebfb7b5a71b": {
@@ -617,6 +678,7 @@
         "Summary": "25000_opportunity_fan_description",
         "Briefing": "25000_opportunity_fan_flavour",
         "Location": "LOCATION_PARENT_MUMBAI",
+        "SubLocation": "LOCATION_MUMBAI",
         "Image": "images/opportunities/mumbai/mumbai_opp_fan.jpg"
     },
     "d9c7ba7e-3f8f-4ed4-9981-d94b6958b3bd": {
@@ -627,6 +689,7 @@
         "Summary": "25000_opportunity_tailor_description",
         "Briefing": "25000_opportunity_tailor_flavour",
         "Location": "LOCATION_PARENT_MUMBAI",
+        "SubLocation": "LOCATION_MUMBAI",
         "Image": "images/opportunities/mumbai/mumbai_opp_tailor.jpg"
     },
     "0145c6e7-5d84-41a8-b711-5ff10e65e7cb": {
@@ -637,6 +700,7 @@
         "Summary": "25000_opportunity_painter_description",
         "Briefing": "25000_opportunity_painter_flavor",
         "Location": "LOCATION_PARENT_MUMBAI",
+        "SubLocation": "LOCATION_MUMBAI",
         "Image": "images/opportunities/mumbai/mumbai_opp_paint.jpg"
     },
     "87372d06-9d13-4612-be48-6206ee788e56": {
@@ -647,6 +711,7 @@
         "Summary": "25000_opportunity_photoshoot_description",
         "Briefing": "25000_opportunity_photoshoot_flavor",
         "Location": "LOCATION_PARENT_MUMBAI",
+        "SubLocation": "LOCATION_MUMBAI",
         "Image": "images/opportunities/mumbai/mumbai_opp_photoshoot.jpg"
     },
     "3bcc7c37-3d5e-4099-9776-d14b1be6e959": {
@@ -657,6 +722,7 @@
         "Summary": "25000_opportunity_barber_description",
         "Briefing": "25000_opportunity_barber_flavor",
         "Location": "LOCATION_PARENT_MUMBAI",
+        "SubLocation": "LOCATION_MUMBAI",
         "Image": "images/opportunities/mumbai/mumbai_opp_barber.jpg"
     },
     "21eeff62-dc2b-4906-a271-4c3b2731b260": {
@@ -667,6 +733,7 @@
         "Summary": "25000_opportunity_laundry_description",
         "Briefing": "25000_opportunity_laundry_flavor",
         "Location": "LOCATION_PARENT_MUMBAI",
+        "SubLocation": "LOCATION_MUMBAI",
         "Image": "images/opportunities/mumbai/mumbai_opp_laundry.jpg"
     },
     "8b7c3665-4ffc-4df0-8141-fd2a9d25d5a5": {
@@ -677,6 +744,7 @@
         "Summary": "25000_opportunity_lostlove_description",
         "Briefing": "25000_opportunity_lostlove_flavor",
         "Location": "LOCATION_PARENT_MUMBAI",
+        "SubLocation": "LOCATION_MUMBAI",
         "Image": "images/opportunities/mumbai/mumbai_opp_lover.jpg"
     },
     "8120be1a-e4a7-4052-8c7c-c235a0bc0b01": {
@@ -687,6 +755,7 @@
         "Summary": "27000_opportunity_bbqserving_description",
         "Briefing": "27000_opportunity_bbqserving_flavor",
         "Location": "LOCATION_PARENT_NORTHAMERICA",
+        "SubLocation": "LOCATION_NORTHAMERICA",
         "Image": "images/opportunities/vermont/skunk_opp_bbqserve.jpg"
     },
     "d7e86cc3-16bc-430a-b4cf-c790b5fe0a95": {
@@ -697,6 +766,7 @@
         "Summary": "27000_opportunity_fumigation_description",
         "Briefing": "27000_opportunity_fumigation_flavor",
         "Location": "LOCATION_PARENT_NORTHAMERICA",
+        "SubLocation": "LOCATION_NORTHAMERICA",
         "Image": "images/opportunities/vermont/skunk_opp_exterminator.jpg"
     },
     "d4792eb3-a837-4e84-8690-03dbaa9c09f8": {
@@ -707,6 +777,7 @@
         "Summary": "27000_opportunity_forsale_description",
         "Briefing": "27000_opportunity_forsale_flavor",
         "Location": "LOCATION_PARENT_NORTHAMERICA",
+        "SubLocation": "LOCATION_NORTHAMERICA",
         "Image": "images/opportunities/vermont/skunk_opp_forsale.jpg"
     },
     "f494d898-fdda-40b5-88f1-ba77c6a3fb87": {
@@ -717,6 +788,7 @@
         "Summary": "27000_opportunity_intelgather_description",
         "Briefing": "27000_opportunity_intelgather_flavor",
         "Location": "LOCATION_PARENT_NORTHAMERICA",
+        "SubLocation": "LOCATION_NORTHAMERICA",
         "Image": "images/opportunities/vermont/skunk_opp_intelgather.jpg"
     },
     "fd4d37ac-33bb-4655-983e-a3be9af0f8f0": {
@@ -727,6 +799,7 @@
         "Summary": "25000_opportunity_healthcheck_description",
         "Briefing": "25000_opportunity_healthcheck_flavour",
         "Location": "LOCATION_PARENT_NORTHAMERICA",
+        "SubLocation": "LOCATION_NORTHAMERICA",
         "Image": "images/opportunities/vermont/skunk_opp_healthcheck.jpg"
     },
     "03d541fb-1ad3-446f-b762-7d6adab99acd": {
@@ -737,6 +810,7 @@
         "Summary": "27000_opportunity_moleholes_description",
         "Briefing": "27000_opportunity_moleholes_flavor",
         "Location": "LOCATION_PARENT_NORTHAMERICA",
+        "SubLocation": "LOCATION_NORTHAMERICA",
         "Image": "images/opportunities/vermont/skunk_opp_moleholes.jpg"
     },
     "024bb599-7dd6-42b0-a60c-5077ce66fa1b": {
@@ -747,6 +821,7 @@
         "Summary": "27000_opportunity_smokes_description",
         "Briefing": "27000_opportunity_smokes_flavor",
         "Location": "LOCATION_PARENT_NORTHAMERICA",
+        "SubLocation": "LOCATION_NORTHAMERICA",
         "Image": "images/opportunities/vermont/skunk_opp_smokes.jpg"
     },
     "7df5f11d-c5b6-4ac4-a333-17a6eb7675fe": {
@@ -757,6 +832,7 @@
         "Summary": "opp29002_effigy_description",
         "Briefing": "opp29002_effigy_briefing",
         "Location": "LOCATION_PARENT_NORTHSEA",
+        "SubLocation": "LOCATION_NORTHSEA",
         "Image": "images/opportunities/theisland/theisland_opp_effigy.jpg"
     },
     "1f3ff756-86e9-4a05-96be-79b0b0afd832": {
@@ -767,6 +843,7 @@
         "Summary": "opp29005_funeral_description",
         "Briefing": "opp29005_funeral_briefing",
         "Location": "LOCATION_PARENT_NORTHSEA",
+        "SubLocation": "LOCATION_NORTHSEA",
         "Image": "images/opportunities/theisland/theisland_opp_funeral.jpg"
     },
     "78009af6-e504-4d79-9cc4-5c058f1d8d09": {
@@ -777,6 +854,7 @@
         "Summary": "opp29006_initiation_description",
         "Briefing": "opp29006_initiation_briefing",
         "Location": "LOCATION_PARENT_NORTHSEA",
+        "SubLocation": "LOCATION_NORTHSEA",
         "Image": "images/opportunities/theisland/theisland_opp_initiation.jpg"
     },
     "13ac726b-cf6d-4452-86b8-de51ab24f09f": {
@@ -787,6 +865,7 @@
         "Summary": "opp29004_meeting_description",
         "Briefing": "opp29004_meeting_briefing",
         "Location": "LOCATION_PARENT_NORTHSEA",
+        "SubLocation": "LOCATION_NORTHSEA",
         "Image": "images/opportunities/theisland/theisland_opp_meeting.jpg"
     },
     "5df965c0-ac44-4c15-8aeb-cc3bef6a8cf7": {
@@ -797,6 +876,7 @@
         "Summary": "opp29001_necklace_description",
         "Briefing": "opp29001_necklace_briefing",
         "Location": "LOCATION_PARENT_NORTHSEA",
+        "SubLocation": "LOCATION_NORTHSEA",
         "Image": "images/opportunities/theisland/theisland_opp_necklace.jpg"
     },
     "875f9f6c-fa12-4661-988f-134d58ab3d85": {
@@ -807,6 +887,7 @@
         "Summary": "opp29003_vote_description",
         "Briefing": "opp29003_vote_briefing",
         "Location": "LOCATION_PARENT_NORTHSEA",
+        "SubLocation": "LOCATION_NORTHSEA",
         "Image": "images/opportunities/theisland/theisland_opp_vote.jpg"
     },
     "49ed98fb-c007-47ac-8d95-45629d12553e": {
@@ -817,6 +898,7 @@
         "Summary": "opp33001_jobapplicant_description",
         "Briefing": "opp33001_jobapplicant_flavor",
         "Location": "LOCATION_PARENT_GREEDY",
+        "SubLocation": "LOCATION_GREEDY_RACCOON",
         "Image": "images/opportunities/greedy/greedy_opp_jobinterview.jpg"
     },
     "d9fa1cae-8362-4cc2-b20d-1dc6b953ef27": {
@@ -827,6 +909,7 @@
         "Summary": "opp33003_turnoffandon_description",
         "Briefing": "opp33003_turnoffandon_flavor",
         "Location": "LOCATION_PARENT_GREEDY",
+        "SubLocation": "LOCATION_GREEDY_RACCOON",
         "Image": "images/opportunities/greedy/greedy_opp_it.jpg"
     },
     "bcbd4477-3e9d-4650-a552-b908090bbfaf": {
@@ -837,6 +920,7 @@
         "Summary": "opp33005_thevault_description",
         "Briefing": "opp33005_thevault_flavor",
         "Location": "LOCATION_PARENT_GREEDY",
+        "SubLocation": "LOCATION_GREEDY_RACCOON",
         "Image": "images/opportunities/greedy/greedy_opp_vault.jpg"
     },
     "19019a2b-7d9a-4b6f-aa99-a4c639a1f1ad": {
@@ -847,6 +931,7 @@
         "Summary": "opp33004_theexpose_description",
         "Briefing": "opp33004_theexpose_flavor",
         "Location": "LOCATION_PARENT_GREEDY",
+        "SubLocation": "LOCATION_GREEDY_RACCOON",
         "Image": "images/opportunities/greedy/greedy_opp_expose.jpg"
     },
     "e18ca915-d2b6-4a8d-8ac2-661e51c2df84": {
@@ -857,6 +942,7 @@
         "Summary": "opp33002_termination_description",
         "Briefing": "opp33002_termination_flavor",
         "Location": "LOCATION_PARENT_GREEDY",
+        "SubLocation": "LOCATION_GREEDY_RACCOON",
         "Image": "images/opportunities/greedy/greedy_opp_fired.jpg"
     },
     "44623041-18e8-4f1f-8fc2-b30ce1e8ad9d": {
@@ -867,6 +953,7 @@
         "Summary": "opp34002_doctor_description",
         "Briefing": "opp34002_doctor_flavor",
         "Location": "LOCATION_PARENT_OPULENT",
+        "SubLocation": "LOCATION_OPULENT_STINGRAY",
         "Image": "images/opportunities/stingray/stingray_opp_doctor.jpg"
     },
     "9b91d8b7-e9b5-4dd0-bc4d-6807f584a6af": {
@@ -877,6 +964,7 @@
         "Summary": "opp34001_thief_description",
         "Briefing": "opp34001_thief_flavor",
         "Location": "LOCATION_PARENT_OPULENT",
+        "SubLocation": "LOCATION_OPULENT_STINGRAY",
         "Image": "images/opportunities/stingray/stingray_opp_thief.jpg"
     },
     "57095852-d261-4365-acbf-af5d0d17a2a3": {
@@ -887,6 +975,7 @@
         "Summary": "opp34004_spa_description",
         "Briefing": "opp34004_spa_flavor",
         "Location": "LOCATION_PARENT_OPULENT",
+        "SubLocation": "LOCATION_OPULENT_STINGRAY",
         "Image": "images/opportunities/stingray/stingray_opp_spa.jpg"
     },
     "77d46c8c-83f2-4668-b4f4-3b6243242152": {
@@ -897,6 +986,7 @@
         "Summary": "opp34003_portman_description",
         "Briefing": "opp34003_portman_flavour",
         "Location": "LOCATION_PARENT_OPULENT",
+        "SubLocation": "LOCATION_OPULENT_STINGRAY",
         "Image": "images/opportunities/stingray/stingray_opp_portman.jpg"
     },
     "07e1bbc5-47ee-4894-85a3-cd2140bd2553": {
@@ -907,6 +997,7 @@
         "Summary": "opp34005_waterscooter_description",
         "Briefing": "opp34005_waterscooter_flavor",
         "Location": "LOCATION_PARENT_OPULENT",
+        "SubLocation": "LOCATION_OPULENT_STINGRAY",
         "Image": "images/opportunities/stingray/stingray_opp_jetski.jpg"
     },
     "6298d6c5-e512-4475-be6b-3ed7040b9f9d": {
@@ -917,6 +1008,7 @@
         "Summary": "opp40002_grey_description",
         "Briefing": "opp40002_grey_flavor",
         "Location": "LOCATION_PARENT_GOLDEN",
+        "SubLocation": "LOCATION_GOLDEN_GECKO",
         "Image": "images/opportunities/gecko/golden_opp_grey.jpg"
     },
     "3e58ea63-c6f5-472d-a52f-d3875a92d196": {
@@ -927,6 +1019,7 @@
         "Summary": "opp40001_assassin_description",
         "Briefing": "opp40001_assassin_flavor",
         "Location": "LOCATION_PARENT_GOLDEN",
+        "SubLocation": "LOCATION_GOLDEN_GECKO",
         "Image": "images/opportunities/gecko/golden_opp_assassin.jpg"
     },
     "c52dc088-cc41-4313-a779-15b4bb3ed74a": {
@@ -937,6 +1030,7 @@
         "Summary": "opp40003_guard_description",
         "Briefing": "opp40003_guard_flavor",
         "Location": "LOCATION_PARENT_GOLDEN",
+        "SubLocation": "LOCATION_GOLDEN_GECKO",
         "Image": "images/opportunities/gecko/golden_opp_guard.jpg"
     },
     "81a84bc1-3219-4f40-8f42-7c49de5166f7": {
@@ -947,6 +1041,7 @@
         "Summary": "opp41003_murder_description",
         "Briefing": "opp41003_murder_flavor",
         "Location": "LOCATION_PARENT_ANCESTRAL",
+        "SubLocation": "LOCATION_ANCESTRAL_BULLDOG",
         "Image": "images/opportunities/ancestral/bulldog_opp_murder.jpg"
     },
     "dcdf2ec2-64f2-493d-80ea-641f32a53794": {
@@ -957,6 +1052,7 @@
         "Summary": "opp33003_photo_description",
         "Briefing": "opp33002_photo_flavor",
         "Location": "LOCATION_PARENT_ANCESTRAL",
+        "SubLocation": "LOCATION_ANCESTRAL_BULLDOG",
         "Image": "images/opportunities/ancestral/bulldog_opp_photo.jpg"
     },
     "0da56b6a-5462-4bec-8721-d36ab91cf4d6": {
@@ -967,6 +1063,7 @@
         "Summary": "opp33001_burial_description",
         "Briefing": "opp33001_burial_flavor",
         "Location": "LOCATION_PARENT_ANCESTRAL",
+        "SubLocation": "LOCATION_ANCESTRAL_BULLDOG",
         "Image": "images/opportunities/ancestral/bulldog_opp_burial.jpg"
     },
     "d741f698-c08c-4760-891c-44e34b2ce2d3": {
@@ -977,6 +1074,7 @@
         "Summary": "opp43001_controller_description",
         "Briefing": "opp43001_controller_flavor",
         "Location": "LOCATION_PARENT_WET",
+        "SubLocation": "LOCATION_WET_RAT",
         "Image": "images/opportunities/wet/wet_opp_thecontroller.jpg"
     },
     "165fee0e-f109-4578-9954-bdf87e4da32e": {
@@ -987,6 +1085,7 @@
         "Summary": "opp43002_test_desciption",
         "Briefing": "opp43002_test_flavor",
         "Location": "LOCATION_PARENT_WET",
+        "SubLocation": "LOCATION_WET_RAT",
         "Image": "images/opportunities/wet/wet_opp_thetestsubject.jpg"
     },
     "98265e5a-00ad-4189-b49e-b3ebf47798f8": {
@@ -997,6 +1096,7 @@
         "Summary": "opp43003_meeting_description",
         "Briefing": "opp43003_meeting_flavor",
         "Location": "LOCATION_PARENT_WET",
+        "SubLocation": "LOCATION_WET_RAT",
         "Image": "images/opportunities/wet/wet_opp_themeetup.jpg"
     },
     "ad88d89a-3bda-401e-9e57-fc66264f239c": {
@@ -1007,6 +1107,7 @@
         "Summary": "opp44001_tour_description",
         "Briefing": "opp44001_tour_flavor",
         "Location": "LOCATION_PARENT_ELEGANT",
+        "SubLocation": "LOCATION_ELEGANT_LLAMA",
         "Image": "images/opportunities/elegant/elegant_llama_opp_privatetour.jpg"
     },
     "0854c929-4291-42fa-ba73-f2b7a2659d83": {
@@ -1017,6 +1118,7 @@
         "Summary": "opp44004_eyesontarget_description",
         "Briefing": "opp44004_eyesontarget_flavor",
         "Location": "LOCATION_PARENT_ELEGANT",
+        "SubLocation": "LOCATION_ELEGANT_LLAMA",
         "Image": "images/opportunities/elegant/elegant_llama_opp_eyesontarget.jpg"
     },
     "53f38ab3-bbdf-4a73-97e1-697c5695519a": {
@@ -1027,6 +1129,7 @@
         "Summary": "opp44003_overflow_description",
         "Briefing": "opp44003_overflow_flavor",
         "Location": "LOCATION_PARENT_ELEGANT",
+        "SubLocation": "LOCATION_ELEGANT_LLAMA",
         "Image": "images/opportunities/elegant/elegant_llama_opp_overflow.jpg"
     },
     "c1d52f61-7ad6-462e-ad7e-1829a888cffd": {
@@ -1037,6 +1140,7 @@
         "Summary": "opp10005_qa_description",
         "Briefing": "opp10005_qa_flavor",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_MOVIESET",
         "Image": "images/opportunities/copperhead/opportunity_copperhead_q_and_a.jpg"
     },
     "1460c27a-96e0-49fa-81a1-c3c5fe9ff361": {
@@ -1047,6 +1151,7 @@
         "Summary": "opp10003_explosion_description",
         "Briefing": "opp10003_explosion_flavor",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_MOVIESET",
         "Image": "images/opportunities/copperhead/opportunity_copperhead_an_explosive_ending.jpg"
     },
     "51abcd8f-1d77-4f5c-a0ee-13a4c9b3ab01": {
@@ -1057,6 +1162,7 @@
         "Summary": "opp10002_robot_description",
         "Briefing": "opp10002_robot_flavor",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_MOVIESET",
         "Image": "images/opportunities/copperhead/opportunity_copperhead_something_to_chew_on.jpg"
     },
     "7b8d5069-6781-4453-bb66-d3c4c227fda5": {
@@ -1067,6 +1173,7 @@
         "Summary": "opp10004_fuel_description",
         "Briefing": "opp10004_fuel_flavor",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_MOVIESET",
         "Image": "images/opportunities/copperhead/opportunity_copperhead_light_my_fire.jpg"
     },
     "28a84af6-a6b1-4f80-a5fb-76d4df0e7326": {
@@ -1077,6 +1184,7 @@
         "Summary": "opp7006_fireworks_002",
         "Briefing": "opp7006_fireworks_003",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_NIGHT",
         "Image": "images/opportunities/mamba/dynamite_smile.jpg"
     },
     "4fbcb774-d726-4424-b951-2c0a7d181d8d": {
@@ -1087,6 +1195,7 @@
         "Summary": "opp7004_meeting_summary",
         "Briefing": "opp7004_meeting_briefing",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_NIGHT",
         "Image": "images/opportunities/mamba/cheat_sheet.jpg"
     },
     "4c697969-ab2c-441a-be71-2cc6e27da78c": {
@@ -1097,6 +1206,7 @@
         "Summary": "opp7002_confession_summary",
         "Briefing": "opp7002_confession_briefing",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_NIGHT",
         "Image": "images/opportunities/mamba/no_absolution_for_the_wicked.jpg"
     },
     "fadc8715-6ac9-4773-89de-f78c8954dd35": {
@@ -1107,6 +1217,7 @@
         "Summary": "opp7005_speech_summary",
         "Briefing": "opp7005_speech_briefing",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_NIGHT",
         "Image": "images/opportunities/mamba/stage_fried.jpg"
     },
     "fc62dec8-37bb-48b1-a9dd-70d93c25f8fc": {
@@ -1117,6 +1228,7 @@
         "Summary": "opp7003_lawyer_summary",
         "Briefing": "opp7003_lawyer_description",
         "Location": "LOCATION_PARENT_COASTALTOWN",
+        "SubLocation": "LOCATION_COASTALTOWN_NIGHT",
         "Image": "images/opportunities/mamba/above_the_law.jpg"
     },
     "ffab528c-0589-459e-83ef-ea38c9821806": {
@@ -1127,6 +1239,7 @@
         "Summary": "opp11000_carpets_summary",
         "Briefing": "opp11000_carpets_briefing",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH_NIGHT",
         "Image": "images/opportunities/marrakesh/python/carpet.jpg"
     },
     "111ebeae-ba92-4570-a15c-ed1ce5589ef7": {
@@ -1137,6 +1250,7 @@
         "Summary": "opp11000_escort_summary",
         "Briefing": "opp11000_escort_briefing",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH_NIGHT",
         "Image": "images/opportunities/marrakesh/python/escort.jpg"
     },
     "03115077-4641-410b-94be-5827c65601b8": {
@@ -1147,6 +1261,7 @@
         "Summary": "opp11000_fortune_summary",
         "Briefing": "opp11000_fortune_briefing",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH_NIGHT",
         "Image": "images/opportunities/marrakesh/python/fortune_teller.jpg"
     },
     "d0b276d9-c32f-4d8e-8142-7f3b8622cd4f": {
@@ -1157,6 +1272,7 @@
         "Summary": "opp11000_landlord_summary",
         "Briefing": "opp11000_landlord_briefing",
         "Location": "LOCATION_PARENT_MARRAKECH",
+        "SubLocation": "LOCATION_MARRAKECH_NIGHT",
         "Image": "images/opportunities/marrakesh/python/landlord.jpg"
     },
     "7aa939bf-7a7d-4983-9ac7-4c117e4ca9e7": {
@@ -1167,6 +1283,7 @@
         "Summary": "opp9004_jet_002",
         "Briefing": "opp9004_jet_003",
         "Location": "LOCATION_PARENT_ICA_FACILITY",
+        "SubLocation": "LOCATION_ICA_FACILITY",
         "Image": "images/opportunities/polarbear/in_case_of_emergency.jpg"
     },
     "2ee0504e-2e6b-48ac-b38a-7ad577a02c1a": {
@@ -1177,6 +1294,7 @@
         "Summary": "opp9001_vodka_002",
         "Briefing": "opp9001_vodka_003",
         "Location": "LOCATION_PARENT_ICA_FACILITY",
+        "SubLocation": "LOCATION_ICA_FACILITY",
         "Image": "images/opportunities/polarbear/to_fallen_comrades.jpg"
     },
     "dd238889-0e34-44eb-82db-c1b5484d388c": {
@@ -1187,6 +1305,7 @@
         "Summary": "opp9002_radio_002",
         "Briefing": "opp9002_radio_003",
         "Location": "LOCATION_PARENT_ICA_FACILITY",
+        "SubLocation": "LOCATION_ICA_FACILITY",
         "Image": "images/opportunities/polarbear/final_terms.jpg"
     },
     "f7c3fc51-c6b6-4ad5-8d42-a46acaacff46": {
@@ -1197,6 +1316,7 @@
         "Summary": "opp9003_slides_002",
         "Briefing": "opp9003_slides_003",
         "Location": "LOCATION_PARENT_ICA_FACILITY",
+        "SubLocation": "LOCATION_ICA_FACILITY",
         "Image": "images/opportunities/polarbear/safe_conduct.jpg"
     }
 }


### PR DESCRIPTION
Uses the same logic as the Career > Challenges, but without any additional filtering applied. Not sure if that logic was actually needed, but it also doesn't give unexpected results (I started in a different way, hence I felt like just adding that).