### PR TITLE
Fix a number of timer-related broken challenges

### DIFF
--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -1425,7 +1425,7 @@ export class ChallengeService extends ChallengeRegistry {
                 ContractId: session.contractId,
                 Name: "ChallengeCompleted",
                 // The timestamp (used for timers) is not important here, since it's not an event sent by the game.
-                Timestamp: 0, 
+                Timestamp: 0,
             },
             session,
         )

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -1424,7 +1424,8 @@ export class ChallengeService extends ChallengeRegistry {
                 ContractSessionId: session.Id,
                 ContractId: session.contractId,
                 Name: "ChallengeCompleted",
-                Timestamp: new Date().getTime(),
+                // The timestamp (used for timers) is not important here, since it's not an event sent by the game.
+                Timestamp: 0, 
             },
             session,
         )


### PR DESCRIPTION
The timers should stick to using timestamps associated with events sent by the game **only**. The `ChallengeCompleted` event is a server-simulated event, so it should not use the current time as its timestamp so as to not mess up with the timers.