### PR TITLE
Correct the order of sublocations in Sapienza

### DIFF
--- a/static/LocationsData.json
+++ b/static/LocationsData.json
@@ -1069,44 +1069,6 @@
             "Rarity": null,
             "DisplayNameLocKey": "UI_LOCATION_COASTALTOWN_NAME"
         },
-        "LOCATION_COASTALTOWN_NIGHT": {
-            "Id": "LOCATION_COASTALTOWN_NIGHT",
-            "Type": "location",
-            "Subtype": "sublocation",
-            "GameAsset": null,
-            "ImageId": "",
-            "RMTPrice": -1,
-            "GamePrice": -1,
-            "IsPurchasable": false,
-            "IsPublished": true,
-            "IsDroppable": false,
-            "Capabilities": [],
-            "Qualities": {},
-            "Properties": {
-                "ParentLocation": "LOCATION_PARENT_COASTALTOWN",
-                "Background": "images/locations/location_coastaltown_mamba/background.jpg",
-                "Icon": "images/locations/location_coastaltown_mamba/tile.jpg",
-                "LockedIcon": "images/locations/LOCATION_COASTALTOWN/tile_unreleased.jpg",
-                "DlcImage": "images/livetile/dlc/tile_hitman3.jpg",
-                "DlcName": "GAME_STORE_METADATA_S3_GAME_TITLE",
-                "IsLocked": false,
-                "GameChangers": [],
-                "Order": 2,
-                "ProgressionKey": "LOCATION_PARENT_COASTALTOWN",
-                "CreateContractId": "43a1bfcb-dede-453e-95f2-c2862329ebee",
-                "IsFreeDLC": true,
-                "HideProgression": false,
-                "ExcludeParentRewards": true,
-                "Season": 1,
-                "RequiredResources": [
-                    "[assembly:/_PRO/Scenes/Missions/CoastalTown/_Scene_Mission_Mamba.entity].entitytemplate"
-                ],
-                "Entitlements": ["H1_LEGACY_STANDARD"]
-            },
-            "Guid": "cb513891-c703-49ee-8db4-1e62264156be",
-            "Rarity": null,
-            "DisplayNameLocKey": "UI_LOCATION_COASTALTOWN_NIGHT_NAME"
-        },
         "LOCATION_COASTALTOWN_MOVIESET": {
             "Id": "LOCATION_COASTALTOWN_MOVIESET",
             "Type": "location",
@@ -1144,6 +1106,44 @@
             "Guid": "73a73f05-83ef-4e2e-87a8-f05f4e9d2811",
             "Rarity": null,
             "DisplayNameLocKey": "UI_LOCATION_COASTALTOWN_MOVIESET_NAME"
+        },
+        "LOCATION_COASTALTOWN_NIGHT": {
+            "Id": "LOCATION_COASTALTOWN_NIGHT",
+            "Type": "location",
+            "Subtype": "sublocation",
+            "GameAsset": null,
+            "ImageId": "",
+            "RMTPrice": -1,
+            "GamePrice": -1,
+            "IsPurchasable": false,
+            "IsPublished": true,
+            "IsDroppable": false,
+            "Capabilities": [],
+            "Qualities": {},
+            "Properties": {
+                "ParentLocation": "LOCATION_PARENT_COASTALTOWN",
+                "Background": "images/locations/location_coastaltown_mamba/background.jpg",
+                "Icon": "images/locations/location_coastaltown_mamba/tile.jpg",
+                "LockedIcon": "images/locations/LOCATION_COASTALTOWN/tile_unreleased.jpg",
+                "DlcImage": "images/livetile/dlc/tile_hitman3.jpg",
+                "DlcName": "GAME_STORE_METADATA_S3_GAME_TITLE",
+                "IsLocked": false,
+                "GameChangers": [],
+                "Order": 2,
+                "ProgressionKey": "LOCATION_PARENT_COASTALTOWN",
+                "CreateContractId": "43a1bfcb-dede-453e-95f2-c2862329ebee",
+                "IsFreeDLC": true,
+                "HideProgression": false,
+                "ExcludeParentRewards": true,
+                "Season": 1,
+                "RequiredResources": [
+                    "[assembly:/_PRO/Scenes/Missions/CoastalTown/_Scene_Mission_Mamba.entity].entitytemplate"
+                ],
+                "Entitlements": ["H1_LEGACY_STANDARD"]
+            },
+            "Guid": "cb513891-c703-49ee-8db4-1e62264156be",
+            "Rarity": null,
+            "DisplayNameLocKey": "UI_LOCATION_COASTALTOWN_NIGHT_NAME"
         },
         "LOCATION_COASTALTOWN_EBOLA": {
             "Id": "LOCATION_COASTALTOWN_EBOLA",


### PR DESCRIPTION
Resolves the issue that The Icon and Landslide are swapped position wise, mentioned in #228.