### PR TITLE
Escalation Picker Revamp

### DIFF
--- a/static/EscalationCodenames.json
+++ b/static/EscalationCodenames.json
@@ -1,608 +1,752 @@
-[
-    {
-        "codename": "Snowdrop",
-        "name": "The Einarsson Inception",
-        "id": "aee6a16f-6525-4d63-a37f-225e293c6118"
-    },
-    {
-        "codename": "Wolfsbane",
-        "name": "The Snorrason Ascension",
-        "id": "c469d91d-01fc-4314-b22c-71cb804e92c0"
-    },
-    {
-        "codename": "Nightshade",
-        "name": "The Seeger Beguilement",
-        "id": "0e5c23b1-4678-458b-ad98-8b55c268e90a"
-    },
-    {
-        "codename": "Bamboo",
-        "name": "The Kotti Paradigm",
-        "id": "162e9039-cb05-418c-ba8f-792fc6cc5165"
-    },
-    {
-        "codename": "Primrose",
-        "name": "The Shapiro Omen",
-        "id": "2e365b7c-817d-4213-8fb1-496fa8067e7b"
-    },
-    {
-        "codename": "Cyclamen",
-        "name": "The Perkins Disarray",
-        "id": "39f03892-a841-4775-91ac-f8c91b485505"
-    },
-    {
-        "codename": "Torenia",
-        "name": "The Corky Commotion",
-        "id": "4f6ee6ec-b6d7-4958-9838-0352c10294a0"
-    },
-    {
-        "codename": "Larkspur",
-        "name": "The Wetzel Determination",
-        "id": "51038604-c3f4-41e9-889b-25d9d5de93c6"
-    },
-    {
-        "codename": "Wisteria",
-        "name": "The Granville Curiosity",
-        "id": "54e6c794-2855-4ecf-acc2-d7710d5d96d1"
-    },
-    {
-        "codename": "Bluebell",
-        "name": "The Osterman Mosaic",
-        "id": "5746f21e-efa1-4787-a9ca-99a5f233f507"
-    },
-    {
-        "codename": "Anemone",
-        "name": "The Gemini Fiasco",
-        "id": "77c7b56f-2410-4919-a4bc-64435c6cff55"
-    },
-    {
-        "codename": "Tulip",
-        "name": "The Ezekiel Paradox",
-        "id": "a1e7fdb4-88a4-4dbd-9ef2-d9bd1762cec2"
-    },
-    {
-        "codename": "Goosefoot",
-        "name": "The Teague Temptation",
-        "id": "bfb0d544-b4c9-4533-bed4-4562a43a3f40"
-    },
-    {
-        "codename": "Nicotiana",
-        "name": "The Adamoli Fascination",
-        "id": "c1db299f-3037-4726-b9fc-5cd951c45812"
-    },
-    {
-        "codename": "Marigold",
-        "name": "The Mandelbulb Requiem",
-        "id": "ced3ecb8-70ab-40b0-b033-6f6235c61900"
-    },
-    {
-        "codename": "Blackthorn",
-        "name": "The Holmwood Disturbance",
-        "id": "d6961637-effe-4c39-b99a-f2df4402657d"
-    },
-    {
-        "codename": "Juniper",
-        "name": "The Videl Cataclysm",
-        "id": "e01113e6-f27d-4ea1-a8ba-93062335bbf5"
-    },
-    {
-        "codename": "Hawthorn",
-        "name": "The Adrian Eclipse",
-        "id": "e6be23e8-8602-42c8-a014-17ffbfa053f5"
-    },
-    {
-        "codename": "Peony",
-        "name": "The Kerner Disquiet",
-        "id": "e75663c8-afca-45a1-af18-25fe3e663848"
-    },
-    {
-        "codename": "Foxglove",
-        "name": "The Hexagon Protocol",
-        "id": "ebf8e5b5-3bf0-487e-8d1b-9473aee61291"
-    },
-    {
-        "codename": "Clover",
-        "name": "The Marsden Isotopy",
-        "id": "edeca4db-7394-4e93-9b6d-00581f16d6c1"
-    },
-    {
-        "codename": "Amaryllis",
-        "name": "The Holcraft Vendetta",
-        "id": "7151ef94-a1e5-4b61-a542-cafa19c49a70"
-    },
-    {
-        "codename": "Edelweiss",
-        "name": "The Selmone Mimesis",
-        "id": "0c4c6ce2-09d5-4fff-a946-099ced0558ea"
-    },
-    {
-        "codename": "Daffodil",
-        "name": "The Scorpio Directive",
-        "id": "3d9dcf91-1708-4e22-88b3-41d184bcc8c3"
-    },
-    {
-        "codename": "Sunflower",
-        "name": "The Hamartia Compulsion",
-        "id": "4b6739eb-bcdb-48ad-8c45-a829794175e1"
-    },
-    {
-        "codename": "Lavender",
-        "name": "The Scarlatti Covenant",
-        "id": "525bd318-04e6-4672-9d01-6bba74362fc5"
-    },
-    {
-        "codename": "Bergamot",
-        "name": "The Zunino Disintegration",
-        "id": "5a8bdb42-b11e-47d1-bc57-b4bf7efa9eda"
-    },
-    {
-        "codename": "Jasmine",
-        "name": "The Lyndon Gyration",
-        "id": "641656f8-ab16-49c5-a09b-952738154b64"
-    },
-    {
-        "codename": "Moon Flower",
-        "name": "The Agana Abyss",
-        "id": "74739eda-6ed5-4318-a501-2fa0bd53ef5a"
-    },
-    {
-        "codename": "Rose",
-        "name": "The Spaggiari Subversion",
-        "id": "8dec1e62-bbf9-438c-8495-24559c884466"
-    },
-    {
-        "codename": "Begonia",
-        "name": "The Eccleston Illumination",
-        "id": "95bb86f8-fbbf-4eb0-b2fa-bd379c0a4878"
-    },
-    {
-        "codename": "Artemisia",
-        "name": "The Szilassi Darkness",
-        "id": "994540ee-3900-4a41-9544-17b2196a4b1a"
-    },
-    {
-        "codename": "Chrysantemum",
-        "name": "The Gladwyn Simulacrum",
-        "id": "d43600cd-1128-4d59-bf87-075c73ae9776"
-    },
-    {
-        "codename": "Hyacinth",
-        "name": "The Andersen Animosity",
-        "id": "ee7e831b-f7ea-4803-8eba-80b42d020a7c"
-    },
-    {
-        "codename": "Orchid",
-        "name": "The Sigma Illusion",
-        "id": "f08934c0-73f3-460c-a612-231035131c96"
-    },
-    {
-        "codename": "Lilac",
-        "name": "The Apeiron Sadness",
-        "id": "fab808f9-e88b-4775-aadb-a462c86bf2d9"
-    },
-    {
-        "codename": "Lupine",
-        "name": "The Raskoph Satisfaction",
-        "id": "11c93649-6b00-46ac-bf2d-a3599a6ab3a9"
-    },
-    {
-        "codename": "Iris",
-        "name": "The Bahadur Dexterity",
-        "id": "19660896-fc1f-49f9-b56b-2059137530e4"
-    },
-    {
-        "codename": "Rhododendron",
-        "name": "The Kilie Agitation",
-        "id": "45e6d255-f8e4-4170-ad7e-3416ab8a881d"
-    },
-    {
-        "codename": "Clematis",
-        "name": "The Reziko Conundrum",
-        "id": "896233eb-e7c5-4915-bf2b-5867799d8bb4"
-    },
-    {
-        "codename": "Hellebore",
-        "name": "The Cheveyo Calibration",
-        "id": "b49de2a1-fe8e-49c4-8331-17aaa9d65d32"
-    },
-    {
-        "codename": "Cereus",
-        "name": "The Ataro Caliginosity",
-        "id": "c2e16fb7-d49f-49ef-9d76-46b8b31b3389"
-    },
-    {
-        "codename": "Honeysuckle",
-        "name": "The Sokoloff Sophistication",
-        "id": "c67a1ead-7489-4d88-bbd2-c68d735e5df0"
-    },
-    {
-        "codename": "Amaranth",
-        "name": "The Lupei Sensitivity",
-        "id": "c949817b-5212-42e8-9b06-9a2eb83de167"
-    },
-    {
-        "codename": "Salvia",
-        "name": "The Ignatiev Integrity",
-        "id": "e359075e-a510-4b7c-a461-477b789ca7e4"
-    },
-    {
-        "codename": "Camellia",
-        "name": "The Varvara Mystification",
-        "id": "ebf8ab97-6ff3-4063-9737-c6f237031de7"
-    },
-    {
-        "codename": "Milfoil",
-        "name": "The Achilles Proposals",
-        "id": "a6807292-1bc5-4fbb-9421-af3f5a2ee5d9"
-    },
-    {
-        "codename": "Geranium",
-        "name": "The Somsak Equation",
-        "id": "1f785def-03b7-4340-af7e-2f5831e77eb5"
-    },
-    {
-        "codename": "Blood Lily",
-        "name": "The Asya Attunement",
-        "id": "45c831c4-b455-4d21-90f3-6f09b28ee01b"
-    },
-    {
-        "codename": "Hibiscus",
-        "name": "The Caden Composition",
-        "id": "ccbde3e2-67e7-4534-95ec-e9bd7ef65273"
-    },
-    {
-        "codename": "Delphinium",
-        "name": "The Arthin Occultation",
-        "id": "f425e64f-99df-4ebf-9f7d-909a65a26aef"
-    },
-    {
-        "codename": "Thistle",
-        "name": "The Mallory Misfortune",
-        "id": "4186dd23-1cfc-4ba0-9863-9f19f7cba249"
-    },
-    {
-        "codename": "Daisy",
-        "name": "The Farley Crescendo",
-        "id": "c5d88e8c-437b-476b-afe2-d94aa4293502"
-    },
-    {
-        "codename": "Scullcap",
-        "name": "The Otaktay Obliteration",
-        "id": "e6f4d3a4-9a33-4bd9-b761-da297069cf8c"
-    },
-    {
-        "codename": "Sakura",
-        "name": "The Susumu Obsession",
-        "id": "85a2b618-2e3c-444f-931c-b89d566e45f7"
-    },
-    {
-        "codename": "Kosumosu",
-        "name": "The Meiko Incarnation",
-        "id": "88451dd9-4b57-441e-9eab-e20b9879bafa"
-    },
-    {
-        "codename": "Asagao",
-        "name": "The Yuuma Tenacity",
-        "id": "a1e5f4f4-ea9c-4a42-b826-50a212026d50"
-    },
-    {
-        "codename": "Tumbleweed",
-        "name": "The Dexter Discordance",
-        "id": "e96fb040-a13f-466c-9d96-c8f3b2b8a09a"
-    },
-    {
-        "codename": "Opuntia",
-        "name": "The Mills Reverie",
-        "id": "3efc73f9-33f0-4af6-9508-7208e6851394"
-    },
-    {
-        "codename": "Dodder",
-        "name": "['UI_CONTRACT_DODDER_GROUP_TITLE']"
-    },
-    {
-        "codename": "Kowhai",
-        "name": "?"
-    },
-    {
-        "codename": "Catchfly",
-        "name": "The BigMooney Flamboyancy",
-        "id": "066ce378-0418-452a-b02e-a5e4ee711096"
-    },
-    {
-        "codename": "Lamium",
-        "name": "The Simmons Concussion",
-        "id": "5284cb9f-9bdd-4b00-99c3-0b5939b01818"
-    },
-    {
-        "codename": "Crinum",
-        "name": "The Riviera Restoration",
-        "id": "719ee044-4b05-4bd9-b2bb-75029f6d2a35"
-    },
-    {
-        "codename": "Pentas",
-        "name": "The Sweeney Scrupulousness",
-        "id": "782a2849-14a2-4cd4-99fc-ddacaeaba2dd"
-    },
-    {
-        "codename": "Bakerian",
-        "name": "The Treasonous Mimicry",
-        "id": "be3ea01f-ec56-4fcb-95ec-164a1d9980f3"
-    },
-    {
-        "codename": "Plumbago",
-        "name": "The Aquatic Retribution",
-        "id": "d0f44e71-6eab-4af4-9484-78d61dbe376a"
-    },
-    {
-        "codename": "Cardinal",
-        "name": "The Unpalatable Termination",
-        "id": "fca539ff-1b1a-4c04-93e0-03b9b902f86c"
-    },
-    {
-        "codename": "Holly",
-        "name": "The Truman Contravention",
-        "id": "390ba7b6-de27-464a-b8af-6d0ff54c2aec"
-    },
-    {
-        "codename": "Arrayan",
-        "name": "The Turms Infatuation",
-        "id": "41ecf8ce-dfd4-4c08-8f44-52dedc3f089a"
-    },
-    {
-        "codename": "Snapdragon",
-        "name": "The Montague Audacity",
-        "id": "70150cd2-ef76-4ba8-80cc-b1e63871b030"
-    },
-    {
-        "codename": "Rafflesia",
-        "name": "The Delgado Larceny",
-        "id": "757fd132-0300-45ec-b5bd-bdd48c543b5c"
-    },
-    {
-        "codename": "Zinnia",
-        "name": "The Calvino Cacophony",
-        "id": "a5e81878-0eae-4bcf-af9b-9a7e7833f85d"
-    },
-    {
-        "codename": "Titanumarum",
-        "name": "The Merle Revelation",
-        "id": "be567ad3-23f4-4d0b-9d2e-b261ea845ef0"
-    },
-    {
-        "codename": "Calluna",
-        "name": "The MacMillan Surreptition",
-        "id": "d336d894-024a-4cd4-9867-dee7de70ee79"
-    },
-    {
-        "codename": "Poppy",
-        "name": "['UI_CONTRACT_POPPY_GROUP_TITLE']"
-    },
-    {
-        "codename": "Verbena",
-        "name": "['UI_CONTRACT_VERBENA_GROUP_TITLE']"
-    },
-    {
-        "codename": "Monkshood",
-        "name": "The Divine Descendance",
-        "id": "4a62b328-dfe7-4956-ac0f-a3a8990fce26"
-    },
-    {
-        "codename": "Gloriosa",
-        "name": "The Han Encasement",
-        "id": "9badee3e-0014-46b1-9ef6-edf8858ba038"
-    },
-    {
-        "codename": "Protea",
-        "name": "The Dubious Cohabitation",
-        "id": "a10472e4-0eb3-451d-814d-38837dd0f407"
-    },
-    {
-        "codename": "Ashoka",
-        "name": "The Chameleon Anonymity",
-        "id": "ae0bd6cd-7062-4336-8cb0-5fafad3d0f4f"
-    },
-    {
-        "codename": "Nutmeg",
-        "name": "The Hirani Evacuation",
-        "id": "b47f34cb-6537-421c-8fc8-720a4a118540"
-    },
-    {
-        "codename": "Anthogonium",
-        "name": "The Raaz Algorithm",
-        "id": "b6a6330a-301a-4e8e-a26f-0f3e0ea809b5"
-    },
-    {
-        "codename": "Claytonia",
-        "name": "The O'Leary Conflagration",
-        "id": "15b7ad4e-565a-4fdb-b669-c9a68176e665"
-    },
-    {
-        "codename": "Milkweed",
-        "name": "The Covert Dispersal",
-        "id": "1d5dcf3e-9682-4e32-ac11-ad6586daa456"
-    },
-    {
-        "codename": "Myrtle",
-        "name": "The Batty Tranquility",
-        "id": "74e6b561-ff1a-4742-9a7b-890b7818c796"
-    },
-    {
-        "codename": "Baneberry",
-        "name": "The McCallister Ransack",
-        "id": "d1b9250b-33f6-4712-831b-f33fa11ee4d8"
-    },
-    {
-        "codename": "Gorse",
-        "name": "The Nolan Disinfection",
-        "id": "fe088a10-5dbf-460f-bbe2-6b55e7a66253"
-    },
-    {
-        "codename": "Hogweed",
-        "name": "The Marinello Motivation",
-        "id": "3721e543-b5e6-4af8-a4fc-c92e9a4453bd"
-    },
-    {
-        "codename": "Dahlia",
-        "name": "The Babayeva Dissonance",
-        "id": "4fbfae2e-a5e7-4b79-b008-94f6cbcb13cb"
-    },
-    {
-        "codename": "Pansy",
-        "name": "The Aelwin Augment",
-        "id": "8c6daf5e-5974-4438-af20-71ff570c7ff3"
-    },
-    {
-        "codename": "Lotus",
-        "name": "The Quimby Quandary",
-        "id": "b66f151d-47a7-4681-a403-c48a46916224"
-    },
-    {
-        "codename": "Galium",
-        "name": "The Scarlett Deceit",
-        "id": "dbb0e22d-084b-4b57-8616-42290982fd90"
-    },
-    {
-        "codename": "Heather",
-        "name": "The Rafael Misadventure",
-        "id": "e63eeb62-29ef-428d-b003-ea043b1f11f9"
-    },
-    {
-        "codename": "Venus Flytrap",
-        "name": "['UI_CONTRACT_VENUS_FLYTRAP_GROUP_TITLE']"
-    },
-    {
-        "codename": "Astilbe",
-        "name": "['UI_CONTRACT_ASTILBE_GROUP_TITLE']"
-    },
-    {
-        "codename": "Dandelion",
-        "name": "The Dalton Dissection",
-        "id": "55063d85-e84a-4c76-8bf7-e70fe2cab651"
-    },
-    {
-        "codename": "Arctic Thyme",
-        "name": "The Bartholomew Hornswoggle",
-        "id": "83d4e87e-2f47-4c81-b831-30bd13a29b05"
-    },
-    {
-        "codename": "Desert Rose",
-        "name": "The Asmodeus Waltz"
-    },
-    {
-        "codename": "Sheep's Sorrel",
-        "name": "The Sinbad Stringent",
-        "id": "89305766-199e-43eb-9fcb-29e6f2b6e9ab"
-    },
-    {
-        "codename": "Vine",
-        "name": "The Phoenix Ascension",
-        "id": "a9dc4bf9-d277-4115-8dac-6c665cd68168"
-    },
-    {
-        "codename": "Lunaria",
-        "name": "The Greed Enumeration",
-        "id": "ae04c7a0-4028-4524-b27f-6a62f020fdca"
-    },
-    {
-        "codename": "SINS PACK testing",
-        "name": "?"
-    },
-    {
-        "codename": "Angelica",
-        "name": "The Sebastian Principle",
-        "id": "8885eeda-ad64-44fa-a944-1438b36c670c"
-    },
-    {
-        "codename": "Fern",
-        "name": "The Percival Passage",
-        "id": "4689ef5e-0ddd-44b3-adca-aebf3293d9e1"
-    },
-    {
-        "codename": "Snake's Head",
-        "name": "The Baskerville Barney",
-        "id": "b12d08ea-c842-498a-82ea-889653588592"
-    },
-    {
-        "codename": "Harebell",
-        "name": "The Sloth Depletion",
-        "id": "a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"
-    },
-    {
-        "codename": "Hollyhock",
-        "name": "The Wrath Termination",
-        "id": "8e95dcd0-704f-4121-8be6-088a3812f838"
-    },
-    {
-        "codename": "Smooth snake",
-        "name": "Dartmoor Garden Show",
-        "id": "5680108a-19dc-4448-9344-3d0290217162"
-    },
-    {
-        "codename": "Cornflower",
-        "name": "The Satu Mare Delirium",
-        "id": "079876de-ddd7-47aa-8719-abe97d82fc12"
-    },
-    {
-        "codename": "Night Phlox",
-        "name": "The Lesley Celebration",
-        "id": "5bb29a6b-7384-4641-944c-3540fa5cd8aa"
-    },
-    {
-        "codename": "Grass snake",
-        "name": "Berlin Egg Hunt",
-        "id": "9d88605f-6871-46a8-bd46-9804ea04fca9"
-    },
-    {
-        "codename": "Smilax",
-        "name": "The Halliwell Fable",
-        "id": "12d83cb0-a2d6-4c01-b9d8-675ac635ee61"
-    },
-    {
-        "codename": "Ambrosia",
-        "name": "The Lust Assignation",
-        "id": "e3b65e65-636b-4dfd-bb42-65a18c5dce4a"
-    },
-    {
-        "codename": "Ginseng",
-        "name": "The Lee Hong Derivation",
-        "id": "84bf03cc-3055-4fd4-a691-d8b0ac61a51f"
-    },
-    {
-        "codename": "Magnolia",
-        "name": "The Jinzhen Incident",
-        "id": "542108f2-f82f-4a04-bfec-efa92785fec1"
-    },
-    {
-        "codename": "Makoyana",
-        "name": "The Pride Profusion",
-        "id": "494d97a6-9e31-45e0-9dae-f3793c731336"
-    },
-    {
-        "codename": "Azalea",
-        "name": "The Gluttony Gobble",
-        "id": "5121acde-313d-4517-ae70-6a54ca5d775a"
-    },
-    {
-        "codename": "White Dryas",
-        "name": "The Gauchito Antiquity",
-        "id": "72aaaa7b-4386-4ee7-9e9e-73fb8ff8e416"
-    },
-    {
-        "codename": "Jacaranda",
-        "name": "The Pasquel Consortium",
-        "id": "14a21819-f81f-453d-8734-a3aab528fa62"
-    },
-    {
-        "codename": "Frangipani",
-        "name": "The Envy Contention",
-        "id": "8c8ed496-948f-4672-879b-4d9575406577"
-    },
-    {
-        "codename": "Bellflower",
-        "name": "The Proloff Parable",
-        "id": "078a50d1-6427-4fc3-9099-e46390e637a0"
-    },
-    {
-        "codename": "Mammoth testing",
-        "name": "?"
-    }
-]
+{
+    "ICA Facility": [
+        {
+            "codename": "Snowdrop",
+            "name": "The Einarsson Inception",
+            "id": "aee6a16f-6525-4d63-a37f-225e293c6118"
+        },
+        {
+            "codename": "Wolfsbane",
+            "name": "The Snorrason Ascension",
+            "id": "c469d91d-01fc-4314-b22c-71cb804e92c0"
+        }
+    ],
+    "Paris": [
+        {
+            "codename": "Southern Comfort",
+            "name": "🦚 The Christmas Calamity",
+            "id": "07bbf22b-d6ae-4883-bec2-122eeeb7b665",
+            "isPeacock": true
+        },
+        {
+            "codename": "Torenia",
+            "name": "The Corky Commotion",
+            "id": "4f6ee6ec-b6d7-4958-9838-0352c10294a0"
+        },
+        {
+            "codename": "Hawthorn",
+            "name": "The Adrian Eclipse",
+            "id": "e6be23e8-8602-42c8-a014-17ffbfa053f5"
+        },
+        {
+            "codename": "Juniper",
+            "name": "The Videl Cataclysm",
+            "id": "e01113e6-f27d-4ea1-a8ba-93062335bbf5"
+        },
+        {
+            "codename": "Nightshade",
+            "name": "The Seeger Beguilement",
+            "id": "0e5c23b1-4678-458b-ad98-8b55c268e90a"
+        },
+        {
+            "codename": "Nicotiana",
+            "name": "The Adamoli Fascination",
+            "id": "c1db299f-3037-4726-b9fc-5cd951c45812"
+        },
+        {
+            "codename": "Goosefoot",
+            "name": "The Teague Temptation",
+            "id": "bfb0d544-b4c9-4533-bed4-4562a43a3f40"
+        },
+        {
+            "codename": "Larkspur",
+            "name": "The Wetzel Determination",
+            "id": "51038604-c3f4-41e9-889b-25d9d5de93c6"
+        },
+        {
+            "codename": "Bamboo",
+            "name": "The Kotti Paradigm",
+            "id": "162e9039-cb05-418c-ba8f-792fc6cc5165"
+        },
+        {
+            "codename": "Peony",
+            "name": "The Kerner Disquiet",
+            "id": "e75663c8-afca-45a1-af18-25fe3e663848"
+        },
+        {
+            "codename": "Foxglove",
+            "name": "The Hexagon Protocol",
+            "id": "ebf8e5b5-3bf0-487e-8d1b-9473aee61291"
+        },
+        {
+            "codename": "Cyclamen",
+            "name": "The Perkins Disarray",
+            "id": "39f03892-a841-4775-91ac-f8c91b485505"
+        },
+        {
+            "codename": "Wisteria",
+            "name": "The Granville Curiosity",
+            "id": "54e6c794-2855-4ecf-acc2-d7710d5d96d1"
+        },
+        {
+            "codename": "Tulip",
+            "name": "The Ezekiel Paradox",
+            "id": "a1e7fdb4-88a4-4dbd-9ef2-d9bd1762cec2"
+        },
+        {
+            "codename": "Primrose",
+            "name": "The Shapiro Omen",
+            "id": "2e365b7c-817d-4213-8fb1-496fa8067e7b"
+        },
+        {
+            "codename": "Clover",
+            "name": "The Marsden Isotopy",
+            "id": "edeca4db-7394-4e93-9b6d-00581f16d6c1"
+        },
+        {
+            "codename": "Bluebell",
+            "name": "The Osterman Mosaic",
+            "id": "5746f21e-efa1-4787-a9ca-99a5f233f507"
+        },
+        {
+            "codename": "Anemone",
+            "name": "The Gemini Fiasco",
+            "id": "77c7b56f-2410-4919-a4bc-64435c6cff55"
+        },
+        {
+            "codename": "Blackthorn",
+            "name": "The Holmwood Disturbance",
+            "id": "d6961637-effe-4c39-b99a-f2df4402657d"
+        },
+        {
+            "codename": "Marigold",
+            "name": "The Mandelbulb Requiem",
+            "id": "ced3ecb8-70ab-40b0-b033-6f6235c61900"
+        },
+        {
+            "codename": "Amaryllis",
+            "name": "The Holcraft Vendetta",
+            "id": "7151ef94-a1e5-4b61-a542-cafa19c49a70",
+            "hidden": true
+        }
+    ],
+    "Sapienza": [
+        {
+            "codename": "Rocco",
+            "name": "🦚 The McVeigh Ascension",
+            "id": "e0188e8-bdad-476c-b4ce-2faa5d2be56c",
+            "isPeacock": true
+        },
+        {
+            "codename": "Blueberry Bush",
+            "name": "🦚 The PurpleKey Peril",
+            "id": "74415eca-d01e-4070-9bc9-5ef9b4e8f7d2",
+            "isPeacock": true
+        },
+        {
+            "codename": "Satanta",
+            "name": "🦚 The Jeffrey Consolation",
+            "id": "0cceeecb-c8fe-42a4-aee4-d7b575f56a1b",
+            "isPeacock": true
+        },
+        {
+            "codename": "Sunflower",
+            "name": "The Hamartia Compulsion",
+            "id": "4b6739eb-bcdb-48ad-8c45-a829794175e1"
+        },
+        {
+            "codename": "Bergamot",
+            "name": "The Zunino Disintegration",
+            "id": "5a8bdb42-b11e-47d1-bc57-b4bf7efa9eda"
+        },
+        {
+            "codename": "Jasmine",
+            "name": "The Lyndon Gyration",
+            "id": "641656f8-ab16-49c5-a09b-952738154b64"
+        },
+        {
+            "codename": "Hyacinth",
+            "name": "The Andersen Animosity",
+            "id": "ee7e831b-f7ea-4803-8eba-80b42d020a7c"
+        },
+        {
+            "codename": "Begonia",
+            "name": "The Eccleston Illumination",
+            "id": "95bb86f8-fbbf-4eb0-b2fa-bd379c0a4878"
+        },
+        {
+            "codename": "Edelweiss",
+            "name": "The Selmone Mimesis",
+            "id": "0c4c6ce2-09d5-4fff-a946-099ced0558ea"
+        },
+        {
+            "codename": "Chrysantemum",
+            "name": "The Gladwyn Simulacrum",
+            "id": "d43600cd-1128-4d59-bf87-075c73ae9776"
+        },
+        {
+            "codename": "Daffodil",
+            "name": "The Scorpio Directive",
+            "id": "3d9dcf91-1708-4e22-88b3-41d184bcc8c3"
+        },
+        {
+            "codename": "Lavender",
+            "name": "The Scarlatti Covenant",
+            "id": "525bd318-04e6-4672-9d01-6bba74362fc5"
+        },
+        {
+            "codename": "Artemisia",
+            "name": "The Szilassi Darkness",
+            "id": "994540ee-3900-4a41-9544-17b2196a4b1a"
+        },
+        {
+            "codename": "Lilac",
+            "name": "The Apeiron Sadness",
+            "id": "fab808f9-e88b-4775-aadb-a462c86bf2d9"
+        },
+        {
+            "codename": "Orchid",
+            "name": "The Sigma Illusion",
+            "id": "f08934c0-73f3-460c-a612-231035131c96"
+        },
+        {
+            "codename": "Rose",
+            "name": "The Spaggiari Subversion",
+            "id": "8dec1e62-bbf9-438c-8495-24559c884466"
+        },
+        {
+            "codename": "Moon Flower",
+            "name": "The Agana Abyss",
+            "id": "74739eda-6ed5-4318-a501-2fa0bd53ef5a"
+        }
+    ],
+    "Marrakesh": [
+        {
+            "codename": "Iris",
+            "name": "The Bahadur Dexterity",
+            "id": "19660896-fc1f-49f9-b56b-2059137530e4"
+        },
+        {
+            "codename": "Lupine",
+            "name": "The Raskoph Satisfaction",
+            "id": "11c93649-6b00-46ac-bf2d-a3599a6ab3a9"
+        },
+        {
+            "codename": "Camellia",
+            "name": "The Varvara Mystification",
+            "id": "ebf8ab97-6ff3-4063-9737-c6f237031de7"
+        },
+        {
+            "codename": "Honeysuckle",
+            "name": "The Sokoloff Sophistication",
+            "id": "c67a1ead-7489-4d88-bbd2-c68d735e5df0"
+        },
+        {
+            "codename": "Clematis",
+            "name": "The Reziko Conundrum",
+            "id": "896233eb-e7c5-4915-bf2b-5867799d8bb4"
+        },
+        {
+            "codename": "Rhododendron",
+            "name": "The Kilie Agitation",
+            "id": "45e6d255-f8e4-4170-ad7e-3416ab8a881d"
+        },
+        {
+            "codename": "Amaranth",
+            "name": "The Lupei Sensitivity",
+            "id": "c949817b-5212-42e8-9b06-9a2eb83de167"
+        },
+        {
+            "codename": "Salvia",
+            "name": "The Ignatiev Integrity",
+            "id": "e359075e-a510-4b7c-a461-477b789ca7e4"
+        },
+        {
+            "codename": "Milfoil",
+            "name": "The Achilles Proposals",
+            "id": "a6807292-1bc5-4fbb-9421-af3f5a2ee5d9",
+            "hidden": true
+        },
+        {
+            "codename": "Hellebore",
+            "name": "The Cheveyo Calibration",
+            "id": "b49de2a1-fe8e-49c4-8331-17aaa9d65d32"
+        },
+        {
+            "codename": "Cereus",
+            "name": "The Ataro Caliginosity",
+            "id": "c2e16fb7-d49f-49ef-9d76-46b8b31b3389"
+        }
+    ],
+    "Bangkok": [
+        {
+            "codename": "Delphinium",
+            "name": "The Arthin Occultation",
+            "id": "f425e64f-99df-4ebf-9f7d-909a65a26aef"
+        },
+        {
+            "codename": "Hibiscus",
+            "name": "The Caden Composition",
+            "id": "ccbde3e2-67e7-4534-95ec-e9bd7ef65273"
+        },
+        {
+            "codename": "Geranium",
+            "name": "The Somsak Equation",
+            "id": "1f785def-03b7-4340-af7e-2f5831e77eb5"
+        },
+        {
+            "codename": "Blood Lily",
+            "name": "The Asya Attunement",
+            "id": "45c831c4-b455-4d21-90f3-6f09b28ee01b"
+        }
+    ],
+    "Colorado": [
+        {
+            "codename": "Scullcap",
+            "name": "The Otaktay Obliteration",
+            "id": "e6f4d3a4-9a33-4bd9-b761-da297069cf8c"
+        },
+        {
+            "codename": "Daisy",
+            "name": "The Farley Crescendo",
+            "id": "c5d88e8c-437b-476b-afe2-d94aa4293502"
+        },
+        {
+            "codename": "Thistle",
+            "name": "The Mallory Misfortune",
+            "id": "4186dd23-1cfc-4ba0-9863-9f19f7cba249"
+        }
+    ],
+    "Hokkaido": [
+        {
+            "codename": "CurryMaker Chaos",
+            "name": "🦚 The CurryMaker Chaos",
+            "id": "115425b1-e797-47bf-b517-410dc7507397",
+            "isPeacock": true
+        },
+        {
+            "codename": "Tumbleweed",
+            "name": "The Dexter Discordance",
+            "id": "e96fb040-a13f-466c-9d96-c8f3b2b8a09a"
+        },
+        {
+            "codename": "Asagao",
+            "name": "The Yuuma Tenacity",
+            "id": "a1e5f4f4-ea9c-4a42-b826-50a212026d50"
+        },
+        {
+            "codename": "Sakura",
+            "name": "The Susumu Obsession",
+            "id": "85a2b618-2e3c-444f-931c-b89d566e45f7"
+        },
+        {
+            "codename": "Kosumosu",
+            "name": "The Meiko Incarnation",
+            "id": "88451dd9-4b57-441e-9eab-e20b9879bafa"
+        }
+    ],
+    "Hawkes Bay": [
+        {
+            "codename": "Opuntia",
+            "name": "The Mills Reverie",
+            "id": "3efc73f9-33f0-4af6-9508-7208e6851394"
+        },
+        {
+            "codename": "Dodder",
+            "name": "['UI_CONTRACT_DODDER_GROUP_TITLE']"
+        },
+        {
+            "codename": "Kowhai",
+            "name": "?"
+        }
+    ],
+    "Miami": [
+        {
+            "codename": "Crinum",
+            "name": "The Riviera Restoration",
+            "id": "719ee044-4b05-4bd9-b2bb-75029f6d2a35"
+        },
+        {
+            "codename": "Lamium",
+            "name": "The Simmons Concussion",
+            "id": "5284cb9f-9bdd-4b00-99c3-0b5939b01818"
+        },
+        {
+            "codename": "Plumbago",
+            "name": "The Aquatic Retribution",
+            "id": "d0f44e71-6eab-4af4-9484-78d61dbe376a"
+        },
+        {
+            "codename": "Cardinal",
+            "name": "The Unpalatable Termination",
+            "id": "fca539ff-1b1a-4c04-93e0-03b9b902f86c"
+        },
+        {
+            "codename": "Pentas",
+            "name": "The Sweeney Scrupulousness",
+            "id": "782a2849-14a2-4cd4-99fc-ddacaeaba2dd"
+        },
+        {
+            "codename": "Bakerian",
+            "name": "The Treasonous Mimicry",
+            "id": "be3ea01f-ec56-4fcb-95ec-164a1d9980f3"
+        },
+        {
+            "codename": "Catchfly",
+            "name": "The BigMooney Flamboyancy",
+            "id": "066ce378-0418-452a-b02e-a5e4ee711096"
+        }
+    ],
+    "Santa Fortuna": [
+        {
+            "codename": "Holly",
+            "name": "The Truman Contravention",
+            "id": "390ba7b6-de27-464a-b8af-6d0ff54c2aec"
+        },
+        {
+            "codename": "Snapdragon",
+            "name": "The Montague Audacity",
+            "id": "70150cd2-ef76-4ba8-80cc-b1e63871b030"
+        },
+        {
+            "codename": "Titanumarum",
+            "name": "The Merle Revelation",
+            "id": "be567ad3-23f4-4d0b-9d2e-b261ea845ef0"
+        },
+        {
+            "codename": "Zinnia",
+            "name": "The Calvino Cacophony",
+            "id": "a5e81878-0eae-4bcf-af9b-9a7e7833f85d"
+        },
+        {
+            "codename": "Rafflesia",
+            "name": "The Delgado Larceny",
+            "id": "757fd132-0300-45ec-b5bd-bdd48c543b5c"
+        },
+        {
+            "codename": "Arrayan",
+            "name": "The Turms Infatuation",
+            "id": "41ecf8ce-dfd4-4c08-8f44-52dedc3f089a"
+        },
+        {
+            "codename": "Calluna",
+            "name": "The MacMillan Surreptition",
+            "id": "d336d894-024a-4cd4-9867-dee7de70ee79"
+        },
+        {
+            "codename": "Poppy",
+            "name": "['UI_CONTRACT_POPPY_GROUP_TITLE']"
+        },
+        {
+            "codename": "Verbena",
+            "name": "['UI_CONTRACT_VERBENA_GROUP_TITLE']"
+        }
+    ],
+    "Mumbai": [
+        {
+            "codename": "Khakiasp Documentation",
+            "name": "🦚 The Khakiasp Documentation",
+            "id": "667f48a3-7f6b-486e-8f6b-2f782a5c4857",
+            "isPeacock": true
+        },
+        {
+            "codename": "Gloriosa",
+            "name": "The Han Encasement",
+            "id": "9badee3e-0014-46b1-9ef6-edf8858ba038"
+        },
+        {
+            "codename": "Anthogonium",
+            "name": "The Raaz Algorithm",
+            "id": "b6a6330a-301a-4e8e-a26f-0f3e0ea809b5"
+        },
+        {
+            "codename": "Monkshood",
+            "name": "The Divine Descendance",
+            "id": "4a62b328-dfe7-4956-ac0f-a3a8990fce26"
+        },
+        {
+            "codename": "Protea",
+            "name": "The Dubious Cohabitation",
+            "id": "a10472e4-0eb3-451d-814d-38837dd0f407"
+        },
+        {
+            "codename": "Ashoka",
+            "name": "The Chameleon Anonymity",
+            "id": "ae0bd6cd-7062-4336-8cb0-5fafad3d0f4f"
+        },
+        {
+            "codename": "Nutmeg",
+            "name": "The Hirani Evacuation",
+            "id": "b47f34cb-6537-421c-8fc8-720a4a118540"
+        }
+    ],
+    "Whittleton Creek": [
+        {
+            "codename": "Thornbush",
+            "name": "🦚 The Dammchicu Disaster",
+            "id": "218302a3-f682-46f9-9ffd-bb3e82487b7c",
+            "isPeacock": true
+        },
+        {
+            "codename": "Baneberry",
+            "name": "The McCallister Ransack",
+            "id": "d1b9250b-33f6-4712-831b-f33fa11ee4d8"
+        },
+        {
+            "codename": "Milkweed",
+            "name": "The Covert Dispersal",
+            "id": "1d5dcf3e-9682-4e32-ac11-ad6586daa456"
+        },
+        {
+            "codename": "Myrtle",
+            "name": "The Batty Tranquility",
+            "id": "74e6b561-ff1a-4742-9a7b-890b7818c796"
+        },
+        {
+            "codename": "Claytonia",
+            "name": "The O'Leary Conflagration",
+            "id": "15b7ad4e-565a-4fdb-b669-c9a68176e665"
+        },
+        {
+            "codename": "Gorse",
+            "name": "The Nolan Disinfection",
+            "id": "fe088a10-5dbf-460f-bbe2-6b55e7a66253"
+        }
+    ],
+    "Isle of Sgàil": [
+        {
+            "codename": "Heather",
+            "name": "The Rafael Misadventure",
+            "id": "e63eeb62-29ef-428d-b003-ea043b1f11f9"
+        },
+        {
+            "codename": "Lotus",
+            "name": "The Quimby Quandary",
+            "id": "b66f151d-47a7-4681-a403-c48a46916224"
+        },
+        {
+            "codename": "Galium",
+            "name": "The Scarlett Deceit",
+            "id": "dbb0e22d-084b-4b57-8616-42290982fd90"
+        },
+        {
+            "codename": "Dahlia",
+            "name": "The Babayeva Dissonance",
+            "id": "4fbfae2e-a5e7-4b79-b008-94f6cbcb13cb"
+        },
+        {
+            "codename": "Hogweed",
+            "name": "The Marinello Motivation",
+            "id": "3721e543-b5e6-4af8-a4fc-c92e9a4453bd"
+        },
+        {
+            "codename": "Pansy",
+            "name": "The Aelwin Augment",
+            "id": "8c6daf5e-5974-4438-af20-71ff570c7ff3"
+        },
+        {
+            "codename": "Venus Flytrap",
+            "name": "['UI_CONTRACT_VENUS_FLYTRAP_GROUP_TITLE']"
+        },
+        {
+            "codename": "Astilbe",
+            "name": "['UI_CONTRACT_ASTILBE_GROUP_TITLE']"
+        }
+    ],
+    "New York": [
+        {
+            "codename": "Hedgebush",
+            "name": "🦚 The PapaLevy Plunderage",
+            "id": "9a461f89-86c5-44e4-998e-f2f66b496aa7",
+            "isPeacock": true
+        },
+        {
+            "codename": "Dandelion",
+            "name": "The Dalton Dissection",
+            "id": "55063d85-e84a-4c76-8bf7-e70fe2cab651"
+        }
+    ],
+    "Haven Island": [
+        {
+            "codename": "Pirates Problem",
+            "name": "🦚 The Pirates Problem",
+            "id": "fadb923c-e6bb-4283-a537-eb4d1150262e",
+            "isPeacock": true
+        },
+        {
+            "codename": "Longbush",
+            "name": "🦚 The sleazeball Situation",
+            "id": "35f1f534-ae2d-42be-8472-dd55e96625ea",
+            "isPeacock": true
+        },
+        {
+            "codename": "Arctic Thyme",
+            "name": "The Bartholomew Hornswoggle",
+            "id": "83d4e87e-2f47-4c81-b831-30bd13a29b05"
+        }
+    ],
+    "Dubai": [
+        {
+            "codename": "Angelica",
+            "name": "The Sebastian Principle",
+            "id": "8885eeda-ad64-44fa-a944-1438b36c670c"
+        },
+        {
+            "codename": "Lunaria",
+            "name": "The Greed Enumeration",
+            "id": "ae04c7a0-4028-4524-b27f-6a62f020fdca"
+        },
+        {
+            "codename": "Sheep's Sorrel",
+            "name": "The Sinbad Stringent",
+            "id": "9448d91d-f7df-4b5a-8ea3-91f1233f644a"
+        },
+        {
+            "codename": "Desert Rose",
+            "name": "The Asmodeus Waltz",
+            "id": "89305766-199e-43eb-9fcb-29e6f2b6e9ab"
+        },
+        {
+            "codename": "Vine",
+            "name": "The Phoenix Ascension",
+            "id": "a9dc4bf9-d277-4115-8dac-6c665cd68168"
+        },
+        {
+            "codename": "SINS PACK testing",
+            "name": "?"
+        }
+    ],
+    "Dartmoor": [
+        {
+            "codename": "Rose Bush",
+            "name": "🦚 The dez Dichotomy",
+            "id": "78628e05-93ce-4f87-8a17-b910d32df51f",
+            "isPeacock": true
+        },
+        {
+            "codename": "Hollyhock",
+            "name": "The Wrath Termination",
+            "id": "8e95dcd0-704f-4121-8be6-088a3812f838"
+        },
+        {
+            "codename": "Harebell",
+            "name": "The Sloth Depletion",
+            "id": "a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"
+        },
+        {
+            "codename": "Snake's Head",
+            "name": "The Baskerville Barney",
+            "id": "b12d08ea-c842-498a-82ea-889653588592"
+        },
+        {
+            "codename": "Fern",
+            "name": "The Percival Passage",
+            "id": "4689ef5e-0ddd-44b3-adca-aebf3293d9e1"
+        },
+        {
+            "codename": "Smooth snake",
+            "name": "Dartmoor Garden Show",
+            "id": "5680108a-19dc-4448-9344-3d0290217162"
+        }
+    ],
+    "Berlin": [
+        {
+            "codename": "Shangrila",
+            "name": "🦚 The mendietinha Madness",
+            "id": "ccdc7043-62af-44e8-a5fc-38b008c2044e",
+            "isPeacock": true
+        },
+        {
+            "codename": "Grass snake",
+            "name": "Berlin Egg Hunt",
+            "id": "9d88605f-6871-46a8-bd46-9804ea04fca9"
+        },
+        {
+            "codename": "Smilax",
+            "name": "The Halliwell Fable",
+            "id": "12d83cb0-a2d6-4c01-b9d8-675ac635ee61"
+        },
+        {
+            "codename": "Ambrosia",
+            "name": "The Lust Assignation",
+            "id": "e3b65e65-636b-4dfd-bb42-65a18c5dce4a"
+        },
+        {
+            "codename": "Cornflower",
+            "name": "The Satu Mare Delirium",
+            "id": "079876de-ddd7-47aa-8719-abe97d82fc12"
+        },
+        {
+            "codename": "Night Phlox",
+            "name": "The Lesley Celebration",
+            "id": "5bb29a6b-7384-4641-944c-3540fa5cd8aa"
+        }
+    ],
+    "Chongqing": [
+        {
+            "codename": "KOats Conspiracy",
+            "name": "🦚 The KOats Conspiracy",
+            "id": "07ffa72a-bbac-45ca-8c9f-b9c1b526153a",
+            "isPeacock": true
+        },
+        {
+            "codename": "Azalea",
+            "name": "The Gluttony Gobble",
+            "id": "5121acde-313d-4517-ae70-6a54ca5d775a"
+        },
+        {
+            "codename": "Makoyana",
+            "name": "The Pride Profusion",
+            "id": "494d97a6-9e31-45e0-9dae-f3793c731336"
+        },
+        {
+            "codename": "Magnolia",
+            "name": "The Jinzhen Incident",
+            "id": "542108f2-f82f-4a04-bfec-efa92785fec1"
+        },
+        {
+            "codename": "Ginseng",
+            "name": "The Lee Hong Derivation",
+            "id": "84bf03cc-3055-4fd4-a691-d8b0ac61a51f"
+        }
+    ],
+    "Mendoza": [
+        {
+            "codename": "Yannini Yearning",
+            "name": "🦚 The Yannini Yearning",
+            "id": "1e4423b7-d4ff-448f-a8a8-4bb600cab7e3",
+            "isPeacock": true
+        },
+        {
+            "codename": "Grape Bush",
+            "name": "🦚 The Argentine Acrimony",
+            "id": "edbacf4b-e402-4548-b723-cd4351571537",
+            "isPeacock": true
+        },
+        {
+            "codename": "Frangipani",
+            "name": "The Envy Contention",
+            "id": "8c8ed496-948f-4672-879b-4d9575406577"
+        },
+        {
+            "codename": "Jacaranda",
+            "name": "The Pasquel Consortium",
+            "id": "14a21819-f81f-453d-8734-a3aab528fa62"
+        },
+        {
+            "codename": "White Dryas",
+            "name": "The Gauchito Antiquity",
+            "id": "72aaaa7b-4386-4ee7-9e9e-73fb8ff8e416"
+        }
+    ],
+    "Carpathian Mountains": [
+        {
+            "codename": "Bellflower",
+            "name": "The Proloff Parable",
+            "id": "078a50d1-6427-4fc3-9099-e46390e637a0"
+        }
+    ],
+    "Ambrose Island": [
+        {
+            "codename": "Pontus",
+            "name": "🦚 ?",
+            "isPeacock": true
+        }
+    ],
+    "Unknown": [
+        {
+            "codename": "Mammoth testing",
+            "name": "?"
+        }
+    ]
+}

--- a/webui/src/EscalationLevelPicker.tsx
+++ b/webui/src/EscalationLevelPicker.tsx
@@ -22,7 +22,7 @@ import { produce } from "immer"
 import { axiosClient } from "./utils"
 
 export interface EscalationLevelPickerProps {
-    codenames: readonly CodenameMeta[]
+    codenames: CodenameMeta
     user: string
     gv: number
 }
@@ -30,6 +30,40 @@ export interface EscalationLevelPickerProps {
 const emptyValue = { __isEmpty: 1 }
 
 type Empty = typeof emptyValue
+
+const locsInGv = [
+    // Hitman 2016 (GV 1)
+    [
+        "ICA Facility",
+        "Paris",
+        "Sapienza",
+        "Marrakesh",
+        "Bangkok",
+        "Colorado",
+        "Hokkaido",
+    ],
+    // Hitman 2 (GV 2)
+    [
+        "Hawkes Bay",
+        "Miami",
+        "Santa Fortuna",
+        "Mumbai",
+        "Whittleton Creek",
+        "Isle of Sgàil",
+        "New York",
+        "Haven Island",
+    ],
+    // Hitman 3 (GV 3)
+    [
+        "Dubai",
+        "Dartmoor",
+        "Berlin",
+        "Chongqing",
+        "Mendoza",
+        "Carpathian Mountains",
+        "Ambrose Island",
+    ],
+]
 
 export function EscalationLevelPicker({
     codenames,
@@ -93,67 +127,92 @@ export function EscalationLevelPicker({
     }
 
     //#region Bootleg column paginator
-    const rows: React.ReactElement[][] = [[]]
-    let latestRow = 0
+    const final: Record<string, React.ReactElement[][]> = {}
+    const locsInGame = locsInGv.slice(0, gv).flat()
 
-    for (const codename of codenames) {
-        if (!codename.id) {
+    console.log(locsInGame)
+    for (const location in codenames) {
+        if (!locsInGame.includes(location)) {
             continue
         }
+        console.log(location)
 
-        const comp = (
-            <div className="col col--4" key={codename.codename}>
-                <div className="card">
-                    <div className="card__header">
-                        <h3>{codename.name}</h3>
-                    </div>
-                    <div className="card__body">
-                        <ul className="tabs">
-                            <li className="tabs__item elp-tab">
-                                <button
-                                    className="button button--sm button--danger"
-                                    onClick={() => onChange(codename.id!, "-")}
-                                >
-                                    -
-                                </button>
-                            </li>
-                            <li className="tabs__item elp-tab">
-                                <p className="elp-tab">
-                                    Current level: {progress[codename.id!] ?? 1}
-                                </p>
-                            </li>
-                            <li className="tabs__item elp-tab">
-                                <button
-                                    className="button button--sm button--success"
-                                    onClick={() => onChange(codename.id!, "+")}
-                                >
-                                    +
-                                </button>
-                            </li>
-                        </ul>
+        const rows: React.ReactElement[][] = [[]]
+        let latestRow = 0
+        for (const codename of codenames[location]) {
+            if (
+                !codename.id ||
+                codename.hidden ||
+                (gv === 1 && codename.isPeacock)
+            ) {
+                continue
+            }
+
+            const comp = (
+                <div className="col col--4" key={codename.codename}>
+                    <div className="card" style={{ padding: "5px" }}>
+                        <div className="card__header centered">
+                            <h3>{codename.name}</h3>
+                        </div>
+                        <div className="card__body">
+                            <ul className="tabs">
+                                <li className="tabs__item elp-tab">
+                                    <button
+                                        className="button button--sm button--danger"
+                                        onClick={() =>
+                                            onChange(codename.id!, "-")
+                                        }
+                                    >
+                                        -
+                                    </button>
+                                </li>
+                                <li className="tabs__item elp-tab">
+                                    <p className="elp-tab">
+                                        Current level:{" "}
+                                        {progress[codename.id!] ?? 1}
+                                    </p>
+                                </li>
+                                <li className="tabs__item elp-tab">
+                                    <button
+                                        className="button button--sm button--success"
+                                        onClick={() =>
+                                            onChange(codename.id!, "+")
+                                        }
+                                    >
+                                        +
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        )
+            )
 
-        if (rows[latestRow].length === 3) {
-            latestRow = latestRow + 1
-            rows.push([])
+            if (rows[latestRow].length === 3) {
+                latestRow = latestRow + 1
+                rows.push([])
+            }
+
+            rows[latestRow].push(comp)
         }
-
-        rows[latestRow].push(comp)
+        if (rows[0].length) final[location] = rows
     }
     //#endregion
 
     return (
         <section className="app-grid">
-            <div className="container">
-                {rows.map((row, index) => (
-                    <div className="row" key={index}>
-                        {row}
+            {Object.keys(final).map((val) => {
+                return (
+                    <div className="container" style={{ padding: "15px" }}>
+                        <h1>{val}</h1>
+                        {final[val].map((row, index) => (
+                            <div className="row" key={index}>
+                                {row}
+                            </div>
+                        ))}
                     </div>
-                ))}
-            </div>
+                )
+            })}
         </section>
     )
 }

--- a/webui/src/SelectUser.tsx
+++ b/webui/src/SelectUser.tsx
@@ -51,7 +51,7 @@ export function SelectUser({
                                 {user.platform}
                             </div>
                             <div className="pagination-nav__label centered">
-                                {user.name}
+                                {user.name ?? "No Name Found"}
                             </div>
                         </button>
                     </div>

--- a/webui/src/pages/EscalationLevelPage.tsx
+++ b/webui/src/pages/EscalationLevelPage.tsx
@@ -25,12 +25,16 @@ import { GameVersionTabs } from "../components/GameVersionTabs"
 import { EscalationLevelPicker } from "../EscalationLevelPicker"
 
 export interface CodenameMeta {
-    readonly codename: string
-    readonly name: string
-    /**
-     * Escalation group ID.
-     */
-    readonly id?: string
+    [location: string]: {
+        readonly codename: string
+        readonly name: string
+        /**
+         * Escalation group ID.
+         */
+        readonly id?: string
+        readonly isPeacock?: boolean
+        readonly hidden?: boolean
+    }[]
 }
 
 export function EscalationLevelPage() {
@@ -96,7 +100,7 @@ export function EscalationLevelPage() {
                     !isReadyToSelectUser &&
                     user && (
                         <EscalationLevelPicker
-                            codenames={codenameData as readonly CodenameMeta[]}
+                            codenames={codenameData as CodenameMeta}
                             gv={gameVersion}
                             user={user!}
                         />


### PR DESCRIPTION
This PR:
- Separates escalations on the escalation picker page by location.
- Adds Peacock escalations to the picker (with 🦚).
- Removes any locations that aren't in the game version (i.e. Chongqing from H2016/2).
- Stops Peacock escalations from showing for H2016.
- Hides unused escalations with IDs with a `hidden` flag. (Amaryllis and Milfoil)