### PR TITLE
Fix some strict type errors

### DIFF
--- a/components/2016/legacyProfileRouter.ts
+++ b/components/2016/legacyProfileRouter.ts
@@ -46,7 +46,7 @@ legacyProfileRouter.post(
 legacyProfileRouter.post(
     "/AuthenticationService/GetBlobOfflineCacheDatabaseDiff",
     (req: RequestWithJwt, res) => {
-        const configs = []
+        const configs: string[] = []
 
         menuSystemDatabase.hooks.getDatabaseDiff.call(configs, req.gameVersion)
 

--- a/components/candle/challengeHelpers.ts
+++ b/components/candle/challengeHelpers.ts
@@ -111,13 +111,13 @@ export function inclusionDataCheck(
     if (!incData) return true
     if (!contract) return false
 
-    return (
+    return Boolean(
         incData.ContractIds?.includes(contract.Metadata.Id) ||
-        incData.ContractTypes?.includes(contract.Metadata.Type) ||
-        incData.Locations?.includes(contract.Metadata.Location) ||
-        contract.Metadata?.Gamemodes?.some((r) =>
-            incData.GameModes?.includes(r),
-        )
+            incData.ContractTypes?.includes(contract.Metadata.Type) ||
+            incData.Locations?.includes(contract.Metadata.Location) ||
+            contract.Metadata?.Gamemodes?.some((r) =>
+                incData.GameModes?.includes(r),
+            ),
     )
 }
 
@@ -134,7 +134,8 @@ export function isChallengeForDifficulty(
 
 /**
  * Judges whether a challenge should be included in the challenges list of a contract.
- * @requires The challenge and the contract share the same parent location.
+ * Requires the challenge and the contract share the same parent location.
+ *
  * @param contractId The id of the contract.
  * @param locationId The sublocation ID of the challenge.
  * @param difficulty The upper bound on the difficulty of the challenges to return.

--- a/components/candle/progressionService.ts
+++ b/components/candle/progressionService.ts
@@ -33,6 +33,7 @@ import {
 } from "../utils"
 import { writeUserData } from "../databaseHandler"
 import { MasteryPackageDrop } from "../types/mastery"
+import assert from "assert"
 
 export class ProgressionService {
     // NOTE: Official will always grant XP to both Location Mastery and the Player Profile
@@ -108,10 +109,13 @@ export class ProgressionService {
          * This is required to unlock the item to the normal inventory too, as the freelancer and normal inventory item ID is not the same
          */
         if (isEvergreenContract) {
-            const evergreenGearUnlockables = unlockables.reduce((acc, u) => {
-                if (u.Properties.Unlocks) acc.push(...u.Properties.Unlocks)
-                return acc
-            }, [])
+            const evergreenGearUnlockables = unlockables.reduce(
+                (acc: string[], u) => {
+                    if (u?.Properties.Unlocks) acc.push(...u.Properties.Unlocks)
+                    return acc
+                },
+                [],
+            )
 
             if (evergreenGearUnlockables.length) {
                 unlockables.push(
@@ -214,6 +218,11 @@ export class ProgressionService {
 
             // Update the EvergreenLevel with the latest Mastery Level
             if (isEvergreenContract) {
+                assert.ok(
+                    contract.Metadata.CpdId,
+                    "evergreen contract has no CPD",
+                )
+
                 userProfile.Extensions.CPD[contract.Metadata.CpdId][
                     "EvergreenLevel"
                 ] = locationData.Level

--- a/components/contracts/contractsModeRouting.ts
+++ b/components/contracts/contractsModeRouting.ts
@@ -73,7 +73,7 @@ export async function officialSearchContract(
     gameVersion: GameVersion,
     filters: string[],
     pageNumber: number,
-): Promise<ContractSearchResult> {
+): Promise<ContractSearchResult | undefined> {
     const remoteService = getRemoteService(gameVersion)
     const user = userAuths.get(userId)
 
@@ -95,7 +95,7 @@ export async function officialSearchContract(
     preserveContracts(
         resp.data.data.Data.Contracts.map(
             (c) => c.UserCentricContract.Contract.Metadata.PublicId,
-        ),
+        ).filter(Boolean) as string[],
     )
 
     return resp.data.data

--- a/components/contracts/escalations/escalationService.ts
+++ b/components/contracts/escalations/escalationService.ts
@@ -26,6 +26,7 @@ import type {
 } from "../../types/types"
 import { getUserData } from "../../databaseHandler"
 import { log, LogLevel } from "../../loggingInterop"
+import assert from "assert"
 
 /**
  * Put a group id in here to hide it from the menus on 2016.
@@ -100,8 +101,10 @@ export function resetUserEscalationProgress(
  * @param groupContract The escalation group's contract.
  * @returns The number of levels.
  */
-export function getLevelCount(groupContract: MissionManifest): number {
-    return groupContract.Metadata.GroupDefinition.Order.length
+export function getLevelCount(
+    groupContract: MissionManifest | undefined,
+): number {
+    return groupContract?.Metadata.GroupDefinition?.Order.length ?? 0
 }
 
 /**
@@ -121,6 +124,8 @@ export function getPlayEscalationInfo(
 
     const p = getUserEscalationProgress(userData, groupContractId)
     const groupCt = controller.escalationMappings.get(groupContractId)
+
+    assert.ok(groupCt, `No escalation mapping for ${groupContractId}`)
 
     const totalLevelCount = getLevelCount(
         controller.resolveContract(groupContractId),

--- a/components/contracts/escalations/escalationService.ts
+++ b/components/contracts/escalations/escalationService.ts
@@ -99,7 +99,7 @@ export function resetUserEscalationProgress(
  * Get the number of levels in the specified group.
  *
  * @param groupContract The escalation group's contract.
- * @returns The number of levels.
+ * @returns The number of levels. If the group contract is undefined, always 0.
  */
 export function getLevelCount(
     groupContract: MissionManifest | undefined,

--- a/components/discord/client.ts
+++ b/components/discord/client.ts
@@ -201,10 +201,10 @@ export class RPCClient extends EventEmitter {
             args.smallImageText
         ) {
             assets = {
-                large_image: args.largeImageKey,
-                large_text: args.largeImageText,
-                small_image: args.smallImageKey,
-                small_text: args.smallImageText,
+                large_image: args.largeImageKey!,
+                large_text: args.largeImageText!,
+                small_image: args.smallImageKey!,
+                small_text: args.smallImageText!,
             }
         }
 

--- a/components/entitlementStrategies.ts
+++ b/components/entitlementStrategies.ts
@@ -78,7 +78,7 @@ export class IOIStrategy extends EntitlementStrategy {
 
         const user = userAuths.get(userId)
 
-        let resp: AxiosResponse<string[]> = undefined
+        let resp: AxiosResponse<string[]> | undefined = undefined
 
         try {
             resp = await user?._useService<string[]>(
@@ -92,7 +92,7 @@ export class IOIStrategy extends EntitlementStrategy {
             if (error instanceof AxiosError) {
                 log(
                     LogLevel.ERROR,
-                    `Failed to get entitlements from Steam: got ${error.response.status} ${error.response.statusText}.`,
+                    `Failed to get entitlements from Steam: got ${error.response?.status} ${error.response?.statusText}.`,
                 )
             } else {
                 log(

--- a/components/hotReloadService.ts
+++ b/components/hotReloadService.ts
@@ -35,7 +35,7 @@ export async function setupHotListener(
             callback(event)
         }
     } catch (err) {
-        if (err.name === "AbortError") {
+        if ((err as Error).name === "AbortError") {
             return
         }
 

--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -513,7 +513,7 @@ function updateWithDefaultSuit(
 export function createInventory(
     profileId: string,
     gameVersion: GameVersion,
-    sublocation = undefined,
+    sublocation: Unlockable | undefined = undefined,
 ): InventoryItem[] {
     if (inventoryUserCache.has(profileId)) {
         return updateWithDefaultSuit(

--- a/components/loggingInterop.ts
+++ b/components/loggingInterop.ts
@@ -175,7 +175,7 @@ export function logDebug(...args: unknown[]): void {
  */
 export function log(
     level: LogLevel,
-    data: string,
+    data: string | unknown,
     category: LogCategory | string = LOG_CATEGORY_DEFAULT,
 ): void {
     if (category === LogCategory.CALLER) {

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -106,7 +106,12 @@ const menuDataRouter = Router()
 
 menuDataRouter.get(
     "/ChallengeLocation",
-    (req: RequestWithJwt<{ locationId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            locationId: string
+        }>,
+        res,
+    ) => {
         if (typeof req.query.locationId !== "string") {
             res.status(400).send("Invalid locationId")
             return
@@ -422,7 +427,7 @@ menuDataRouter.get("/SafehouseCategory", (req: RequestWithJwt, res) => {
             category.SubCategories.push(subcategory)
         }
 
-        subcategory.Data.Items.push({
+        subcategory.Data?.Items.push({
             Item: item,
             ItemDetails: {
                 Capabilities: [],
@@ -612,7 +617,12 @@ menuDataRouter.get(
 
 menuDataRouter.get(
     "/missionrewards",
-    (req: RequestWithJwt<{ contractSessionId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            contractSessionId: string
+        }>,
+        res,
+    ) => {
         const { contractId } = getSession(req.jwt.unique_name)
         const contractData = controller.resolveContract(contractId, true)
 
@@ -693,7 +703,12 @@ menuDataRouter.get("/Planning", planningView)
 
 menuDataRouter.get(
     "/selectagencypickup",
-    (req: RequestWithJwt<{ contractId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            contractId: string
+        }>,
+        res,
+    ) => {
         const pickupData = getConfig<SceneConfig>("AgencyPickups", false)
 
         const selectagencypickup = {
@@ -781,7 +796,12 @@ menuDataRouter.get(
 
 menuDataRouter.get(
     "/selectentrance",
-    (req: RequestWithJwt<{ contractId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            contractId: string
+        }>,
+        res,
+    ) => {
         const entranceData = getConfig<SceneConfig>("Entrances", false)
 
         const selectEntrance: CommonSelectScreenConfig = {
@@ -891,7 +911,13 @@ menuDataRouter.get("/scoreoverviewandunlocks", missionEnd)
 
 menuDataRouter.get(
     "/Destination",
-    (req: RequestWithJwt<{ locationId: string; difficulty?: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            locationId: string
+            difficulty?: string
+        }>,
+        res,
+    ) => {
         const LOCATION = req.query.locationId
 
         const locData = getVersionedConfig<PeacockLocationsData>(
@@ -1177,7 +1203,12 @@ async function lookupContractPublicId(
 
 menuDataRouter.get(
     "/LookupContractPublicId",
-    async (req: RequestWithJwt<{ publicid: string }>, res) => {
+    async (
+        req: RequestWithJwt<{
+            publicid: string
+        }>,
+        res,
+    ) => {
         if (!req.query.publicid || typeof req.query.publicid !== "string") {
             return res.status(400).send("no/invalid public id specified!")
         }
@@ -1200,7 +1231,10 @@ menuDataRouter.get(
 menuDataRouter.get(
     "/HitsCategory",
     async (
-        req: RequestWithJwt<{ type: string; page?: number | string }>,
+        req: RequestWithJwt<{
+            type: string
+            page?: number | string
+        }>,
         res,
     ) => {
         const category = req.query.type
@@ -1237,7 +1271,12 @@ menuDataRouter.get(
 
 menuDataRouter.get(
     "/PlayNext",
-    (req: RequestWithJwt<{ contractId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            contractId: string
+        }>,
+        res,
+    ) => {
         if (!req.query.contractId) {
             res.status(400).send("no contract id!")
             return
@@ -1359,7 +1398,10 @@ menuDataRouter.get("/LeaderboardsView", (req, res) => {
 })
 
 const leaderboardEntries = async (
-    req: RequestWithJwt<{ contractid: string; difficultyLevel?: string }>,
+    req: RequestWithJwt<{
+        contractid: string
+        difficultyLevel?: string
+    }>,
     res: Response,
 ) => {
     let difficulty = "unset"
@@ -1448,7 +1490,10 @@ menuDataRouter.get("/LeaderboardEntries", leaderboardEntries)
 menuDataRouter.get(
     "/DebriefingLeaderboards",
     async (
-        req: RequestWithJwt<{ contractid: string; difficulty?: string }>,
+        req: RequestWithJwt<{
+            contractid: string
+            difficulty?: string
+        }>,
         res,
     ) => {
         const debriefingLeaderboardsTemplate = getConfig(
@@ -1474,7 +1519,9 @@ menuDataRouter.get("/Contracts", contractsModeHome)
 preMenuDataRouter.get(
     "/contractcreation/planning",
     (
-        req: RequestWithJwt<{ contractCreationIdOverwrite: string }>,
+        req: RequestWithJwt<{
+            contractCreationIdOverwrite: string
+        }>,
         res,
         next,
     ) => {
@@ -1550,7 +1597,15 @@ menuDataRouter.get("/contractsearchpage", (req: RequestWithJwt, res) => {
 menuDataRouter.post(
     "/ContractSearch",
     jsonMiddleware(),
-    async (req: RequestWithJwt<{ sorting?: unknown }, string[]>, res) => {
+    async (
+        req: RequestWithJwt<
+            {
+                sorting?: unknown
+            },
+            string[]
+        >,
+        res,
+    ) => {
         const specialContracts: string[] = []
 
         await controller.hooks.getSearchResults.callAsync(
@@ -1563,7 +1618,9 @@ menuDataRouter.post(
         if (specialContracts.length > 0) {
             // Handled by a plugin
 
-            const contracts: { UserCentricContract: UserCentricContract }[] = []
+            const contracts: {
+                UserCentricContract: UserCentricContract
+            }[] = []
 
             for (const contract of specialContracts) {
                 const userCentric = generateUserCentric(
@@ -1619,7 +1676,15 @@ menuDataRouter.post(
 menuDataRouter.post(
     "/ContractSearchPaginate",
     jsonMiddleware(),
-    async (req: RequestWithJwt<{ page: number }, string[]>, res) => {
+    async (
+        req: RequestWithJwt<
+            {
+                page: number
+            },
+            string[]
+        >,
+        res,
+    ) => {
         res.json({
             template: getConfig("ContractSearchPaginateTemplate", false),
             data: await officialSearchContract(
@@ -1634,7 +1699,12 @@ menuDataRouter.post(
 
 menuDataRouter.get(
     "/DebriefingChallenges",
-    (req: RequestWithJwt<{ contractId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            contractId: string
+        }>,
+        res,
+    ) => {
         res.json({
             template: getConfig("DebriefingChallengesTemplate", false),
             data: {
@@ -1889,8 +1959,8 @@ menuDataRouter.get("/PlayerProfile", (req: RequestWithJwt, res) => {
         ),
     )
 
-    playerProfilePage.data.PlayerProfileXp.Seasons.forEach((e) =>
-        e.Locations.forEach((f) => {
+    for (const e of playerProfilePage.data.PlayerProfileXp.Seasons) {
+        for (const f of e.Locations) {
             const subLocationData = subLocationMap.get(f.LocationId)
 
             f.Xp = subLocationData?.Xp || 0
@@ -1906,8 +1976,8 @@ menuDataRouter.get("/PlayerProfile", (req: RequestWithJwt, res) => {
                         ] as ProgressionData
                     ).Level || 1
             }
-        }),
-    )
+        }
+    }
 
     res.json(playerProfilePage)
 })
@@ -2010,7 +2080,12 @@ menuDataRouter.get(
 
 menuDataRouter.get(
     "/MasteryDataForLocation",
-    (req: RequestWithJwt<{ locationId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            locationId: string
+        }>,
+        res,
+    ) => {
         res.json(
             controller.masteryService.getMasteryDataForLocation(
                 req.query.locationId,
@@ -2023,7 +2098,12 @@ menuDataRouter.get(
 
 menuDataRouter.get(
     "/GetMasteryCompletionDataForUnlockable",
-    (req: RequestWithJwt<{ unlockableId: string }>, res) => {
+    (
+        req: RequestWithJwt<{
+            unlockableId: string
+        }>,
+        res,
+    ) => {
         // We make this lookup table to quickly get it, there's no other quick way for it.
         const unlockToLoc = {
             FIREARMS_SC_HERO_SNIPER_HM: "LOCATION_PARENT_AUSTRIA",

--- a/components/menus/campaigns.ts
+++ b/components/menus/campaigns.ts
@@ -484,7 +484,7 @@ export function makeCampaigns(
                             ),
                         ],
                     },
-                ].filter((o) => o !== undefined),
+                ].filter(Boolean) as Campaign[],
                 StoryData: [],
                 Properties: {
                     BackgroundImage:

--- a/components/menus/imageHandler.ts
+++ b/components/menus/imageHandler.ts
@@ -100,7 +100,10 @@ export async function imageFetchingMiddleware(
             axiosResponse.data.pipe(writeStream)
         }
     } catch (e) {
-        log(LogLevel.DEBUG, `[Image loading] Err ${e} ${e.stack}`)
+        log(
+            LogLevel.DEBUG,
+            `[Image loading] Err ${e} ${(e as Error | undefined)?.stack}`,
+        )
 
         res.status(500).send("Failed to get data")
     }

--- a/components/menus/sniper.ts
+++ b/components/menus/sniper.ts
@@ -43,7 +43,7 @@ export function createSniperLoadouts(
     const parentLocation = getSubLocationByName(
         contractData.Metadata.Location,
         gameVersion,
-    ).Properties.ParentLocation
+    )?.Properties.ParentLocation
 
     // This function call is used as it gets all mastery data for the current location
     // which includes all the characters we'll need.
@@ -122,7 +122,7 @@ export function createSniperLoadouts(
                         ],
                         LimitedLoadoutUnlockLevel: 0 as number | undefined,
                     },
-                    CompletionData: masteryData.CompletionData,
+                    CompletionData: masteryData?.CompletionData,
                 }
 
                 if (loadoutData) {

--- a/components/platformEntitlements.ts
+++ b/components/platformEntitlements.ts
@@ -165,7 +165,7 @@ export async function getEpicEntitlements(
     async function getEnts(
         ents: string[],
     ): Promise<NamespaceEntitlementEpic[]> {
-        const v = {
+        const v: { headers: Record<string, string> } = {
             headers: {},
         }
 
@@ -183,7 +183,7 @@ export async function getEpicEntitlements(
             if (error instanceof AxiosError) {
                 log(
                     LogLevel.ERROR,
-                    `Failed to get entitlements from Epic: got ${error.response.status} ${error.response.statusText}.`,
+                    `Failed to get entitlements from Epic: got ${error.response?.status} ${error.response?.statusText}.`,
                 )
             } else {
                 log(

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -1149,15 +1149,16 @@ export async function missionEnd(
                             Total: calculateScoreResult.scoreWithBonus,
                             AchievedMasteries:
                                 result.ScoreOverview.ContractScore
-                                    .AchievedMasteries,
+                                    ?.AchievedMasteries,
                             AwardedBonuses:
                                 result.ScoreOverview.ContractScore
-                                    .AwardedBonuses,
+                                    ?.AwardedBonuses,
                             TotalNoMultipliers:
                                 result.ScoreOverview.ContractScore
-                                    .TotalNoMultipliers,
+                                    ?.TotalNoMultipliers,
                             TimeUsedSecs:
-                                result.ScoreOverview.ContractScore.TimeUsedSecs,
+                                result.ScoreOverview.ContractScore
+                                    ?.TimeUsedSecs,
                             FailedBonuses: null,
                             IsVR: false,
                             SilentAssassin: result.ScoreOverview.SilentAssassin,

--- a/components/types/score.ts
+++ b/components/types/score.ts
@@ -63,7 +63,7 @@ export interface MissionEndChallenge {
     XPGain: number
     IsGlobal: boolean
     IsActionReward: boolean
-    Drops: string[]
+    Drops?: string[]
 }
 
 export interface MissionEndSourceChallenge {

--- a/components/utils.ts
+++ b/components/utils.ts
@@ -338,6 +338,7 @@ function updateUserProfile(
                 {},
             )
 
+            // ts-expect-error Legacy property.
             delete profile.Extensions.progression["Unlockables"]
 
             profile.Version = 1
@@ -527,7 +528,7 @@ export function attainableDefaults(gameVersion: GameVersion): string[] {
  * @param subLocation The sub-location.
  * @returns The default suit for the given sub-location and parent location.
  */
-export function getDefaultSuitFor(subLocation: Unlockable) {
+export function getDefaultSuitFor(subLocation: Unlockable): string | undefined {
     return (
         defaultSuits[subLocation.Id] ||
         defaultSuits[subLocation.Properties.ParentLocation] ||
@@ -688,7 +689,9 @@ export function isSuit(repoId: string): boolean {
     ).filter((unlockable) => unlockable.Type === "disguise")
 
     for (const u of unlockablesFiltered) {
-        suitsToTypeMap[u.Properties.RepositoryId] = u.Subtype
+        if (u.Subtype && u.Properties.RepositoryId) {
+            suitsToTypeMap[u.Properties.RepositoryId] = u.Subtype
+        }
     }
 
     return suitsToTypeMap[repoId]

--- a/components/webFeatures.ts
+++ b/components/webFeatures.ts
@@ -156,15 +156,14 @@ webFeaturesRouter.get(
             return
         }
 
-        if (controller.escalationMappings.get(req.query.id) === undefined) {
+        const mapping = controller.escalationMappings.get(req.query.id)
+
+        if (mapping === undefined) {
             formErrorMessage(res, "Unknown escalation.")
             return
         }
 
-        if (
-            Object.keys(controller.escalationMappings.get(req.query.id))
-                .length < parseInt(req.query.level, 10)
-        ) {
+        if (Object.keys(mapping).length < parseInt(req.query.level, 10)) {
             formErrorMessage(
                 res,
                 "Cannot exceed the maximum level for this escalation!",


### PR DESCRIPTION
More work towards making the codebase TS strict mode compliant.

Namely:
- Fixed some cases where TS couldn't narrow types well enough
- Added assertions for cases that shouldn't(?) happen
- Fixed some docstring issues
- Changed a few maps to objects just because we don't need to use maps to access well-known keys (e.g. game versions)

This does contain a few API changes:
- Some APIs now explicitly mark that they could return undefined (to match their actual behavior)
- `getLevelCount` now always returns 0 if given an undefined group contract, instead of throwing from accessing undefined keys.

A LOT of the remaining type issues actually boil down to the routers expecting RequestWithJwt when the express types don't guarantee that, which is very annoying. Blocked by #337 