### PR TITLE
Feature/escalations

### DIFF
--- a/contractdata/DARTMOOR/ESCALATION/DEZ/DEZ3.json
+++ b/contractdata/DARTMOOR/ESCALATION/DEZ/DEZ3.json
@@ -239,7 +239,7 @@
                     "display": {
                         "$loc": {
                             "key": "UI_CONTRACT_GENERAL_OBJ_KILL",
-                            "data": "$($repository 3036afda-a6ab-4830-9f9a-192bcd5d958d).Name"
+                            "data": "$($repository 1639e08a-4150-4a92-a4b3-bcec99b336fe).Name"
                         }
                     }
                 },

--- a/contractdata/HAVEN/ESCALATION/SLEAZEBALL/SLEAZEBALL1.json
+++ b/contractdata/HAVEN/ESCALATION/SLEAZEBALL/SLEAZEBALL1.json
@@ -9,7 +9,7 @@
                 "BriefingText": "$loc UI_PEACOCK_LONGBUSH_GYM_ACCIDENT1_DESC",
                 "ObjectiveType": "customkill",
                 "HUDTemplate": {
-                    "display": "$loc UI_PEACOCK_LONGBUSH_GYM_ACCIDENT_HUD"
+                    "display": "$loc UI_PEACOCK_LONGBUSH_GYM_ACCIDENT1_HUD"
                 },
                 "Category": "primary",
                 "Definition": {

--- a/contractdata/SAPIENZA/ESCALATION/JEFFREY/JEFFREY1.json
+++ b/contractdata/SAPIENZA/ESCALATION/JEFFREY/JEFFREY1.json
@@ -13,7 +13,8 @@
                 "LongBriefingText": "$loc UI_PEACOCK_SATANTA_OBJ1_LONG",
                 "ObjectiveType": "custom",
                 "HUDTemplate": {
-                    "display": "$loc UI_PEACOCK_SATANTA_OBJ1_TITLE"
+                    "display": "$loc UI_PEACOCK_SATANTA_OBJ1_TITLE",
+                    "iconType": 17
                 },
                 "Definition": {
                     "Context": {
@@ -46,7 +47,8 @@
                 "LongBriefingText": "$loc UI_PEACOCK_SATANTA_OBJ2_LONG",
                 "ObjectiveType": "custom",
                 "HUDTemplate": {
-                    "display": "$loc UI_PEACOCK_SATANTA_OBJ2_TITLE"
+                    "display": "$loc UI_PEACOCK_SATANTA_OBJ2_TITLE",
+                    "iconType": 17
                 },
                 "Definition": {
                     "Scope": "session",

--- a/contractdata/SAPIENZA/ESCALATION/JEFFREY/JEFFREY2.json
+++ b/contractdata/SAPIENZA/ESCALATION/JEFFREY/JEFFREY2.json
@@ -13,7 +13,8 @@
                 "LongBriefingText": "$loc UI_PEACOCK_SATANTA_OBJ1_LONG",
                 "ObjectiveType": "custom",
                 "HUDTemplate": {
-                    "display": "$loc UI_PEACOCK_SATANTA_OBJ1_TITLE"
+                    "display": "$loc UI_PEACOCK_SATANTA_OBJ1_TITLE",
+                    "iconType": 17
                 },
                 "Definition": {
                     "Context": {
@@ -46,7 +47,8 @@
                 "LongBriefingText": "$loc UI_PEACOCK_SATANTA_OBJ2_LONG",
                 "ObjectiveType": "custom",
                 "HUDTemplate": {
-                    "display": "$loc UI_PEACOCK_SATANTA_OBJ2_TITLE"
+                    "display": "$loc UI_PEACOCK_SATANTA_OBJ2_TITLE",
+                    "iconType": 17
                 },
                 "Definition": {
                     "Scope": "session",

--- a/contractdata/SAPIENZA/ESCALATION/JEFFREY/JEFFREY3.json
+++ b/contractdata/SAPIENZA/ESCALATION/JEFFREY/JEFFREY3.json
@@ -13,7 +13,8 @@
                 "LongBriefingText": "$loc UI_PEACOCK_SATANTA_OBJ1_LONG",
                 "ObjectiveType": "custom",
                 "HUDTemplate": {
-                    "display": "$loc UI_PEACOCK_SATANTA_OBJ1_TITLE"
+                    "display": "$loc UI_PEACOCK_SATANTA_OBJ1_TITLE",
+                    "iconType": 17
                 },
                 "Definition": {
                     "Context": {
@@ -46,7 +47,8 @@
                 "LongBriefingText": "$loc UI_PEACOCK_SATANTA_OBJ2_LONG",
                 "ObjectiveType": "custom",
                 "HUDTemplate": {
-                    "display": "$loc UI_PEACOCK_SATANTA_OBJ2_TITLE"
+                    "display": "$loc UI_PEACOCK_SATANTA_OBJ2_TITLE",
+                    "iconType": 17
                 },
                 "Definition": {
                     "Scope": "session",


### PR DESCRIPTION
Hello everyone !

As I've said in my previous pull request, #302 where I added french translations to Peacock, I've noticed some small issues and small things while playing the Peacock escalations to check my translations.

This pull request addresses those, here's a detail of what's changed:
- The dez Dichotomy: on level 3, the HUD showed two targets with the same name
- The sleazeball Situation: on level 1, the HUD objective was broken, showing a missing translation
- The Jeffrey Consolation: a small thing, but the icon used for the two objectives was the "hit" one, it's now the "objective" one.

Here's a few before and afters so you can see the changes more clearly:
![changes-dez](https://github.com/thepeacockproject/Peacock/assets/5084309/ba39fb3e-6211-4073-bfc2-f194dce61183)
![changes-jeffrey](https://github.com/thepeacockproject/Peacock/assets/5084309/964a15db-5a72-4b40-87ec-c2063fc4f92c)
![changes-sleazeball](https://github.com/thepeacockproject/Peacock/assets/5084309/98bb30d4-5876-441b-b154-686fb063f3f9)

I should note that there's also an issue with The Jeffrey Consolation where "ghost" objectives appear in-game in the notebook. Those are from the complications, but I haven't found a way to hide them.