### PR TITLE
Fix disconnection when dying in arcade

### DIFF
--- a/components/eventHandler.ts
+++ b/components/eventHandler.ts
@@ -461,7 +461,8 @@ function contractFailed(
     // If this is an arcade contract, reset it
     arcadeFail: if (json.Metadata.Type === "arcade") {
         manualExit: if (
-            (event.Value as string).startsWith("Contract ended manually")
+            typeof event.Value === "string" &&
+            event.Value.startsWith("Contract ended manually")
         ) {
             if (session.completedObjectives.size === 0) break arcadeFail
 


### PR DESCRIPTION
Fixed disconnecting when dying in arcade because the event will have a non-string Value.
``` json
"Value": {
    "FailType": "HitmanDead",
    "Reasons": ["Agent Down"]
}
```