### PR TITLE
Add support for compiling plugins from TS to JS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,8 @@ module.exports = {
         project: [
             // server full
             "./tsconfig.json",
+            // plugins
+            "./plugins/tsconfig.json",
             // web UI
             "./webui/tsconfig.json",
             // tests

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "prettier": "pprettier --write \"**/*.{js,json,ts,md,tsx,css,mjs,html}\"",
         "prettier:check": "pprettier --check \"**/*.{js,json,ts,md,tsx,css,mjs,html}\"",
         "build": "yarn webui:build && node packaging/build.mjs",
+        "build-plugin": "tsc --project ./plugins/tsconfig.json",
         "typecheck-ws": "tsc",
         "typecheck": "yarn workspaces foreach -A run typecheck-ws",
         "lint": "eslint --format=pretty .",

--- a/plugins/tsconfig.json
+++ b/plugins/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "extends": ["../tsconfig.json"],
+    "compilerOptions": {
+        "declaration": false,
+        "emitDeclarationOnly": false,
+        "rootDir": ".",
+        "outDir": "./build",
+        "composite": false
+    },
+    "references": [
+        {
+            "path": ".."
+        }
+    ],
+    "include": ["*.ts"],
+    "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
         "rootDir": "components",
         "outDir": "./build",
         "isolatedModules": true,
-        "stripInternal": true
+        "stripInternal": true,
+        "composite": true
     },
     "include": ["components"],
     "exclude": ["packaging", "chunk0.js", "webui", "tests"]


### PR DESCRIPTION
Adds overall developer happiness. Useful when creating plugins in TypeScript with all the goodness it offers (eg. Peacock ESLint rules), and releasing the JS version of it.