### PR TITLE
Fix contract creation not using appropriate bricks

### DIFF
--- a/components/contracts/contractRouting.ts
+++ b/components/contracts/contractRouting.ts
@@ -316,7 +316,7 @@ contractRoutingRouter.post(
             Data: {
                 Objectives: objectives,
                 GameChangers: gamechangers,
-                Bricks: [],
+                Bricks: contractData.Data.Bricks,
             },
             Metadata: {
                 Title: req.body.creationData.Title,


### PR DESCRIPTION
Fixes #354

Haven't tested in game, but I'm almost certain this will fix the issue. Looking at the official servers output, it also emits all bricks stated in the creation contract to generated contracts.