### PR TITLE
Check for small item sizes for hidden stash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ THIRDPARTYNOTICES.txt
 overrides
 
 DEBUG_PROFILE.zip
+
+packaging/add_itemsize/*
+!packaging/add_itemsize/add_itemsize.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,5 @@ components/contracts.json
 logs
 resources/**/*.json
 !resources/locale.json
+packaging/add_itemsize/*
+!packaging/add_itemsize/add_itemsize.js

--- a/components/2016/legacyMenuData.ts
+++ b/components/2016/legacyMenuData.ts
@@ -155,8 +155,8 @@ legacyMenuDataRouter.get(
                                             item.Unlockable.Properties
                                                 .LoadoutSlot !== "disguise")) && // => display all non-disguise items
                                     (req.query.allowlargeitems === "true" ||
-                                        item.Unlockable.Properties
-                                            .LoadoutSlot !== "carriedweapon") &&
+                                        item.Unlockable.Properties.ItemSize === // regular gear slot or hidden stash => small item
+                                            "ITEMSIZE_SMALL") &&
                                     item.Unlockable.Type !==
                                         "challengemultipler" &&
                                     !item.Unlockable.Properties.InclusionData

--- a/components/2016/legacyMenuData.ts
+++ b/components/2016/legacyMenuData.ts
@@ -156,7 +156,11 @@ legacyMenuDataRouter.get(
                                                 .LoadoutSlot !== "disguise")) && // => display all non-disguise items
                                     (req.query.allowlargeitems === "true" ||
                                         item.Unlockable.Properties.ItemSize === // regular gear slot or hidden stash => small item
-                                            "ITEMSIZE_SMALL") &&
+                                            "ITEMSIZE_SMALL" ||
+                                        (!item.Unlockable.Properties.ItemSize &&
+                                            item.Unlockable.Properties
+                                                .LoadoutSlot !== // use old logic if itemsize is not set
+                                                "carriedweapon")) &&
                                     item.Unlockable.Type !==
                                         "challengemultipler" &&
                                     !item.Unlockable.Properties.InclusionData

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -568,8 +568,10 @@ menuDataRouter.get(
                                 !item.Unlockable.Properties.IsContainer) &&
                             (req.query.allowlargeitems === "true" ||
                                 (req.query.slotname === "stashpoint" &&
-                                    item.Unlockable.Properties.ItemSize === // hidden stash => only allow small items
+                                    item.Unlockable.Properties.ItemSize === // hidden stash => only allow small items / guns
                                         "ITEMSIZE_SMALL") ||
+                                item.Unlockable.Properties.LoadoutSlot ===
+                                    "concealedweapon" ||
                                 (req.query.slotname !== "stashpoint" &&
                                     item.Unlockable.Properties.LoadoutSlot !==
                                         "carriedweapon")) &&

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -567,8 +567,12 @@ menuDataRouter.get(
                             (req.query.allowcontainers === "true" ||
                                 !item.Unlockable.Properties.IsContainer) &&
                             (req.query.allowlargeitems === "true" ||
-                                item.Unlockable.Properties.LoadoutSlot !==
-                                    "carriedweapon") &&
+                                (req.query.slotname === "stashpoint" &&
+                                    item.Unlockable.Properties.ItemSize === // hidden stash => only allow small items
+                                        "ITEMSIZE_SMALL") ||
+                                (req.query.slotname !== "stashpoint" &&
+                                    item.Unlockable.Properties.LoadoutSlot !==
+                                        "carriedweapon")) &&
                             item.Unlockable.Type !== "challengemultiplier" &&
                             !item.Unlockable.Properties.InclusionData
                         ) // not sure about this one

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -567,14 +567,8 @@ menuDataRouter.get(
                             (req.query.allowcontainers === "true" ||
                                 !item.Unlockable.Properties.IsContainer) &&
                             (req.query.allowlargeitems === "true" ||
-                                (req.query.slotname === "stashpoint" &&
-                                    item.Unlockable.Properties.ItemSize === // hidden stash => only allow small items / guns
-                                        "ITEMSIZE_SMALL") ||
-                                item.Unlockable.Properties.LoadoutSlot ===
-                                    "concealedweapon" ||
-                                (req.query.slotname !== "stashpoint" &&
-                                    item.Unlockable.Properties.LoadoutSlot !==
-                                        "carriedweapon")) &&
+                                item.Unlockable.Properties.ItemSize === // regular gear slot or hidden stash => small item
+                                    "ITEMSIZE_SMALL") &&
                             item.Unlockable.Type !== "challengemultiplier" &&
                             !item.Unlockable.Properties.InclusionData
                         ) // not sure about this one

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -568,7 +568,10 @@ menuDataRouter.get(
                                 !item.Unlockable.Properties.IsContainer) &&
                             (req.query.allowlargeitems === "true" ||
                                 item.Unlockable.Properties.ItemSize === // regular gear slot or hidden stash => small item
-                                    "ITEMSIZE_SMALL") &&
+                                    "ITEMSIZE_SMALL" ||
+                                (!item.Unlockable.Properties.ItemSize &&
+                                    item.Unlockable.Properties.LoadoutSlot !== // use old logic if itemsize is not set
+                                        "carriedweapon")) &&
                             item.Unlockable.Type !== "challengemultiplier" &&
                             !item.Unlockable.Properties.InclusionData
                         ) // not sure about this one

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -656,6 +656,7 @@ export interface Unlockable {
             | "disguise"
             | "gear"
             | string
+        ItemSize?: string
         IsConsumable?: boolean
         RepositoryId?: RepositoryId
         OrderIndex?: number

--- a/packaging/add_itemsize/add_itemsize.js
+++ b/packaging/add_itemsize/add_itemsize.js
@@ -11,7 +11,7 @@ async function main() {
     const { execSync } = require("child_process")
     let chunk0patches = fs
         .readdirSync(`${process.argv[2]}`)
-        .filter((fn) => fn.includes("chunk0"))
+        .filter((fn) => fn.includes("chunk0") && !fn.includes("300.rpkg"))
     let gameprefix = ""
     if (process.argv[3] === "H1") {
         gameprefix = "Legacy"

--- a/packaging/add_itemsize/add_itemsize.js
+++ b/packaging/add_itemsize/add_itemsize.js
@@ -1,0 +1,113 @@
+// Usage:
+// - Go to https://glaciermodding.org/rpkg/ and click "Download latest CLI"
+// - Extract contents of downloaded zip file to packaging/add_itemsize/
+// - From packaging/add_itemsize/ directory, run: node add_itemsize.js <path to Runtime> <Game Version (H1 / H2 / H3 / Scpc)>
+// - E.g. node add_itemsize.js "C:\Program Files\Epic Games\HITMAN3\Runtime" H3
+// - either H2 or H3 Runtime path seem to work for Scpc Game Version
+
+async function main() {
+    const fs = require("fs")
+    const rpkgCli = `"./rpkg-cli.exe"`
+    const { execSync } = require("child_process")
+    let chunk0patches = fs
+        .readdirSync(`${process.argv[2]}`)
+        .filter((fn) => fn.includes("chunk0"))
+    let gameprefix = ""
+    if (process.argv[3] === "H1") {
+        gameprefix = "Legacy"
+    } else if (process.argv[3] === "H2") {
+        gameprefix = "H2"
+    } else if (process.argv[3] === "Scpc") {
+        gameprefix = "Scpc"
+    }
+
+    // Something about how this is reading in the json also removes the decimal from whole numbers (e.g. 1.0 becomes 1)
+    // See: allunlockables[i].Properties.Gameplay.damage for example
+    let allunlockables = require(`../../static/${gameprefix}allunlockables.json`)
+
+    // Run on every chunk0patch file just in case
+    for (let i = 0; i < chunk0patches.length; i++) {
+        console.log(`${chunk0patches[i]} detected`)
+        execSync(
+            `${rpkgCli} -output_path "./" -filter REPO -extract_from_rpkg "${process.argv[2]}/${chunk0patches[i]}"`,
+        )
+        let searchIndexStart = "chunk0"
+        let searchIndexEnd = ".rpkg"
+        let chunkvar = chunk0patches[i].slice(
+            chunk0patches[i].indexOf(searchIndexStart),
+            chunk0patches[i].indexOf(searchIndexEnd),
+        )
+        let repofiles = fs
+            .readdirSync(`${chunkvar}/REPO`)
+            .filter((fn) => fn.endsWith(".REPO"))
+
+        let orig = `${chunkvar}/REPO/${repofiles[0]}`
+        let newfile = `${chunkvar}/REPO/${repofiles[0].slice(
+            0,
+            repofiles[0].length - 5,
+        )}.json`
+        await fs.promises
+            .copyFile(orig, newfile)
+            .then(function () {
+                console.log(`${newfile} file copied`)
+            })
+            .catch(function (error) {
+                console.log(error)
+            })
+        let repochunk0 = require(`../add_itemsize/${newfile}`)
+
+        for (let i = 0; i < allunlockables.length; i++) {
+            if (
+                allunlockables[i].Properties.LoadoutSlot === "gear" ||
+                allunlockables[i].Properties.LoadoutSlot ===
+                    "concealedweapon" ||
+                allunlockables[i].Properties.LoadoutSlot === "carriedweapon"
+            ) {
+                for (let j = 0; j < repochunk0.length; j++) {
+                    if (
+                        repochunk0[j].ID_ ===
+                        allunlockables[i].Properties.RepositoryId
+                    ) {
+                        allunlockables[i].Properties.ItemSize =
+                            repochunk0[j].ItemSize
+                    }
+                }
+            }
+        }
+    }
+
+    // Check if any items in original peacock file (allunlockables.json) did not get itemSize updated
+    // H2 and H3 do not have: PROP_MELEE_EIFFELSOUVENIR_CLUB, RepositoryId: '7257eaa1-c8f3-4e0c-acbf-74f73869c1b2'
+    console.log("Items that did not get itemSize updated:")
+
+    for (let i = 0; i < allunlockables.length; i++) {
+        if (
+            !allunlockables[i].Properties.ItemSize &&
+            allunlockables[i].Properties.LoadoutSlot &&
+            (allunlockables[i].Properties.LoadoutSlot === "gear" ||
+                allunlockables[i].Properties.LoadoutSlot ===
+                    "concealedweapon" ||
+                allunlockables[i].Properties.LoadoutSlot === "carriedweapon")
+        ) {
+            console.log(allunlockables[i])
+        }
+    }
+
+    const jsonContent = JSON.stringify(allunlockables, null, 4)
+    fs.writeFile(
+        `../../static/${gameprefix}allunlockables.json`,
+        jsonContent,
+        "utf8",
+        function (err) {
+            if (err) {
+                return console.log(err)
+            }
+            console.log(
+                `${gameprefix}allunlockables.json file updated with item sizes!`,
+            )
+            // Might be better to have the user call this themselves, but it resolves line break inconsistencies
+            execSync(`yarn prettier`)
+        },
+    )
+}
+main()

--- a/static/H2allunlockables.json
+++ b/static/H2allunlockables.json
@@ -6074,7 +6074,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "1a11a060-358c-4054-98ec-d3491af1d7c6"
+            "RepositoryId": "1a11a060-358c-4054-98ec-d3491af1d7c6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6095,7 +6096,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "7685be69-ff8f-479c-91b9-7347253f8bf1"
+            "RepositoryId": "7685be69-ff8f-479c-91b9-7347253f8bf1",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6118,7 +6120,8 @@
             "Rarity": "common",
             "RepositoryId": "ad2ed125-2371-4bd1-b9e9-fbfa2f0b7947",
             "OrderIndex": 720,
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6141,7 +6144,8 @@
             "Rarity": "common",
             "RepositoryId": "75a0d0de-fe3c-47d3-b64f-7fc446ee59c4",
             "AllowUpSync": true,
-            "OrderIndex": 670
+            "OrderIndex": 670,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6162,7 +6166,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2147b6cd-5a42-4cd6-b366-2c5c50d97db7"
+            "RepositoryId": "2147b6cd-5a42-4cd6-b366-2c5c50d97db7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6183,7 +6188,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "a804e004-7d45-42c8-87bd-b7cbcffa56cc"
+            "RepositoryId": "a804e004-7d45-42c8-87bd-b7cbcffa56cc",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6205,7 +6211,8 @@
             "Rarity": "common",
             "RepositoryId": "2c037ef5-a01b-4532-8216-1d535193a837",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6227,7 +6234,8 @@
             "Rarity": "common",
             "RepositoryId": "5c211971-235a-4856-9eea-fe890940f63a",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6249,7 +6257,8 @@
             "Rarity": "common",
             "RepositoryId": "9e728dc1-3344-4615-be7a-1bcbdd7ad4aa",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6271,7 +6280,8 @@
             "Rarity": "common",
             "RepositoryId": "736132de-78f3-4366-b927-ed9a401dbe26",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6295,7 +6305,8 @@
             "Quality": "2",
             "UnlockOrder": 5,
             "AllowUpSync": true,
-            "OrderIndex": 660
+            "OrderIndex": 660,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6323,7 +6334,8 @@
                 "e55eb9a4-e79c-43c7-970b-79e94e7683b7"
             ],
             "Quality": "2",
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6354,7 +6366,8 @@
                 "92330cd4-1bb1-419e-98d3-ef26631504bf"
             ],
             "Quality": "2",
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6378,7 +6391,8 @@
             "Rarity": "common",
             "RepositoryId": "e30a5b15-ce4d-41d5-a2a5-08dec9c4fe79",
             "Quality": "2",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6400,7 +6414,8 @@
             "Rarity": "common",
             "RepositoryId": "c7296c5f-6c0e-4d52-98cd-e70a0d329e73",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6422,7 +6437,8 @@
             "Rarity": "common",
             "RepositoryId": "54f800df-0c14-4a6f-873f-16497b4edf00",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6444,7 +6460,8 @@
             "Rarity": "common",
             "RepositoryId": "fba6e133-78d1-4af1-8450-1ff30466c553",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6466,7 +6483,8 @@
             "Rarity": "common",
             "RepositoryId": "1033c25d-3d57-4c15-b7d0-acf3b45665ef",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -6488,7 +6506,8 @@
             "Rarity": "common",
             "RepositoryId": "6b87c27d-0d73-4c63-b852-5a9c7a9ffb90",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -6509,7 +6528,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "d439fb64-8713-4c54-a3f3-90730dbdf370",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6533,7 +6553,8 @@
             "Rarity": "common",
             "RepositoryId": "4dee7cd6-f447-45af-a90e-c2e234386dc3",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -6554,7 +6575,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3dbd9ee9-f887-41bb-83bf-386324d11485"
+            "RepositoryId": "3dbd9ee9-f887-41bb-83bf-386324d11485",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6597,7 +6619,8 @@
             "Rarity": "common",
             "RepositoryId": "a42123a6-75ea-4687-96cf-b099a49d3529",
             "Quality": "2",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6618,7 +6641,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "c4747fa2-4958-4a02-926e-3b069cf218dc",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -6647,7 +6671,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "304fd49f-0624-4691-8506-149a4b16808e"
+            "RepositoryId": "304fd49f-0624-4691-8506-149a4b16808e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6674,7 +6699,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "d5728a0f-fe8d-4e2d-9350-03cf4243c98e"
+            "RepositoryId": "d5728a0f-fe8d-4e2d-9350-03cf4243c98e",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6703,7 +6729,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "6dda9c11-d472-4ae9-aadc-b916881583a7"
+            "RepositoryId": "6dda9c11-d472-4ae9-aadc-b916881583a7",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6732,7 +6759,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "73875794-5a86-410e-84a4-1b5b2f7e5a54"
+            "RepositoryId": "73875794-5a86-410e-84a4-1b5b2f7e5a54",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6762,7 +6790,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "f93b99a3-aef6-419f-b303-59470577696d",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6791,7 +6820,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "a15af673-8e21-47e3-bdfa-f5dea7b5f9e9"
+            "RepositoryId": "a15af673-8e21-47e3-bdfa-f5dea7b5f9e9",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6820,7 +6850,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "ba102d90-b8c9-47b9-97eb-b462344b46c3"
+            "RepositoryId": "ba102d90-b8c9-47b9-97eb-b462344b46c3",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6847,7 +6878,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "03658b5a-b49e-4e82-82e2-f5d8c5cc602e"
+            "RepositoryId": "03658b5a-b49e-4e82-82e2-f5d8c5cc602e",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -6877,7 +6909,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "341ba426-d52d-4ae3-97a9-40b9b3633d76",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6907,7 +6940,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "e70adb5b-0646-4f88-bd4a-85bea7a2a654",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6937,7 +6971,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "e55c71d6-cbf6-41b8-8838-2d1be1d07e1c",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6967,7 +7002,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "be4e7b4e-d895-47c1-979d-d79bfbe79a02",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6997,7 +7033,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "f91cf558-04a5-4fd8-8814-b1c765668b39",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7027,7 +7064,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7bf3a6e6-b5aa-4c88-b953-c2c378d36118",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7055,7 +7093,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7373fafa-7adb-4c14-ac02-225895f9eb7f",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7083,7 +7122,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "f6657618-d723-419f-a71b-84d0e93402e3",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7112,7 +7152,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "b1cb79d7-9960-4d5c-8b43-81213c8594cd"
+            "RepositoryId": "b1cb79d7-9960-4d5c-8b43-81213c8594cd",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7131,8 +7172,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -7142,7 +7183,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "1264f20b-b901-4d36-bc03-a9115709b531",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7170,7 +7212,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "2f6eec38-45ea-49df-83a2-0b98a858e60a",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7200,7 +7243,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7e1b2364-a190-41f7-a16d-a7d7a9a2f623",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7228,7 +7272,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "54bba84c-6751-430e-b47d-e4b5ddf7a835",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7256,7 +7301,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "545ff36e-b43c-4a35-9ab3-680b23b9e354",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7275,8 +7321,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -7286,7 +7332,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "034ce4ab-b85a-4706-bdef-cba77f9b45f7",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7314,7 +7361,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "c8a09c31-a53e-436f-8421-a4dc4115f633",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7333,8 +7381,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -7344,7 +7392,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "370580fc-7fcf-47f8-b994-cebd279f69f9",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7363,8 +7412,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -7374,7 +7423,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "3d681794-bd95-4340-9a18-59372a2239a0",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7401,7 +7451,8 @@
             ],
             "RepositoryId": "9aabe1cf-2a11-49d5-8baa-e8ed3ef22c3e",
             "RepositoryAssets": ["9aabe1cf-2a11-49d5-8baa-e8ed3ef22c3e"],
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7432,7 +7483,8 @@
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf",
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf",
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7463,7 +7515,8 @@
                 "98bf7fc1-7857-4999-bc99-586c49f24017",
                 "98bf7fc1-7857-4999-bc99-586c49f24017",
                 "98bf7fc1-7857-4999-bc99-586c49f24017"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7484,7 +7537,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3dd70135-55c0-4199-b55b-d80ea1ac070b"
+            "RepositoryId": "3dd70135-55c0-4199-b55b-d80ea1ac070b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7505,7 +7559,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "af9ad679-6a7c-4f8e-9700-ceb5e6887666"
+            "RepositoryId": "af9ad679-6a7c-4f8e-9700-ceb5e6887666",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7526,7 +7581,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "b39d7a0d-e839-417b-880c-cf9b165d4e11"
+            "RepositoryId": "b39d7a0d-e839-417b-880c-cf9b165d4e11",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7547,7 +7603,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3ccbcbac-5822-4d26-bf10-7cd59796b822"
+            "RepositoryId": "3ccbcbac-5822-4d26-bf10-7cd59796b822",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7568,7 +7625,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2eacd4f6-0018-41a5-800d-5fd85f9ecefe"
+            "RepositoryId": "2eacd4f6-0018-41a5-800d-5fd85f9ecefe",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7589,7 +7647,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "494e74b2-f3c0-4c77-be15-8f22a6eed97b"
+            "RepositoryId": "494e74b2-f3c0-4c77-be15-8f22a6eed97b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7613,7 +7672,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_AUDIODISTRACTION"],
             "RepositoryId": "661b9cf9-e278-442a-a87a-ad87ead52d7d",
             "RepositoryAssets": ["661b9cf9-e278-442a-a87a-ad87ead52d7d"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7637,7 +7697,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_MUSICDISTRACTION"],
             "RepositoryId": "2880296a-1014-4147-828a-80d82d4404fe",
             "RepositoryAssets": ["2880296a-1014-4147-828a-80d82d4404fe"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7661,7 +7722,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_EXPLOSIVE"],
             "RepositoryId": "7d0c107e-4279-4fda-a7e2-77359271cb9a",
             "RepositoryAssets": ["7d0c107e-4279-4fda-a7e2-77359271cb9a"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7685,7 +7747,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "4ca96340-ae60-427b-a011-9e296cd67fd9",
             "RepositoryAssets": ["4ca96340-ae60-427b-a011-9e296cd67fd9"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7708,7 +7771,8 @@
             "Rarity": "common",
             "GameAssets": ["PROP_DEVICE_ACTIONFIGURE_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "3fc1a8f8-f8fc-422e-884a-730ca9491737",
-            "RepositoryAssets": ["3fc1a8f8-f8fc-422e-884a-730ca9491737"]
+            "RepositoryAssets": ["3fc1a8f8-f8fc-422e-884a-730ca9491737"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7732,7 +7796,8 @@
             "GameAssets": ["PROP_DEVICE_NAPOLEON_FIGURE_REMOTE_EXPLOSIVE"],
             "RepositoryId": "0a5bebc8-0148-4745-90b2-f54b3c71116c",
             "RepositoryAssets": ["0a5bebc8-0148-4745-90b2-f54b3c71116c"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7754,7 +7819,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "6561a437-86ef-4338-a01f-005b3476be20",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7776,7 +7842,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "d64f77a8-6271-484a-9450-ad75740ce461",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7800,7 +7867,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_REMOTE_EXPLOSIVE"],
             "RepositoryId": "356b016c-fdb3-47d3-913c-3973e6a5a8cf",
             "RepositoryAssets": ["356b016c-fdb3-47d3-913c-3973e6a5a8cf"],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7824,7 +7892,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_C4_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "b20fc045-e453-4280-8b18-b0a0e5c17236",
             "RepositoryAssets": ["b20fc045-e453-4280-8b18-b0a0e5c17236"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7848,7 +7917,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_C4_REMOTE_EXPLOSIVE"],
             "RepositoryId": "ccdd6689-092d-49b2-85f8-416a02e25566",
             "RepositoryAssets": ["ccdd6689-092d-49b2-85f8-416a02e25566"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7872,7 +7942,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_BREACHCHARGE"],
             "RepositoryId": "fc715a9a-3bf1-4768-bd67-0def61b92551",
             "RepositoryAssets": ["fc715a9a-3bf1-4768-bd67-0def61b92551"],
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7896,7 +7967,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_PHONE_EXPLOSIVE"],
             "RepositoryId": "74a22451-8920-488f-883c-b5246ba0f9f3",
             "RepositoryAssets": ["74a22451-8920-488f-883c-b5246ba0f9f3"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7918,7 +7990,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "6410cb8e-c8be-47d6-ad88-8c181c4a3183",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7939,7 +8012,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "ec31f55f-6109-4f97-9286-8f59fae666f6"
+            "RepositoryId": "ec31f55f-6109-4f97-9286-8f59fae666f6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7960,7 +8034,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "93f34bf9-2bd4-4aff-85c7-7e4a9921dfe7"
+            "RepositoryId": "93f34bf9-2bd4-4aff-85c7-7e4a9921dfe7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7987,7 +8062,8 @@
                 "196c112b-9923-4927-97cf-5d3773ae90ea",
                 "196c112b-9923-4927-97cf-5d3773ae90ea",
                 "196c112b-9923-4927-97cf-5d3773ae90ea"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8014,7 +8090,8 @@
                 "5952b621-fee9-4699-809c-8889abadfdb8",
                 "5952b621-fee9-4699-809c-8889abadfdb8",
                 "5952b621-fee9-4699-809c-8889abadfdb8"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -8036,7 +8113,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "a10cf0cb-266d-498b-ac29-49ab10c4e575",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8058,7 +8136,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "88b961c5-7235-48d1-9067-e7d34e75ec63",
-            "UnlockOrder": 11
+            "UnlockOrder": 11,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8080,7 +8159,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "7d668011-77f9-4cae-97f1-e3eda5e0c8b2",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8102,7 +8182,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "261f1057-b1b2-4fe0-bd0d-b621102972c8",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8123,7 +8204,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "c45e59f4-d8e1-4c37-b079-8b74b1fe9b24"
+            "RepositoryId": "c45e59f4-d8e1-4c37-b079-8b74b1fe9b24",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8144,7 +8226,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "1bfbb69d-c876-4d05-ab0b-f0be63b55b7a"
+            "RepositoryId": "1bfbb69d-c876-4d05-ab0b-f0be63b55b7a",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8166,7 +8249,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "1c50d6e0-11c8-4cbc-be05-f51a8e5013be",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8197,7 +8281,8 @@
                 "b970a355-4296-4acc-9ec9-584e69a79eed",
                 "b970a355-4296-4acc-9ec9-584e69a79eed"
             ],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8218,7 +8303,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4d0d6b2a-dd81-474c-a412-3bf19af8233d"
+            "RepositoryId": "4d0d6b2a-dd81-474c-a412-3bf19af8233d",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -8239,7 +8325,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4fad7437-59e9-4ca9-9b31-a6d97484216b"
+            "RepositoryId": "4fad7437-59e9-4ca9-9b31-a6d97484216b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8260,7 +8347,8 @@
             "Quality": 3,
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
-            "RepositoryId": "12200bd8-9605-4111-8b26-4e73cb07d816"
+            "RepositoryId": "12200bd8-9605-4111-8b26-4e73cb07d816",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8281,7 +8369,8 @@
             "Quality": 3,
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
-            "RepositoryId": "23b8ad17-1913-40ce-b3bc-2c92317801dd"
+            "RepositoryId": "23b8ad17-1913-40ce-b3bc-2c92317801dd",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -8302,7 +8391,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "8b7c3ec6-c072-4a21-a323-0f8751028052"
+            "RepositoryId": "8b7c3ec6-c072-4a21-a323-0f8751028052",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8323,7 +8413,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "54b1ffd7-5290-4b58-8e1c-53fd038a08f5"
+            "RepositoryId": "54b1ffd7-5290-4b58-8e1c-53fd038a08f5",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8344,7 +8435,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "f04bd2e9-3f3a-42cd-9150-b7845e952d67"
+            "RepositoryId": "f04bd2e9-3f3a-42cd-9150-b7845e952d67",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8365,7 +8457,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "b6108af4-702f-4954-ae7f-1204460833c7"
+            "RepositoryId": "b6108af4-702f-4954-ae7f-1204460833c7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8386,7 +8479,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "0209f0b7-f6de-45c2-a730-4802abe35a75"
+            "RepositoryId": "0209f0b7-f6de-45c2-a730-4802abe35a75",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8407,7 +8501,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "021ed731-eebc-400a-9658-8f6fc5af9da6"
+            "RepositoryId": "021ed731-eebc-400a-9658-8f6fc5af9da6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8428,7 +8523,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "bbfeb648-7a9b-4fba-a5d4-7fdf84ad0017"
+            "RepositoryId": "bbfeb648-7a9b-4fba-a5d4-7fdf84ad0017",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8449,7 +8545,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "5d816eee-4238-4201-b715-635976c535ae"
+            "RepositoryId": "5d816eee-4238-4201-b715-635976c535ae",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8472,7 +8569,8 @@
             "Rarity": "common",
             "RepositoryId": "1d4f5a7c-c0fb-4d66-9e77-35ae526ef83a",
             "OrderIndex": 710,
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8493,7 +8591,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "5c0edabd-dee9-4504-a98e-ce0d837a1c2a"
+            "RepositoryId": "5c0edabd-dee9-4504-a98e-ce0d837a1c2a",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8514,7 +8613,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "8afed6c5-a730-4f47-b02c-1e4608f2ae81"
+            "RepositoryId": "8afed6c5-a730-4f47-b02c-1e4608f2ae81",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8535,7 +8635,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2bdf5016-e70b-4ac9-a3d5-f35b6743c09a"
+            "RepositoryId": "2bdf5016-e70b-4ac9-a3d5-f35b6743c09a",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8557,7 +8658,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "67b6eb96-89c6-43ce-ba7a-526b092a55f9",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8578,7 +8680,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "59e407df-c49b-4abe-a1be-0806b026e47e"
+            "RepositoryId": "59e407df-c49b-4abe-a1be-0806b026e47e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8599,7 +8702,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "b988422a-02a6-499e-b796-302a782be3d1"
+            "RepositoryId": "b988422a-02a6-499e-b796-302a782be3d1",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8620,7 +8724,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "042fae7b-fe9e-4a83-ac7b-5c914a71b2ca"
+            "RepositoryId": "042fae7b-fe9e-4a83-ac7b-5c914a71b2ca",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8641,7 +8746,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3f9cf03f-b84f-4419-b831-4704cff9775c"
+            "RepositoryId": "3f9cf03f-b84f-4419-b831-4704cff9775c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8662,7 +8768,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "ee4dd67d-e80c-4d97-8ca8-f0d05dc3a698"
+            "RepositoryId": "ee4dd67d-e80c-4d97-8ca8-f0d05dc3a698",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8683,7 +8790,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "6f935509-1e77-4991-baa4-d5515c20ab3e"
+            "RepositoryId": "6f935509-1e77-4991-baa4-d5515c20ab3e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8704,7 +8812,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "04812f8d-fa7c-43f8-9021-5f3587dbb2a9"
+            "RepositoryId": "04812f8d-fa7c-43f8-9021-5f3587dbb2a9",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8725,7 +8834,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "9278382c-9c73-4d0b-8be2-9cb151d3667c"
+            "RepositoryId": "9278382c-9c73-4d0b-8be2-9cb151d3667c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8746,7 +8856,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2b869559-0c63-4731-844c-4d96554edf99"
+            "RepositoryId": "2b869559-0c63-4731-844c-4d96554edf99",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8767,7 +8878,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3dbbbb5e-61a7-4cae-8df0-0e911e744dca"
+            "RepositoryId": "3dbbbb5e-61a7-4cae-8df0-0e911e744dca",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -8788,7 +8900,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "8bde9428-eb24-41e1-85fd-9a5a82dd81d7"
+            "RepositoryId": "8bde9428-eb24-41e1-85fd-9a5a82dd81d7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8809,7 +8922,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "9cd12159-8374-451a-b43a-c27060fe0bc7"
+            "RepositoryId": "9cd12159-8374-451a-b43a-c27060fe0bc7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8830,7 +8944,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4e6bbdeb-74c0-4b7f-a1aa-1c16ab26d6ad"
+            "RepositoryId": "4e6bbdeb-74c0-4b7f-a1aa-1c16ab26d6ad",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8851,7 +8966,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "1bfa04db-6d53-4979-9e3a-eeb45925e4bf"
+            "RepositoryId": "1bfa04db-6d53-4979-9e3a-eeb45925e4bf",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8872,7 +8988,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "ed75b407-0e3d-4009-91c3-0fdbaae677c4"
+            "RepositoryId": "ed75b407-0e3d-4009-91c3-0fdbaae677c4",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8893,7 +9010,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "c02c1311-1c02-4ea9-9b96-3f2d1e4379f2"
+            "RepositoryId": "c02c1311-1c02-4ea9-9b96-3f2d1e4379f2",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8914,7 +9032,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "cdc20ebf-cd83-4707-8732-913c0f970cb5"
+            "RepositoryId": "cdc20ebf-cd83-4707-8732-913c0f970cb5",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8935,7 +9054,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "0de2e787-193a-4c53-8f9b-7056f50a9708"
+            "RepositoryId": "0de2e787-193a-4c53-8f9b-7056f50a9708",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8961,7 +9081,8 @@
                 "6dadf34c-00f2-43f9-b4e8-6763502aa2c8",
                 "6dadf34c-00f2-43f9-b4e8-6763502aa2c8",
                 "6dadf34c-00f2-43f9-b4e8-6763502aa2c8"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8982,7 +9103,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "9d5daae3-10c8-4f03-a85d-9bd92861a672"
+            "RepositoryId": "9d5daae3-10c8-4f03-a85d-9bd92861a672",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9003,7 +9125,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4c30021f-8ae4-4668-bf5d-1561b2e67d0b"
+            "RepositoryId": "4c30021f-8ae4-4668-bf5d-1561b2e67d0b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9024,7 +9147,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "081f8265-63db-4759-96a3-5186caf59f62"
+            "RepositoryId": "081f8265-63db-4759-96a3-5186caf59f62",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9046,7 +9170,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "26605ee6-6e82-4a57-909f-76b91e7d93ed"
+            "RepositoryId": "26605ee6-6e82-4a57-909f-76b91e7d93ed",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9067,7 +9192,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "7d64d9df-5d30-4e98-9af0-7562ee145d5c"
+            "RepositoryId": "7d64d9df-5d30-4e98-9af0-7562ee145d5c",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9088,7 +9214,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f5d0b800-bf37-41ff-bd19-4c04e3b69754"
+            "RepositoryId": "f5d0b800-bf37-41ff-bd19-4c04e3b69754",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9109,7 +9236,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f5ebb935-9bec-422b-b772-37adc3ba23db"
+            "RepositoryId": "f5ebb935-9bec-422b-b772-37adc3ba23db",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9130,7 +9258,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "e3b6e1d1-fea5-4035-87b3-6b996b3488c2"
+            "RepositoryId": "e3b6e1d1-fea5-4035-87b3-6b996b3488c2",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9151,7 +9280,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "eca66732-a356-4c13-8e33-d0f7e87b5860"
+            "RepositoryId": "eca66732-a356-4c13-8e33-d0f7e87b5860",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9172,7 +9302,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "b58f4e9f-60b1-4bcb-bd87-b11dbcb8e6b2"
+            "RepositoryId": "b58f4e9f-60b1-4bcb-bd87-b11dbcb8e6b2",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9193,7 +9324,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "092f6514-c34e-4d04-8d28-7ebbe14230d1"
+            "RepositoryId": "092f6514-c34e-4d04-8d28-7ebbe14230d1",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9214,7 +9346,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "26b5496d-9a8c-4059-9d69-d8712078a33c"
+            "RepositoryId": "26b5496d-9a8c-4059-9d69-d8712078a33c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9235,7 +9368,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "351c144c-8687-426a-a6f0-c4abd7021062"
+            "RepositoryId": "351c144c-8687-426a-a6f0-c4abd7021062",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9256,7 +9390,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "4bbe3b64-8bce-416e-a3e9-00bcd1571980"
+            "RepositoryId": "4bbe3b64-8bce-416e-a3e9-00bcd1571980",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9277,7 +9412,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f6f525d2-a28c-4548-825b-f7ce93f6577c"
+            "RepositoryId": "f6f525d2-a28c-4548-825b-f7ce93f6577c",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9298,7 +9434,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "4e66bf97-e6da-4cb6-b873-10a9af274bf4"
+            "RepositoryId": "4e66bf97-e6da-4cb6-b873-10a9af274bf4",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9319,7 +9456,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "bc2df333-bce1-4758-9bc5-4bce40d2c218"
+            "RepositoryId": "bc2df333-bce1-4758-9bc5-4bce40d2c218",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9340,7 +9478,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "e638b949-9b96-4c41-bec4-0a8fbfb05c75"
+            "RepositoryId": "e638b949-9b96-4c41-bec4-0a8fbfb05c75",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9361,7 +9500,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "224822b8-7c8b-4c42-9194-8b307eadb31b"
+            "RepositoryId": "224822b8-7c8b-4c42-9194-8b307eadb31b",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9382,7 +9522,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "b0314606-caa4-4a2c-a3e2-bd011f98cfdf"
+            "RepositoryId": "b0314606-caa4-4a2c-a3e2-bd011f98cfdf",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9403,7 +9544,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "77ecaad6-652f-480d-b365-cdf90820a5ec"
+            "RepositoryId": "77ecaad6-652f-480d-b365-cdf90820a5ec",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9425,7 +9567,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "ecf7f361-c2aa-4d96-b66d-e973c3e87154",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9447,7 +9590,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "c5ec6168-2e5e-4340-b71a-c60f2ee6bd66",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9469,7 +9613,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "ef63eda6-6411-4ce0-b35b-143fc5767fc0",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9488,8 +9633,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -9498,7 +9643,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "eedb7f84-896d-403b-905b-11b105e7ce35"
+            "RepositoryId": "eedb7f84-896d-403b-905b-11b105e7ce35",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9526,7 +9672,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "907e0277-7806-42a4-b4b2-338cf8dd9391",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9554,7 +9701,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "214004ec-5c86-4c26-8403-9e83a9bcdd24",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9575,7 +9723,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "15291f69-88d0-4a8f-b31b-71605ba5ff38"
+            "RepositoryId": "15291f69-88d0-4a8f-b31b-71605ba5ff38",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9596,7 +9745,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "b549ea89-e9cc-44f4-87ae-7145a7060028",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9617,7 +9767,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "acc9d7b8-80f1-4bb0-ba81-3a69b09e0543",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -9638,7 +9789,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "b2321154-4520-4911-9d94-9256b85e0983",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9659,7 +9811,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "6c6adf56-1027-471c-adb4-64dbb8b81232",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9680,7 +9833,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "9488fa1e-10e1-49c9-bb24-6635d2e5bd49",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -9701,7 +9855,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "76d1f44c-8a78-462a-a39c-23d4101f4d6f",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9722,7 +9877,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "d70c739a-6956-4771-ba9c-7f3c9206f762",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -9745,7 +9901,8 @@
             "RepositoryId": "a6706101-3aaf-4797-a0f8-a5b6aac9cdfe",
             "Quality": 4,
             "AllowUpSync": true,
-            "OrderIndex": 680
+            "OrderIndex": 680,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9767,7 +9924,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f301f605-007c-4fe1-aa99-a8cd2cae033f"
+            "RepositoryId": "f301f605-007c-4fe1-aa99-a8cd2cae033f",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11048,7 +11206,8 @@
             "RepositoryAssets": [
                 "00bc7fdc-8cce-4cb5-b31a-4d2d8b4156f8",
                 "efced006-633d-40bb-90a2-ff142c6fa34b"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11075,7 +11234,8 @@
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8",
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8",
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11102,7 +11262,8 @@
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc",
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc",
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11129,7 +11290,8 @@
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d",
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d",
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11150,7 +11312,8 @@
             "Quality": 1,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4ab356b3-234d-4546-9490-65458a8a82ab"
+            "RepositoryId": "4ab356b3-234d-4546-9490-65458a8a82ab",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -13123,7 +13286,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "15e6200e-2000-4966-9771-923ab13c6a1c"
+            "RepositoryId": "15e6200e-2000-4966-9771-923ab13c6a1c",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -13145,7 +13309,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "d21f52a2-988b-4e97-8f47-9d1c6b341adc"
+            "RepositoryId": "d21f52a2-988b-4e97-8f47-9d1c6b341adc",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -13167,7 +13332,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "8493fe56-8303-4285-94c1-06f96c604dba"
+            "RepositoryId": "8493fe56-8303-4285-94c1-06f96c604dba",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -13191,7 +13357,8 @@
             "AllowUpSync": true,
             "Rarity": "common",
             "RepositoryId": "1082607a-6bb0-49c9-ab77-e631f7a603f3",
-            "OrderIndex": 690
+            "OrderIndex": 690,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -13213,7 +13380,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "c1238ece-fcbf-4ab9-bcfb-9371d5e3b576"
+            "RepositoryId": "c1238ece-fcbf-4ab9-bcfb-9371d5e3b576",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -13235,7 +13403,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "8e2ccfc2-67d9-4ac1-87db-76e7535cd18d"
+            "RepositoryId": "8e2ccfc2-67d9-4ac1-87db-76e7535cd18d",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -13258,7 +13427,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "8cb03c05-feba-444a-9ef6-fcb918620e43",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },

--- a/static/Legacyallunlockables.json
+++ b/static/Legacyallunlockables.json
@@ -4703,7 +4703,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "1a11a060-358c-4054-98ec-d3491af1d7c6"
+            "RepositoryId": "1a11a060-358c-4054-98ec-d3491af1d7c6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -4725,7 +4726,8 @@
             "Rarity": "common",
             "RepositoryId": "2c037ef5-a01b-4532-8216-1d535193a837",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -4753,7 +4755,8 @@
                 "e55eb9a4-e79c-43c7-970b-79e94e7683b7"
             ],
             "Quality": "2",
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -4777,7 +4780,8 @@
             "Rarity": "rare",
             "RepositoryId": "e30a5b15-ce4d-41d5-a2a5-08dec9c4fe79",
             "Quality": "2",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -4799,7 +4803,8 @@
             "Rarity": "common",
             "RepositoryId": "c7296c5f-6c0e-4d52-98cd-e70a0d329e73",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -4821,7 +4826,8 @@
             "Rarity": "common",
             "RepositoryId": "54f800df-0c14-4a6f-873f-16497b4edf00",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -4843,7 +4849,8 @@
             "Rarity": "common",
             "RepositoryId": "1033c25d-3d57-4c15-b7d0-acf3b45665ef",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -4864,7 +4871,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "legendary",
             "RepositoryId": "d439fb64-8713-4c54-a3f3-90730dbdf370",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -4888,7 +4896,8 @@
             "Rarity": "rare",
             "RepositoryId": "4dee7cd6-f447-45af-a90e-c2e234386dc3",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -4909,7 +4918,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "rare",
-            "RepositoryId": "3dbd9ee9-f887-41bb-83bf-386324d11485"
+            "RepositoryId": "3dbd9ee9-f887-41bb-83bf-386324d11485",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -4930,7 +4940,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "rare",
             "RepositoryId": "7257eaa1-c8f3-4e0c-acbf-74f73869c1b2",
-            "Quality": "2"
+            "Quality": "2",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -4952,7 +4963,8 @@
             "Rarity": "common",
             "RepositoryId": "a42123a6-75ea-4687-96cf-b099a49d3529",
             "Quality": "2",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -4973,7 +4985,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "c4747fa2-4958-4a02-926e-3b069cf218dc",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -5002,7 +5015,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "304fd49f-0624-4691-8506-149a4b16808e"
+            "RepositoryId": "304fd49f-0624-4691-8506-149a4b16808e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5031,7 +5045,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "d5728a0f-fe8d-4e2d-9350-03cf4243c98e"
+            "RepositoryId": "d5728a0f-fe8d-4e2d-9350-03cf4243c98e",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -5060,7 +5075,8 @@
             "Quality": 4,
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "6dda9c11-d472-4ae9-aadc-b916881583a7"
+            "RepositoryId": "6dda9c11-d472-4ae9-aadc-b916881583a7",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5089,7 +5105,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "73875794-5a86-410e-84a4-1b5b2f7e5a54"
+            "RepositoryId": "73875794-5a86-410e-84a4-1b5b2f7e5a54",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5118,7 +5135,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "a15af673-8e21-47e3-bdfa-f5dea7b5f9e9"
+            "RepositoryId": "a15af673-8e21-47e3-bdfa-f5dea7b5f9e9",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -5147,7 +5165,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "ba102d90-b8c9-47b9-97eb-b462344b46c3"
+            "RepositoryId": "ba102d90-b8c9-47b9-97eb-b462344b46c3",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -5174,7 +5193,8 @@
             "Quality": 4,
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "03658b5a-b49e-4e82-82e2-f5d8c5cc602e"
+            "RepositoryId": "03658b5a-b49e-4e82-82e2-f5d8c5cc602e",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5204,7 +5224,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "341ba426-d52d-4ae3-97a9-40b9b3633d76",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5234,7 +5255,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "e70adb5b-0646-4f88-bd4a-85bea7a2a654",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5264,7 +5286,8 @@
             "Rarity": "legendary",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "e55c71d6-cbf6-41b8-8838-2d1be1d07e1c",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "legendary"
     },
@@ -5294,7 +5317,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "be4e7b4e-d895-47c1-979d-d79bfbe79a02",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5324,7 +5348,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "f91cf558-04a5-4fd8-8814-b1c765668b39",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5354,7 +5379,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7bf3a6e6-b5aa-4c88-b953-c2c378d36118",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5382,7 +5408,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7373fafa-7adb-4c14-ac02-225895f9eb7f",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5412,7 +5439,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "f6657618-d723-419f-a71b-84d0e93402e3",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5441,7 +5469,8 @@
             "Quality": 4,
             "Rarity": "legendary",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "b1cb79d7-9960-4d5c-8b43-81213c8594cd"
+            "RepositoryId": "b1cb79d7-9960-4d5c-8b43-81213c8594cd",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -5460,8 +5489,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -5471,7 +5500,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "1264f20b-b901-4d36-bc03-a9115709b531",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5499,7 +5529,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "2f6eec38-45ea-49df-83a2-0b98a858e60a",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5529,7 +5560,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7e1b2364-a190-41f7-a16d-a7d7a9a2f623",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5557,7 +5589,8 @@
             "Rarity": "legendary",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "54bba84c-6751-430e-b47d-e4b5ddf7a835",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -5587,7 +5620,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "545ff36e-b43c-4a35-9ab3-680b23b9e354",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5606,8 +5640,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -5617,7 +5651,8 @@
             "Rarity": "legendary",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "034ce4ab-b85a-4706-bdef-cba77f9b45f7",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -5645,7 +5680,8 @@
             "Rarity": "legendary",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "c8a09c31-a53e-436f-8421-a4dc4115f633",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "legendary"
     },
@@ -5664,8 +5700,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -5675,7 +5711,8 @@
             "Rarity": "rare",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "370580fc-7fcf-47f8-b994-cebd279f69f9",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "rare"
     },
@@ -5702,7 +5739,8 @@
             ],
             "RepositoryId": "9aabe1cf-2a11-49d5-8baa-e8ed3ef22c3e",
             "RepositoryAssets": ["9aabe1cf-2a11-49d5-8baa-e8ed3ef22c3e"],
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5733,7 +5771,8 @@
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf",
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf",
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5754,7 +5793,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3dd70135-55c0-4199-b55b-d80ea1ac070b"
+            "RepositoryId": "3dd70135-55c0-4199-b55b-d80ea1ac070b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5775,7 +5815,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "af9ad679-6a7c-4f8e-9700-ceb5e6887666"
+            "RepositoryId": "af9ad679-6a7c-4f8e-9700-ceb5e6887666",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5796,7 +5837,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "b39d7a0d-e839-417b-880c-cf9b165d4e11"
+            "RepositoryId": "b39d7a0d-e839-417b-880c-cf9b165d4e11",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5820,7 +5862,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_AUDIODISTRACTION"],
             "RepositoryId": "661b9cf9-e278-442a-a87a-ad87ead52d7d",
             "RepositoryAssets": ["661b9cf9-e278-442a-a87a-ad87ead52d7d"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5844,7 +5887,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_MUSICDISTRACTION"],
             "RepositoryId": "2880296a-1014-4147-828a-80d82d4404fe",
             "RepositoryAssets": ["2880296a-1014-4147-828a-80d82d4404fe"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5868,7 +5912,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_EXPLOSIVE"],
             "RepositoryId": "7d0c107e-4279-4fda-a7e2-77359271cb9a",
             "RepositoryAssets": ["7d0c107e-4279-4fda-a7e2-77359271cb9a"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -5892,7 +5937,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "4ca96340-ae60-427b-a011-9e296cd67fd9",
             "RepositoryAssets": ["4ca96340-ae60-427b-a011-9e296cd67fd9"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5915,7 +5961,8 @@
             "Rarity": "rare",
             "GameAssets": ["PROP_DEVICE_ACTIONFIGURE_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "3fc1a8f8-f8fc-422e-884a-730ca9491737",
-            "RepositoryAssets": ["3fc1a8f8-f8fc-422e-884a-730ca9491737"]
+            "RepositoryAssets": ["3fc1a8f8-f8fc-422e-884a-730ca9491737"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5939,7 +5986,8 @@
             "GameAssets": ["PROP_DEVICE_NAPOLEON_FIGURE_REMOTE_EXPLOSIVE"],
             "RepositoryId": "0a5bebc8-0148-4745-90b2-f54b3c71116c",
             "RepositoryAssets": ["0a5bebc8-0148-4745-90b2-f54b3c71116c"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5963,7 +6011,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_REMOTE_EXPLOSIVE"],
             "RepositoryId": "356b016c-fdb3-47d3-913c-3973e6a5a8cf",
             "RepositoryAssets": ["356b016c-fdb3-47d3-913c-3973e6a5a8cf"],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -5987,7 +6036,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_C4_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "b20fc045-e453-4280-8b18-b0a0e5c17236",
             "RepositoryAssets": ["b20fc045-e453-4280-8b18-b0a0e5c17236"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6011,7 +6061,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_C4_REMOTE_EXPLOSIVE"],
             "RepositoryId": "ccdd6689-092d-49b2-85f8-416a02e25566",
             "RepositoryAssets": ["ccdd6689-092d-49b2-85f8-416a02e25566"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6041,7 +6092,8 @@
                 "fc715a9a-3bf1-4768-bd67-0def61b92551",
                 "fc715a9a-3bf1-4768-bd67-0def61b92551"
             ],
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6065,7 +6117,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_PHONE_EXPLOSIVE"],
             "RepositoryId": "74a22451-8920-488f-883c-b5246ba0f9f3",
             "RepositoryAssets": ["74a22451-8920-488f-883c-b5246ba0f9f3"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6087,7 +6140,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "rare",
             "RepositoryId": "6410cb8e-c8be-47d6-ad88-8c181c4a3183",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6108,7 +6162,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "rare",
-            "RepositoryId": "ec31f55f-6109-4f97-9286-8f59fae666f6"
+            "RepositoryId": "ec31f55f-6109-4f97-9286-8f59fae666f6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6135,7 +6190,8 @@
                 "196c112b-9923-4927-97cf-5d3773ae90ea",
                 "196c112b-9923-4927-97cf-5d3773ae90ea",
                 "196c112b-9923-4927-97cf-5d3773ae90ea"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6157,7 +6213,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "a10cf0cb-266d-498b-ac29-49ab10c4e575",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6179,7 +6236,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "88b961c5-7235-48d1-9067-e7d34e75ec63",
-            "UnlockOrder": 11
+            "UnlockOrder": 11,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6201,7 +6259,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "7d668011-77f9-4cae-97f1-e3eda5e0c8b2",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6223,7 +6282,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "rare",
             "RepositoryId": "261f1057-b1b2-4fe0-bd0d-b621102972c8",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6244,7 +6304,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "rare",
-            "RepositoryId": "1bfbb69d-c876-4d05-ab0b-f0be63b55b7a"
+            "RepositoryId": "1bfbb69d-c876-4d05-ab0b-f0be63b55b7a",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6266,7 +6327,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "1c50d6e0-11c8-4cbc-be05-f51a8e5013be",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6297,7 +6359,8 @@
                 "b970a355-4296-4acc-9ec9-584e69a79eed",
                 "b970a355-4296-4acc-9ec9-584e69a79eed"
             ],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -6316,8 +6379,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -6326,7 +6389,8 @@
             "Quality": 4,
             "Rarity": "legendary",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "eedb7f84-896d-403b-905b-11b105e7ce35"
+            "RepositoryId": "eedb7f84-896d-403b-905b-11b105e7ce35",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -6356,7 +6420,8 @@
             "Rarity": "legendary",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "907e0277-7806-42a4-b4b2-338cf8dd9391",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -6384,7 +6449,8 @@
             "Rarity": "legendary",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "214004ec-5c86-4c26-8403-9e83a9bcdd24",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "legendary"
     },
@@ -6405,7 +6471,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "15291f69-88d0-4a8f-b31b-71605ba5ff38"
+            "RepositoryId": "15291f69-88d0-4a8f-b31b-71605ba5ff38",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "legendary"
     },
@@ -6426,7 +6493,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "b549ea89-e9cc-44f4-87ae-7145a7060028",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -6448,7 +6516,8 @@
             "Quality": 4,
             "Rarity": "legendary",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f301f605-007c-4fe1-aa99-a8cd2cae033f"
+            "RepositoryId": "f301f605-007c-4fe1-aa99-a8cd2cae033f",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "legendary"
     },
@@ -8568,7 +8637,8 @@
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8",
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8",
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8595,7 +8665,8 @@
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc",
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc",
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "rare"
     },
@@ -8622,7 +8693,8 @@
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d",
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d",
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "legendary"
     },

--- a/static/Scpcallunlockables.json
+++ b/static/Scpcallunlockables.json
@@ -66,8 +66,8 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
@@ -79,7 +79,8 @@
                 "marksman",
                 "versatilescope_3"
             ],
-            "UnlockOrder": 1
+            "UnlockOrder": 1,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -678,14 +679,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 2
+            "UnlockOrder": 2,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -719,14 +721,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 3
+            "UnlockOrder": 3,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -762,14 +765,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 4
+            "UnlockOrder": 4,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -806,14 +810,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -852,14 +857,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 6
+            "UnlockOrder": 6,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -899,14 +905,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -947,14 +954,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 8
+            "UnlockOrder": 8,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -996,14 +1004,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 9
+            "UnlockOrder": 9,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1045,14 +1054,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1095,14 +1105,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 11
+            "UnlockOrder": 11,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1146,14 +1157,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 12
+            "UnlockOrder": 12,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1199,14 +1211,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 13
+            "UnlockOrder": 13,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1253,14 +1266,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 14
+            "UnlockOrder": 14,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1308,14 +1322,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1363,14 +1378,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 16
+            "UnlockOrder": 16,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1419,14 +1435,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 17
+            "UnlockOrder": 17,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1476,14 +1493,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 18
+            "UnlockOrder": 18,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1534,14 +1552,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 19
+            "UnlockOrder": 19,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1592,14 +1611,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1629,14 +1649,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": ["highpressure", "tacticalshock", "versatilescope_2"],
-            "UnlockOrder": 1
+            "UnlockOrder": 1,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1668,14 +1689,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 2
+            "UnlockOrder": 2,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1709,14 +1731,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 3
+            "UnlockOrder": 3,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1752,14 +1775,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 4
+            "UnlockOrder": 4,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1797,14 +1821,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1844,14 +1869,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 6
+            "UnlockOrder": 6,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1892,14 +1918,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1941,14 +1968,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 8
+            "UnlockOrder": 8,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -1991,14 +2019,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 9
+            "UnlockOrder": 9,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2041,14 +2070,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2092,14 +2122,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 11
+            "UnlockOrder": 11,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2144,14 +2175,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 12
+            "UnlockOrder": 12,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2196,14 +2228,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 13
+            "UnlockOrder": 13,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2249,14 +2282,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 14
+            "UnlockOrder": 14,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2303,14 +2337,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2358,14 +2393,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 16
+            "UnlockOrder": 16,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2413,14 +2449,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 17
+            "UnlockOrder": 17,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2469,14 +2506,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 18
+            "UnlockOrder": 18,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2526,14 +2564,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 19
+            "UnlockOrder": 19,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2584,14 +2623,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2618,14 +2658,15 @@
             "Modifiers": ["a8f4e9c8-5dcf-4543-8f7e-3ccbb4d525a7"],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": ["titaniumcomposite", "highpressure", "versatilescope_3"],
-            "UnlockOrder": 1
+            "UnlockOrder": 1,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2656,14 +2697,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 2
+            "UnlockOrder": 2,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2696,14 +2738,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 3
+            "UnlockOrder": 3,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2738,14 +2781,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 4
+            "UnlockOrder": 4,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2782,14 +2826,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2828,14 +2873,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 6
+            "UnlockOrder": 6,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2875,14 +2921,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2923,14 +2970,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 8
+            "UnlockOrder": 8,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -2972,14 +3020,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 9
+            "UnlockOrder": 9,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3021,14 +3070,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3071,14 +3121,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 11
+            "UnlockOrder": 11,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3122,14 +3173,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 12
+            "UnlockOrder": 12,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3174,14 +3226,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 13
+            "UnlockOrder": 13,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3227,14 +3280,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 14
+            "UnlockOrder": 14,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3281,14 +3335,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3336,14 +3391,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 16
+            "UnlockOrder": 16,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3392,14 +3448,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 17
+            "UnlockOrder": 17,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3448,14 +3505,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 18
+            "UnlockOrder": 18,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3505,14 +3563,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 19
+            "UnlockOrder": 19,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},
@@ -3563,14 +3622,15 @@
             ],
             "Gameplay": {
                 "clipsize": 0.2,
-                "damage": 1.0,
-                "range": 1.0,
+                "damage": 1,
+                "range": 1,
                 "rateoffire": 0.3
             },
             "Quality": 4,
             "Rarity": "common",
             "Perks": [],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Capabilities": [],
         "Qualities": {},

--- a/static/allunlockables.json
+++ b/static/allunlockables.json
@@ -6871,7 +6871,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "1a11a060-358c-4054-98ec-d3491af1d7c6"
+            "RepositoryId": "1a11a060-358c-4054-98ec-d3491af1d7c6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6892,7 +6893,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "edd82229-9984-45db-802f-8584ecf38ef3"
+            "RepositoryId": "edd82229-9984-45db-802f-8584ecf38ef3",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6913,7 +6915,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "7685be69-ff8f-479c-91b9-7347253f8bf1"
+            "RepositoryId": "7685be69-ff8f-479c-91b9-7347253f8bf1",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6936,7 +6939,8 @@
             "Rarity": "common",
             "RepositoryId": "ad2ed125-2371-4bd1-b9e9-fbfa2f0b7947",
             "OrderIndex": 720,
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6959,7 +6963,8 @@
             "Rarity": "common",
             "RepositoryId": "14aea5f5-82b8-447e-b7f6-042f24d11a15",
             "OrderIndex": 720,
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -6982,7 +6987,8 @@
             "Rarity": "common",
             "RepositoryId": "75a0d0de-fe3c-47d3-b64f-7fc446ee59c4",
             "AllowUpSync": true,
-            "OrderIndex": 670
+            "OrderIndex": 670,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7003,7 +7009,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2147b6cd-5a42-4cd6-b366-2c5c50d97db7"
+            "RepositoryId": "2147b6cd-5a42-4cd6-b366-2c5c50d97db7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7024,7 +7031,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "a804e004-7d45-42c8-87bd-b7cbcffa56cc"
+            "RepositoryId": "a804e004-7d45-42c8-87bd-b7cbcffa56cc",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7046,7 +7054,8 @@
             "Rarity": "common",
             "RepositoryId": "2c037ef5-a01b-4532-8216-1d535193a837",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7068,7 +7077,8 @@
             "Rarity": "common",
             "RepositoryId": "5c211971-235a-4856-9eea-fe890940f63a",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7090,7 +7100,8 @@
             "Rarity": "common",
             "RepositoryId": "9e728dc1-3344-4615-be7a-1bcbdd7ad4aa",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7112,7 +7123,8 @@
             "Rarity": "common",
             "RepositoryId": "736132de-78f3-4366-b927-ed9a401dbe26",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7136,7 +7148,8 @@
             "Quality": "2",
             "UnlockOrder": 5,
             "AllowUpSync": true,
-            "OrderIndex": 660
+            "OrderIndex": 660,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7212,7 +7225,8 @@
                 "e55eb9a4-e79c-43c7-970b-79e94e7683b7"
             ],
             "Quality": "2",
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7243,7 +7257,8 @@
                 "92330cd4-1bb1-419e-98d3-ef26631504bf"
             ],
             "Quality": "2",
-            "UnlockOrder": 7
+            "UnlockOrder": 7,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7267,7 +7282,8 @@
             "Rarity": "common",
             "RepositoryId": "e30a5b15-ce4d-41d5-a2a5-08dec9c4fe79",
             "Quality": "2",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7399,7 +7415,8 @@
             "Rarity": "common",
             "RepositoryId": "1033c25d-3d57-4c15-b7d0-acf3b45665ef",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -7421,7 +7438,8 @@
             "Rarity": "common",
             "RepositoryId": "6b87c27d-0d73-4c63-b852-5a9c7a9ffb90",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -7487,7 +7505,8 @@
             "Rarity": "common",
             "RepositoryId": "4dee7cd6-f447-45af-a90e-c2e234386dc3",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -7508,7 +7527,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3dbd9ee9-f887-41bb-83bf-386324d11485"
+            "RepositoryId": "3dbd9ee9-f887-41bb-83bf-386324d11485",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7551,7 +7571,8 @@
             "Rarity": "common",
             "RepositoryId": "a42123a6-75ea-4687-96cf-b099a49d3529",
             "Quality": "2",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7573,7 +7594,8 @@
             "Rarity": "common",
             "RepositoryId": "683e2888-9e57-4ab8-a56e-38836585298d",
             "Quality": "2",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7594,7 +7616,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "c4747fa2-4958-4a02-926e-3b069cf218dc",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -8164,8 +8187,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -8336,8 +8359,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -8499,8 +8522,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -8529,8 +8552,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -8567,7 +8590,8 @@
             ],
             "RepositoryId": "9aabe1cf-2a11-49d5-8baa-e8ed3ef22c3e",
             "RepositoryAssets": ["9aabe1cf-2a11-49d5-8baa-e8ed3ef22c3e"],
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8598,7 +8622,8 @@
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf",
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf",
                 "dda002e9-02b1-4208-82a5-cf059f3c79cf"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8629,7 +8654,8 @@
                 "98bf7fc1-7857-4999-bc99-586c49f24017",
                 "98bf7fc1-7857-4999-bc99-586c49f24017",
                 "98bf7fc1-7857-4999-bc99-586c49f24017"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8650,7 +8676,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3dd70135-55c0-4199-b55b-d80ea1ac070b"
+            "RepositoryId": "3dd70135-55c0-4199-b55b-d80ea1ac070b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8671,7 +8698,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "aaffeb68-c597-4ca8-9b8d-802ce08e1187"
+            "RepositoryId": "aaffeb68-c597-4ca8-9b8d-802ce08e1187",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8692,7 +8720,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "637a7b20-39b1-48c6-9908-8fb628488262"
+            "RepositoryId": "637a7b20-39b1-48c6-9908-8fb628488262",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8713,7 +8742,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "af9ad679-6a7c-4f8e-9700-ceb5e6887666"
+            "RepositoryId": "af9ad679-6a7c-4f8e-9700-ceb5e6887666",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8734,7 +8764,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "999e005f-d49f-4606-a929-6387bf511c72"
+            "RepositoryId": "999e005f-d49f-4606-a929-6387bf511c72",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8755,7 +8786,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "ddaf38de-2ad3-467d-bdd0-2f6b13cd3f51"
+            "RepositoryId": "ddaf38de-2ad3-467d-bdd0-2f6b13cd3f51",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8776,7 +8808,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "5fed2bb2-4fe9-4613-9f21-fedc19ba5eb7"
+            "RepositoryId": "5fed2bb2-4fe9-4613-9f21-fedc19ba5eb7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8797,7 +8830,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "b39d7a0d-e839-417b-880c-cf9b165d4e11"
+            "RepositoryId": "b39d7a0d-e839-417b-880c-cf9b165d4e11",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8818,7 +8852,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3ccbcbac-5822-4d26-bf10-7cd59796b822"
+            "RepositoryId": "3ccbcbac-5822-4d26-bf10-7cd59796b822",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8839,7 +8874,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "d3387f28-866d-4262-88cb-6e5b1076bac0"
+            "RepositoryId": "d3387f28-866d-4262-88cb-6e5b1076bac0",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8860,7 +8896,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2eacd4f6-0018-41a5-800d-5fd85f9ecefe"
+            "RepositoryId": "2eacd4f6-0018-41a5-800d-5fd85f9ecefe",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8881,7 +8918,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "99ad5567-2734-44c7-a7db-5d0aaf01932e"
+            "RepositoryId": "99ad5567-2734-44c7-a7db-5d0aaf01932e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8902,7 +8940,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "494e74b2-f3c0-4c77-be15-8f22a6eed97b"
+            "RepositoryId": "494e74b2-f3c0-4c77-be15-8f22a6eed97b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8923,7 +8962,8 @@
             "Quality": 5,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "92d9acf6-fd79-4818-bda6-c4c28b123d8c"
+            "RepositoryId": "92d9acf6-fd79-4818-bda6-c4c28b123d8c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8947,7 +8987,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_AUDIODISTRACTION"],
             "RepositoryId": "661b9cf9-e278-442a-a87a-ad87ead52d7d",
             "RepositoryAssets": ["661b9cf9-e278-442a-a87a-ad87ead52d7d"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8971,7 +9012,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_MUSICDISTRACTION"],
             "RepositoryId": "2880296a-1014-4147-828a-80d82d4404fe",
             "RepositoryAssets": ["2880296a-1014-4147-828a-80d82d4404fe"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8995,7 +9037,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_EXPLOSIVE"],
             "RepositoryId": "7d0c107e-4279-4fda-a7e2-77359271cb9a",
             "RepositoryAssets": ["7d0c107e-4279-4fda-a7e2-77359271cb9a"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9019,7 +9062,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_EXPLOSIVE_S3"],
             "RepositoryId": "b26bb84e-8f15-4b4f-8554-52faa456cf2e",
             "RepositoryAssets": ["b26bb84e-8f15-4b4f-8554-52faa456cf2e"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9043,7 +9087,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "4ca96340-ae60-427b-a011-9e296cd67fd9",
             "RepositoryAssets": ["4ca96340-ae60-427b-a011-9e296cd67fd9"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9069,7 +9114,8 @@
             ],
             "RepositoryId": "0bc37bb7-dcd8-4348-a338-22fd8676a416",
             "RepositoryAssets": ["0bc37bb7-dcd8-4348-a338-22fd8676a416"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9093,7 +9139,8 @@
             "GameAssets": ["PROP_DEVICE_DEVIL_RUBBERDUCK_REMOTE_EXPLOSIVE"],
             "RepositoryId": "7e52d861-481c-4f7c-87d2-6211d90586bf",
             "RepositoryAssets": ["7e52d861-481c-4f7c-87d2-6211d90586bf"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9116,7 +9163,8 @@
             "Rarity": "common",
             "GameAssets": ["PROP_DEVICE_ACTIONFIGURE_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "3fc1a8f8-f8fc-422e-884a-730ca9491737",
-            "RepositoryAssets": ["3fc1a8f8-f8fc-422e-884a-730ca9491737"]
+            "RepositoryAssets": ["3fc1a8f8-f8fc-422e-884a-730ca9491737"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9139,7 +9187,8 @@
             "Rarity": "common",
             "GameAssets": ["PROP_DEVICE_ICA_PROXIMITY_EXPLOSIVE_S3"],
             "RepositoryId": "fb1c7db4-2a41-4f3f-a17d-e93b205de481",
-            "RepositoryAssets": ["fb1c7db4-2a41-4f3f-a17d-e93b205de481"]
+            "RepositoryAssets": ["fb1c7db4-2a41-4f3f-a17d-e93b205de481"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9162,7 +9211,8 @@
             "Rarity": "common",
             "GameAssets": ["PROP_DEVICE_ICA_SEMTEX_PROXIMITY_EXPLOSIVE_S3"],
             "RepositoryId": "ba5c5c48-3d2e-4d4d-9dbe-f57b95200b1a",
-            "RepositoryAssets": ["ba5c5c48-3d2e-4d4d-9dbe-f57b95200b1a"]
+            "RepositoryAssets": ["ba5c5c48-3d2e-4d4d-9dbe-f57b95200b1a"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9185,7 +9235,8 @@
             "Rarity": "common",
             "GameAssets": ["PROP_DEVICE_ICA_SEMTEX_REMOTE_EXPLOSIVE_S3"],
             "RepositoryId": "7488229b-3fa8-4539-90ba-a7bf65798568",
-            "RepositoryAssets": ["7488229b-3fa8-4539-90ba-a7bf65798568"]
+            "RepositoryAssets": ["7488229b-3fa8-4539-90ba-a7bf65798568"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9209,7 +9260,8 @@
             "GameAssets": ["PROP_DEVICE_NAPOLEON_FIGURE_REMOTE_EXPLOSIVE"],
             "RepositoryId": "0a5bebc8-0148-4745-90b2-f54b3c71116c",
             "RepositoryAssets": ["0a5bebc8-0148-4745-90b2-f54b3c71116c"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9231,7 +9283,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "6561a437-86ef-4338-a01f-005b3476be20",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9253,7 +9306,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "c601c095-e1dc-4490-aeae-e8e200dd9ac8",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -9275,7 +9329,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "d64f77a8-6271-484a-9450-ad75740ce461",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9298,7 +9353,8 @@
             "Rarity": "common",
             "RepositoryId": "89957566-316c-4014-88c2-6a8bdfc31108",
             "UnlockOrder": 10,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9322,7 +9378,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_REMOTE_EXPLOSIVE"],
             "RepositoryId": "356b016c-fdb3-47d3-913c-3973e6a5a8cf",
             "RepositoryAssets": ["356b016c-fdb3-47d3-913c-3973e6a5a8cf"],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9346,7 +9403,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_PROXIMITY_EXPLOSIVE_S3"],
             "RepositoryId": "2699ad7a-185a-464f-b5c6-7d58d0fd5867",
             "RepositoryAssets": ["2699ad7a-185a-464f-b5c6-7d58d0fd5867"],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9370,7 +9428,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_RUBBERDUCK_REMOTE_EXPLOSIVE_STA"],
             "RepositoryId": "71d7c7eb-812b-40d5-9bb7-029759f0bf01",
             "RepositoryAssets": ["71d7c7eb-812b-40d5-9bb7-029759f0bf01"],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9394,7 +9453,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_C4_PROXIMITY_EXPLOSIVE"],
             "RepositoryId": "b20fc045-e453-4280-8b18-b0a0e5c17236",
             "RepositoryAssets": ["b20fc045-e453-4280-8b18-b0a0e5c17236"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9418,7 +9478,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_C4_REMOTE_EXPLOSIVE"],
             "RepositoryId": "ccdd6689-092d-49b2-85f8-416a02e25566",
             "RepositoryAssets": ["ccdd6689-092d-49b2-85f8-416a02e25566"],
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9442,7 +9503,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_MODULAR_REMOTE_BREACHCHARGE"],
             "RepositoryId": "fc715a9a-3bf1-4768-bd67-0def61b92551",
             "RepositoryAssets": ["fc715a9a-3bf1-4768-bd67-0def61b92551"],
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9466,7 +9528,8 @@
             "GameAssets": ["PROP_DEVICE_ICA_PHONE_EXPLOSIVE"],
             "RepositoryId": "74a22451-8920-488f-883c-b5246ba0f9f3",
             "RepositoryAssets": ["74a22451-8920-488f-883c-b5246ba0f9f3"],
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9488,7 +9551,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "6410cb8e-c8be-47d6-ad88-8c181c4a3183",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9509,7 +9573,8 @@
             "Quality": 1,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "c95c55aa-34e5-42bd-bf27-32be3978b269"
+            "RepositoryId": "c95c55aa-34e5-42bd-bf27-32be3978b269",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9530,7 +9595,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "ec31f55f-6109-4f97-9286-8f59fae666f6"
+            "RepositoryId": "ec31f55f-6109-4f97-9286-8f59fae666f6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9551,7 +9617,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "93f34bf9-2bd4-4aff-85c7-7e4a9921dfe7"
+            "RepositoryId": "93f34bf9-2bd4-4aff-85c7-7e4a9921dfe7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9578,7 +9645,8 @@
                 "196c112b-9923-4927-97cf-5d3773ae90ea",
                 "196c112b-9923-4927-97cf-5d3773ae90ea",
                 "196c112b-9923-4927-97cf-5d3773ae90ea"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9605,7 +9673,8 @@
                 "5952b621-fee9-4699-809c-8889abadfdb8",
                 "5952b621-fee9-4699-809c-8889abadfdb8",
                 "5952b621-fee9-4699-809c-8889abadfdb8"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -9627,7 +9696,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "a10cf0cb-266d-498b-ac29-49ab10c4e575",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9649,7 +9719,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "88b961c5-7235-48d1-9067-e7d34e75ec63",
-            "UnlockOrder": 11
+            "UnlockOrder": 11,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9671,7 +9742,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "67637973-ff21-4b00-88c3-304f8405dbb7",
-            "UnlockOrder": 11
+            "UnlockOrder": 11,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9693,7 +9765,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "7d668011-77f9-4cae-97f1-e3eda5e0c8b2",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9715,7 +9788,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "261f1057-b1b2-4fe0-bd0d-b621102972c8",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9737,7 +9811,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "15295f15-b72d-49ce-9c36-fbb45c68c72a",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9759,7 +9834,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "83930544-d8db-4020-901f-ea6017764aaa",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9780,7 +9856,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "c45e59f4-d8e1-4c37-b079-8b74b1fe9b24"
+            "RepositoryId": "c45e59f4-d8e1-4c37-b079-8b74b1fe9b24",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9801,7 +9878,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "1bfbb69d-c876-4d05-ab0b-f0be63b55b7a"
+            "RepositoryId": "1bfbb69d-c876-4d05-ab0b-f0be63b55b7a",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9823,7 +9901,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "1c50d6e0-11c8-4cbc-be05-f51a8e5013be",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9854,7 +9933,8 @@
                 "b970a355-4296-4acc-9ec9-584e69a79eed",
                 "b970a355-4296-4acc-9ec9-584e69a79eed"
             ],
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9875,7 +9955,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4d0d6b2a-dd81-474c-a412-3bf19af8233d"
+            "RepositoryId": "4d0d6b2a-dd81-474c-a412-3bf19af8233d",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -9896,7 +9977,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4fad7437-59e9-4ca9-9b31-a6d97484216b"
+            "RepositoryId": "4fad7437-59e9-4ca9-9b31-a6d97484216b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -9980,7 +10062,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "8b7c3ec6-c072-4a21-a323-0f8751028052"
+            "RepositoryId": "8b7c3ec6-c072-4a21-a323-0f8751028052",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10001,7 +10084,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "54b1ffd7-5290-4b58-8e1c-53fd038a08f5"
+            "RepositoryId": "54b1ffd7-5290-4b58-8e1c-53fd038a08f5",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10022,7 +10106,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "f04bd2e9-3f3a-42cd-9150-b7845e952d67"
+            "RepositoryId": "f04bd2e9-3f3a-42cd-9150-b7845e952d67",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10043,7 +10128,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "b6108af4-702f-4954-ae7f-1204460833c7"
+            "RepositoryId": "b6108af4-702f-4954-ae7f-1204460833c7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10064,7 +10150,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "0209f0b7-f6de-45c2-a730-4802abe35a75"
+            "RepositoryId": "0209f0b7-f6de-45c2-a730-4802abe35a75",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10085,7 +10172,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "021ed731-eebc-400a-9658-8f6fc5af9da6"
+            "RepositoryId": "021ed731-eebc-400a-9658-8f6fc5af9da6",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10106,7 +10194,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "765b2c7d-8554-463a-9ee4-de7b20822161"
+            "RepositoryId": "765b2c7d-8554-463a-9ee4-de7b20822161",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10127,7 +10216,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "bbfeb648-7a9b-4fba-a5d4-7fdf84ad0017"
+            "RepositoryId": "bbfeb648-7a9b-4fba-a5d4-7fdf84ad0017",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10150,7 +10240,8 @@
             "Rarity": "common",
             "RepositoryId": "1d4f5a7c-c0fb-4d66-9e77-35ae526ef83a",
             "OrderIndex": 710,
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10171,7 +10262,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "5c0edabd-dee9-4504-a98e-ce0d837a1c2a"
+            "RepositoryId": "5c0edabd-dee9-4504-a98e-ce0d837a1c2a",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10192,7 +10284,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "8e77e2c5-caa6-45fe-8594-6a75c21569ec"
+            "RepositoryId": "8e77e2c5-caa6-45fe-8594-6a75c21569ec",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10213,7 +10306,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "8afed6c5-a730-4f47-b02c-1e4608f2ae81"
+            "RepositoryId": "8afed6c5-a730-4f47-b02c-1e4608f2ae81",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10234,7 +10328,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2bdf5016-e70b-4ac9-a3d5-f35b6743c09a"
+            "RepositoryId": "2bdf5016-e70b-4ac9-a3d5-f35b6743c09a",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10256,7 +10351,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "09c37e1a-c2b3-4dba-9e26-50fac96d3f65",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10278,7 +10374,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "67b6eb96-89c6-43ce-ba7a-526b092a55f9",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10299,7 +10396,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "59e407df-c49b-4abe-a1be-0806b026e47e"
+            "RepositoryId": "59e407df-c49b-4abe-a1be-0806b026e47e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10320,7 +10418,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "af8a7b6c-692c-4a76-b9bc-2b91ce32bcbc"
+            "RepositoryId": "af8a7b6c-692c-4a76-b9bc-2b91ce32bcbc",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10341,7 +10440,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "a83349bf-3d9c-43ec-92ee-c8c98cbeabc1"
+            "RepositoryId": "a83349bf-3d9c-43ec-92ee-c8c98cbeabc1",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10362,7 +10462,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "b988422a-02a6-499e-b796-302a782be3d1"
+            "RepositoryId": "b988422a-02a6-499e-b796-302a782be3d1",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10383,7 +10484,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "af82349c-259f-4bdd-8be7-d5ff61695c29"
+            "RepositoryId": "af82349c-259f-4bdd-8be7-d5ff61695c29",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10404,7 +10506,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "a49fe9f6-aa5a-4000-8aec-2902ab57b4b7"
+            "RepositoryId": "a49fe9f6-aa5a-4000-8aec-2902ab57b4b7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10425,7 +10528,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "042fae7b-fe9e-4a83-ac7b-5c914a71b2ca"
+            "RepositoryId": "042fae7b-fe9e-4a83-ac7b-5c914a71b2ca",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10446,7 +10550,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "a02af9a5-aefb-47e0-9d67-51cc9ec89774"
+            "RepositoryId": "a02af9a5-aefb-47e0-9d67-51cc9ec89774",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10467,7 +10572,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3f9cf03f-b84f-4419-b831-4704cff9775c"
+            "RepositoryId": "3f9cf03f-b84f-4419-b831-4704cff9775c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10488,7 +10594,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "ee4dd67d-e80c-4d97-8ca8-f0d05dc3a698"
+            "RepositoryId": "ee4dd67d-e80c-4d97-8ca8-f0d05dc3a698",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10509,7 +10616,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "6f935509-1e77-4991-baa4-d5515c20ab3e"
+            "RepositoryId": "6f935509-1e77-4991-baa4-d5515c20ab3e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10530,7 +10638,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "04812f8d-fa7c-43f8-9021-5f3587dbb2a9"
+            "RepositoryId": "04812f8d-fa7c-43f8-9021-5f3587dbb2a9",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10551,7 +10660,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "9278382c-9c73-4d0b-8be2-9cb151d3667c"
+            "RepositoryId": "9278382c-9c73-4d0b-8be2-9cb151d3667c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10572,7 +10682,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "2b869559-0c63-4731-844c-4d96554edf99"
+            "RepositoryId": "2b869559-0c63-4731-844c-4d96554edf99",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10593,7 +10704,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "3dbbbb5e-61a7-4cae-8df0-0e911e744dca"
+            "RepositoryId": "3dbbbb5e-61a7-4cae-8df0-0e911e744dca",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -10614,7 +10726,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "8bde9428-eb24-41e1-85fd-9a5a82dd81d7"
+            "RepositoryId": "8bde9428-eb24-41e1-85fd-9a5a82dd81d7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10635,7 +10748,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "9cd12159-8374-451a-b43a-c27060fe0bc7"
+            "RepositoryId": "9cd12159-8374-451a-b43a-c27060fe0bc7",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10656,7 +10770,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4e6bbdeb-74c0-4b7f-a1aa-1c16ab26d6ad"
+            "RepositoryId": "4e6bbdeb-74c0-4b7f-a1aa-1c16ab26d6ad",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10677,7 +10792,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "1bfa04db-6d53-4979-9e3a-eeb45925e4bf"
+            "RepositoryId": "1bfa04db-6d53-4979-9e3a-eeb45925e4bf",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10698,7 +10814,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "ed75b407-0e3d-4009-91c3-0fdbaae677c4"
+            "RepositoryId": "ed75b407-0e3d-4009-91c3-0fdbaae677c4",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10719,7 +10836,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "cdc20ebf-cd83-4707-8732-913c0f970cb5"
+            "RepositoryId": "cdc20ebf-cd83-4707-8732-913c0f970cb5",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10740,7 +10858,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "882fe39c-4395-4c29-87a3-a378fada5c67"
+            "RepositoryId": "882fe39c-4395-4c29-87a3-a378fada5c67",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10761,7 +10880,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "0de2e787-193a-4c53-8f9b-7056f50a9708"
+            "RepositoryId": "0de2e787-193a-4c53-8f9b-7056f50a9708",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10782,7 +10902,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "407bf3c3-6319-4573-b193-2611b0ee397e"
+            "RepositoryId": "407bf3c3-6319-4573-b193-2611b0ee397e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10808,7 +10929,8 @@
                 "6dadf34c-00f2-43f9-b4e8-6763502aa2c8",
                 "6dadf34c-00f2-43f9-b4e8-6763502aa2c8",
                 "6dadf34c-00f2-43f9-b4e8-6763502aa2c8"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10834,7 +10956,8 @@
                 "8b114fce-586b-4b06-b446-75d0bb4a4cfb",
                 "8b114fce-586b-4b06-b446-75d0bb4a4cfb",
                 "8b114fce-586b-4b06-b446-75d0bb4a4cfb"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10855,7 +10978,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "9d5daae3-10c8-4f03-a85d-9bd92861a672"
+            "RepositoryId": "9d5daae3-10c8-4f03-a85d-9bd92861a672",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10876,7 +11000,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "293af6cc-dd8d-4641-b650-14cdfd00f1de"
+            "RepositoryId": "293af6cc-dd8d-4641-b650-14cdfd00f1de",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -10897,7 +11022,8 @@
             "Quality": 3,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4c30021f-8ae4-4668-bf5d-1561b2e67d0b"
+            "RepositoryId": "4c30021f-8ae4-4668-bf5d-1561b2e67d0b",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11941,7 +12067,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "ecf7f361-c2aa-4d96-b66d-e973c3e87154",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11963,7 +12090,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "c5ec6168-2e5e-4340-b71a-c60f2ee6bd66",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11985,7 +12113,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "ef63eda6-6411-4ce0-b35b-143fc5767fc0",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12006,7 +12135,8 @@
             "Quality": 4,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "49765e76-dea7-4ad4-b502-2bad7727a15f"
+            "RepositoryId": "49765e76-dea7-4ad4-b502-2bad7727a15f",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12025,8 +12155,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -12287,7 +12417,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "acc9d7b8-80f1-4bb0-ba81-3a69b09e0543",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12308,7 +12439,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "b2321154-4520-4911-9d94-9256b85e0983",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12329,7 +12461,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "6c6adf56-1027-471c-adb4-64dbb8b81232",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12350,7 +12483,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "c61fea13-aaf0-4173-8fd0-9c34b43638ae",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12371,7 +12505,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "ac2b7cf1-523a-4aee-a73b-5b2ccfd6079f",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12392,7 +12527,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "9488fa1e-10e1-49c9-bb24-6635d2e5bd49",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12413,7 +12549,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "76d1f44c-8a78-462a-a39c-23d4101f4d6f",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12518,7 +12655,8 @@
             "LoadoutSlot": "gear",
             "Rarity": "common",
             "RepositoryId": "58a036dc-79d4-4d64-8bf5-3faafa3cfead",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12541,7 +12679,8 @@
             "RepositoryId": "a6706101-3aaf-4797-a0f8-a5b6aac9cdfe",
             "Quality": 4,
             "AllowUpSync": true,
-            "OrderIndex": 680
+            "OrderIndex": 680,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12563,7 +12702,8 @@
             "Rarity": "common",
             "RepositoryId": "903d273c-c750-441d-916a-31557fea3382",
             "Quality": 4,
-            "OrderIndex": 680
+            "OrderIndex": 680,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -13978,7 +14118,8 @@
             "RepositoryAssets": [
                 "00bc7fdc-8cce-4cb5-b31a-4d2d8b4156f8",
                 "efced006-633d-40bb-90a2-ff142c6fa34b"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14005,7 +14146,8 @@
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8",
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8",
                 "a9758ca5-eee1-4b0d-b354-f8bb1261fab8"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14032,7 +14174,8 @@
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc",
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc",
                 "9d7522dd-34e3-426d-944b-20b22f8cd9dc"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14059,7 +14202,8 @@
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d",
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d",
                 "e942b814-ca60-4f27-971e-9a3141bbdc4d"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14086,7 +14230,8 @@
                 "dec4723f-91c3-47ce-9032-5ef07269d93b",
                 "dec4723f-91c3-47ce-9032-5ef07269d93b",
                 "dec4723f-91c3-47ce-9032-5ef07269d93b"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14113,7 +14258,8 @@
                 "b9b0c5f2-41d1-4087-a57b-48a67731b699",
                 "b9b0c5f2-41d1-4087-a57b-48a67731b699",
                 "b9b0c5f2-41d1-4087-a57b-48a67731b699"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14140,7 +14286,8 @@
                 "28c542d2-7673-4b9a-ba49-b3c49acc2184",
                 "28c542d2-7673-4b9a-ba49-b3c49acc2184",
                 "28c542d2-7673-4b9a-ba49-b3c49acc2184"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14168,7 +14315,8 @@
                 "2d5657ee-d467-4202-ada5-b00b7dc3bb76",
                 "2d5657ee-d467-4202-ada5-b00b7dc3bb76",
                 "2d5657ee-d467-4202-ada5-b00b7dc3bb76"
-            ]
+            ],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -14189,7 +14337,8 @@
             "Quality": 1,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "4ab356b3-234d-4546-9490-65458a8a82ab"
+            "RepositoryId": "4ab356b3-234d-4546-9490-65458a8a82ab",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -16223,7 +16372,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "15e6200e-2000-4966-9771-923ab13c6a1c"
+            "RepositoryId": "15e6200e-2000-4966-9771-923ab13c6a1c",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16245,7 +16395,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "d21f52a2-988b-4e97-8f47-9d1c6b341adc"
+            "RepositoryId": "d21f52a2-988b-4e97-8f47-9d1c6b341adc",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16267,7 +16418,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "8493fe56-8303-4285-94c1-06f96c604dba"
+            "RepositoryId": "8493fe56-8303-4285-94c1-06f96c604dba",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16291,7 +16443,8 @@
             "AllowUpSync": true,
             "Rarity": "common",
             "RepositoryId": "1082607a-6bb0-49c9-ab77-e631f7a603f3",
-            "OrderIndex": 690
+            "OrderIndex": 690,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16313,7 +16466,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "c1238ece-fcbf-4ab9-bcfb-9371d5e3b576"
+            "RepositoryId": "c1238ece-fcbf-4ab9-bcfb-9371d5e3b576",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16335,7 +16489,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "d5d55894-a37a-4a39-b192-7c09b040c73e"
+            "RepositoryId": "d5d55894-a37a-4a39-b192-7c09b040c73e",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16357,7 +16512,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "8e2ccfc2-67d9-4ac1-87db-76e7535cd18d"
+            "RepositoryId": "8e2ccfc2-67d9-4ac1-87db-76e7535cd18d",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16379,7 +16535,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "7b71cf70-ce68-4ad2-b29a-3b2b3bacf11c"
+            "RepositoryId": "7b71cf70-ce68-4ad2-b29a-3b2b3bacf11c",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16402,7 +16559,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "8cb03c05-feba-444a-9ef6-fcb918620e43",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16424,7 +16582,8 @@
             "LoadoutSlot": "gear",
             "IsContainer": true,
             "Rarity": "common",
-            "RepositoryId": "adf6a54d-eb23-44d1-94c4-34d3195e368a"
+            "RepositoryId": "adf6a54d-eb23-44d1-94c4-34d3195e368a",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16447,7 +16606,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "d5f7e973-fbd8-477e-a34e-37985bedd831",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16470,7 +16630,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "7185b682-6c9d-4684-9b5d-d25c336f5cbd",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16493,7 +16654,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "7ef0c49f-a5dc-421e-abe9-c94fe17ea0f9",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16516,7 +16678,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "6a86aea4-77db-4b54-a23a-bb90a398a157",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16539,7 +16702,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "411cfaca-502b-41e3-9a97-311f6644d5a1",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16562,7 +16726,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "d27e9671-c2cb-4d32-b64f-c401140a4de2",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -16585,7 +16750,8 @@
             "IsContainer": true,
             "Rarity": "common",
             "RepositoryId": "4c2dfff7-9bb4-4cf0-b749-3916175912b8",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24415,8 +24581,8 @@
         "Qualities": {},
         "Properties": {
             "Gameplay": {
-                "range": 1.0,
-                "damage": 1.0,
+                "range": 1,
+                "damage": 1,
                 "clipsize": 0.2,
                 "rateoffire": 0.3
             },
@@ -24471,7 +24637,8 @@
             "RepositoryId": "e82b61a6-c534-495a-bbe2-b45e9ae9a030",
             "Quality": "2",
             "UnlockOrder": 5,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -24492,7 +24659,8 @@
             "Quality": 2,
             "LoadoutSlot": "gear",
             "Rarity": "common",
-            "RepositoryId": "89957566-316c-4014-88c2-6a8bdfc31108"
+            "RepositoryId": "89957566-316c-4014-88c2-6a8bdfc31108",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },

--- a/static/allunlockables.json
+++ b/static/allunlockables.json
@@ -7173,7 +7173,8 @@
             "Quality": "2",
             "UnlockOrder": 5,
             "AllowUpSync": true,
-            "OrderIndex": 660
+            "OrderIndex": 660,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7197,7 +7198,8 @@
             "Quality": "2",
             "UnlockOrder": 5,
             "AllowUpSync": true,
-            "OrderIndex": 660
+            "OrderIndex": 660,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7305,7 +7307,8 @@
             "Rarity": "common",
             "RepositoryId": "c7296c5f-6c0e-4d52-98cd-e70a0d329e73",
             "Quality": "1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7327,7 +7330,8 @@
             "Rarity": "common",
             "RepositoryId": "54f800df-0c14-4a6f-873f-16497b4edf00",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7349,7 +7353,8 @@
             "Rarity": "common",
             "RepositoryId": "5db9cefd-391e-4c35-a4c4-bb672ac9b996",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7371,7 +7376,8 @@
             "Rarity": "common",
             "RepositoryId": "fba6e133-78d1-4af1-8450-1ff30466c553",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7393,7 +7399,8 @@
             "Rarity": "common",
             "RepositoryId": "5b28437f-e440-40e0-ba77-426c1ee9fe0c",
             "Quality": "2",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7460,7 +7467,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "d439fb64-8713-4c54-a3f3-90730dbdf370",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7481,7 +7489,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "cdab8f33-0491-497c-91c2-316c77d59e55",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7646,7 +7655,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "304fd49f-0624-4691-8506-149a4b16808e"
+            "RepositoryId": "304fd49f-0624-4691-8506-149a4b16808e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7673,7 +7683,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "d5728a0f-fe8d-4e2d-9350-03cf4243c98e"
+            "RepositoryId": "d5728a0f-fe8d-4e2d-9350-03cf4243c98e",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7702,7 +7713,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "6dda9c11-d472-4ae9-aadc-b916881583a7"
+            "RepositoryId": "6dda9c11-d472-4ae9-aadc-b916881583a7",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7731,7 +7743,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "73875794-5a86-410e-84a4-1b5b2f7e5a54"
+            "RepositoryId": "73875794-5a86-410e-84a4-1b5b2f7e5a54",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7761,7 +7774,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "f93b99a3-aef6-419f-b303-59470577696d",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7790,7 +7804,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "a15af673-8e21-47e3-bdfa-f5dea7b5f9e9"
+            "RepositoryId": "a15af673-8e21-47e3-bdfa-f5dea7b5f9e9",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7819,7 +7834,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "ba102d90-b8c9-47b9-97eb-b462344b46c3"
+            "RepositoryId": "ba102d90-b8c9-47b9-97eb-b462344b46c3",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7846,7 +7862,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "03658b5a-b49e-4e82-82e2-f5d8c5cc602e"
+            "RepositoryId": "03658b5a-b49e-4e82-82e2-f5d8c5cc602e",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -7876,7 +7893,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "341ba426-d52d-4ae3-97a9-40b9b3633d76",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7906,7 +7924,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "e70adb5b-0646-4f88-bd4a-85bea7a2a654",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7934,7 +7953,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "b8ec525e-8de3-4b9a-9b2a-97eb6a8dd9f6",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7964,7 +7984,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "e55c71d6-cbf6-41b8-8838-2d1be1d07e1c",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -7994,7 +8015,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "be4e7b4e-d895-47c1-979d-d79bfbe79a02",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8024,7 +8046,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "f91cf558-04a5-4fd8-8814-b1c765668b39",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8053,7 +8076,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "ebff0c9a-e04d-4bc2-8f7a-e9c3cd6d6a93"
+            "RepositoryId": "ebff0c9a-e04d-4bc2-8f7a-e9c3cd6d6a93",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8083,7 +8107,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7bf3a6e6-b5aa-4c88-b953-c2c378d36118",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8111,7 +8136,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7373fafa-7adb-4c14-ac02-225895f9eb7f",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8139,7 +8165,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "f6657618-d723-419f-a71b-84d0e93402e3",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8168,7 +8195,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "b1cb79d7-9960-4d5c-8b43-81213c8594cd"
+            "RepositoryId": "b1cb79d7-9960-4d5c-8b43-81213c8594cd",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8198,7 +8226,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "1264f20b-b901-4d36-bc03-a9115709b531",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8226,7 +8255,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "2f6eec38-45ea-49df-83a2-0b98a858e60a",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8256,7 +8286,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "7e1b2364-a190-41f7-a16d-a7d7a9a2f623",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8284,7 +8315,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "54bba84c-6751-430e-b47d-e4b5ddf7a835",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8312,7 +8344,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "41ac4076-e197-4576-894b-499534fd37e8",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8340,7 +8373,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "545ff36e-b43c-4a35-9ab3-680b23b9e354",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8370,7 +8404,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "034ce4ab-b85a-4706-bdef-cba77f9b45f7",
-            "UnlockOrder": 15
+            "UnlockOrder": 15,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8398,7 +8433,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "c8a09c31-a53e-436f-8421-a4dc4115f633",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8426,7 +8462,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "97f3ab46-e409-40dd-a0ba-8e9dd0b0345b",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8454,7 +8491,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "b2d514ba-86d6-456a-be10-7592a30dcae1",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8482,7 +8520,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "a8309099-1b89-4492-bf37-37d4312b6615",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8503,7 +8542,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "6576f6aa-8d77-48f1-a4c7-f57fb5ddcc51"
+            "RepositoryId": "6576f6aa-8d77-48f1-a4c7-f57fb5ddcc51",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -8533,7 +8573,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "370580fc-7fcf-47f8-b994-cebd279f69f9",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -8563,7 +8604,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "3d681794-bd95-4340-9a18-59372a2239a0",
-            "UnlockOrder": 5
+            "UnlockOrder": 5,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -9999,7 +10041,8 @@
             "Quality": 3,
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
-            "RepositoryId": "12200bd8-9605-4111-8b26-4e73cb07d816"
+            "RepositoryId": "12200bd8-9605-4111-8b26-4e73cb07d816",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -10020,7 +10063,8 @@
             "Quality": 3,
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
-            "RepositoryId": "b4d4ed1a-0687-48a9-a731-0e3b99494eb6"
+            "RepositoryId": "b4d4ed1a-0687-48a9-a731-0e3b99494eb6",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -10041,7 +10085,8 @@
             "Quality": 3,
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
-            "RepositoryId": "23b8ad17-1913-40ce-b3bc-2c92317801dd"
+            "RepositoryId": "23b8ad17-1913-40ce-b3bc-2c92317801dd",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -11044,7 +11089,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "081f8265-63db-4759-96a3-5186caf59f62"
+            "RepositoryId": "081f8265-63db-4759-96a3-5186caf59f62",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11065,7 +11111,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f4e92f7a-c13e-4f7f-8406-137dfd3f8378"
+            "RepositoryId": "f4e92f7a-c13e-4f7f-8406-137dfd3f8378",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11087,7 +11134,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "26605ee6-6e82-4a57-909f-76b91e7d93ed"
+            "RepositoryId": "26605ee6-6e82-4a57-909f-76b91e7d93ed",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11109,7 +11157,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f5e3a7ca-d0d3-421e-b341-b5ba46bc900f"
+            "RepositoryId": "f5e3a7ca-d0d3-421e-b341-b5ba46bc900f",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11130,7 +11179,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "7d64d9df-5d30-4e98-9af0-7562ee145d5c"
+            "RepositoryId": "7d64d9df-5d30-4e98-9af0-7562ee145d5c",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11151,7 +11201,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f5d0b800-bf37-41ff-bd19-4c04e3b69754"
+            "RepositoryId": "f5d0b800-bf37-41ff-bd19-4c04e3b69754",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11172,7 +11223,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "559d8002-9dc5-4da7-ab54-18c8ad20f047"
+            "RepositoryId": "559d8002-9dc5-4da7-ab54-18c8ad20f047",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11193,7 +11245,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f9d471fc-a3d0-49bd-8e2d-af7fb8cedf6f"
+            "RepositoryId": "f9d471fc-a3d0-49bd-8e2d-af7fb8cedf6f",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11214,7 +11267,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f5ebb935-9bec-422b-b772-37adc3ba23db"
+            "RepositoryId": "f5ebb935-9bec-422b-b772-37adc3ba23db",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11235,7 +11289,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "74562c61-4405-413f-8d69-353688942390"
+            "RepositoryId": "74562c61-4405-413f-8d69-353688942390",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11256,7 +11311,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "79b48d90-26aa-4b17-9332-599ed8e0bd7f"
+            "RepositoryId": "79b48d90-26aa-4b17-9332-599ed8e0bd7f",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11277,7 +11333,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "87bf38ca-de63-4037-ae32-7817a42c7ced"
+            "RepositoryId": "87bf38ca-de63-4037-ae32-7817a42c7ced",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11298,7 +11355,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "e3b6e1d1-fea5-4035-87b3-6b996b3488c2"
+            "RepositoryId": "e3b6e1d1-fea5-4035-87b3-6b996b3488c2",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11319,7 +11377,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "eca66732-a356-4c13-8e33-d0f7e87b5860"
+            "RepositoryId": "eca66732-a356-4c13-8e33-d0f7e87b5860",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11340,7 +11399,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "6696a10d-9138-4184-8104-a6c7ec2e0eb1"
+            "RepositoryId": "6696a10d-9138-4184-8104-a6c7ec2e0eb1",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11361,7 +11421,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "ef4c35c7-b7d4-4886-81b5-fda089f91173"
+            "RepositoryId": "ef4c35c7-b7d4-4886-81b5-fda089f91173",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11382,7 +11443,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "b58f4e9f-60b1-4bcb-bd87-b11dbcb8e6b2"
+            "RepositoryId": "b58f4e9f-60b1-4bcb-bd87-b11dbcb8e6b2",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11403,7 +11465,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "d4f6e560-cf9f-4a0a-955d-787577b073d6"
+            "RepositoryId": "d4f6e560-cf9f-4a0a-955d-787577b073d6",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11424,7 +11487,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "33cadd6f-3813-4be1-8e50-bd6819cb9b13"
+            "RepositoryId": "33cadd6f-3813-4be1-8e50-bd6819cb9b13",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11445,7 +11509,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f8f1acee-cb96-47a0-a969-4527251a713d"
+            "RepositoryId": "f8f1acee-cb96-47a0-a969-4527251a713d",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11466,7 +11531,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "092f6514-c34e-4d04-8d28-7ebbe14230d1"
+            "RepositoryId": "092f6514-c34e-4d04-8d28-7ebbe14230d1",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11487,7 +11553,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "66f9cf6f-ff2b-4870-9516-59f0f0ef9b0b"
+            "RepositoryId": "66f9cf6f-ff2b-4870-9516-59f0f0ef9b0b",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11515,7 +11582,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "93a95f8a-a1bb-4d6c-bfd5-e6eec4eeaa1e",
-            "UnlockOrder": 20
+            "UnlockOrder": 20,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11536,7 +11604,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "c03498c1-db54-402a-9923-63ada447a4b8",
-            "Quality": "1"
+            "Quality": "1",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11557,7 +11626,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "26b5496d-9a8c-4059-9d69-d8712078a33c"
+            "RepositoryId": "26b5496d-9a8c-4059-9d69-d8712078a33c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11578,7 +11648,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "351c144c-8687-426a-a6f0-c4abd7021062"
+            "RepositoryId": "351c144c-8687-426a-a6f0-c4abd7021062",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11599,7 +11670,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "adced1ef-ecb5-4d46-ab73-d955d4b1fa1d"
+            "RepositoryId": "adced1ef-ecb5-4d46-ab73-d955d4b1fa1d",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11620,7 +11692,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "808ebdcb-aafe-496a-9541-5903bf03c12e"
+            "RepositoryId": "808ebdcb-aafe-496a-9541-5903bf03c12e",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11641,7 +11714,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "8762d292-91ce-4385-9f78-dbf845f8366d"
+            "RepositoryId": "8762d292-91ce-4385-9f78-dbf845f8366d",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11662,7 +11736,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "351c144c-8687-426a-a6f0-c4abd7021062"
+            "RepositoryId": "351c144c-8687-426a-a6f0-c4abd7021062",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11683,7 +11758,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "4bbe3b64-8bce-416e-a3e9-00bcd1571980"
+            "RepositoryId": "4bbe3b64-8bce-416e-a3e9-00bcd1571980",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11704,7 +11780,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "ff340698-bc83-479c-8917-16d99b39406c"
+            "RepositoryId": "ff340698-bc83-479c-8917-16d99b39406c",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11726,7 +11803,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "fca954f6-40b1-448d-b4a8-0c543e521cc3",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11748,7 +11826,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "563e5651-3024-4dc8-9063-93030a670ca3",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11770,7 +11849,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "cfa664fc-e583-4ad5-ade5-2f746d8656ca",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11792,7 +11872,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "028bcbf4-a0a3-42b5-beaf-163a777164e8",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11813,7 +11894,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "4e66bf97-e6da-4cb6-b873-10a9af274bf4"
+            "RepositoryId": "4e66bf97-e6da-4cb6-b873-10a9af274bf4",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11834,7 +11916,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "bc2df333-bce1-4758-9bc5-4bce40d2c218"
+            "RepositoryId": "bc2df333-bce1-4758-9bc5-4bce40d2c218",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11855,7 +11938,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "e638b949-9b96-4c41-bec4-0a8fbfb05c75"
+            "RepositoryId": "e638b949-9b96-4c41-bec4-0a8fbfb05c75",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11877,7 +11961,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "f6d61543-405b-411f-b0c7-a5befc1c62cd",
-            "AllowUpSync": true
+            "AllowUpSync": true,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -11898,7 +11983,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "224822b8-7c8b-4c42-9194-8b307eadb31b"
+            "RepositoryId": "224822b8-7c8b-4c42-9194-8b307eadb31b",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11919,7 +12005,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "851c8aee-3de2-48ea-ae16-667c8f180f2d"
+            "RepositoryId": "851c8aee-3de2-48ea-ae16-667c8f180f2d",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -11940,7 +12027,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "10f0653c-fe9c-4a43-98f1-18d20d18d9ab"
+            "RepositoryId": "10f0653c-fe9c-4a43-98f1-18d20d18d9ab",
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -11961,7 +12049,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "8a30c788-049a-4b83-b148-1a6db49d2ae5"
+            "RepositoryId": "8a30c788-049a-4b83-b148-1a6db49d2ae5",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -11982,7 +12071,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "6738e8ad-b8d0-496a-9749-d27a93b40113"
+            "RepositoryId": "6738e8ad-b8d0-496a-9749-d27a93b40113",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12003,7 +12093,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "79f8c0e9-4690-4ebf-b2b3-fd8411a1407f"
+            "RepositoryId": "79f8c0e9-4690-4ebf-b2b3-fd8411a1407f",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12024,7 +12115,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "b0314606-caa4-4a2c-a3e2-bd011f98cfdf"
+            "RepositoryId": "b0314606-caa4-4a2c-a3e2-bd011f98cfdf",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12045,7 +12137,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "77ecaad6-652f-480d-b365-cdf90820a5ec"
+            "RepositoryId": "77ecaad6-652f-480d-b365-cdf90820a5ec",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12165,7 +12258,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "eedb7f84-896d-403b-905b-11b105e7ce35"
+            "RepositoryId": "eedb7f84-896d-403b-905b-11b105e7ce35",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12193,7 +12287,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "907e0277-7806-42a4-b4b2-338cf8dd9391",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12221,7 +12316,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "214004ec-5c86-4c26-8403-9e83a9bcdd24",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12249,7 +12345,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "256ac829-2ec6-44de-8d5f-16801a0491df",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12277,7 +12374,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "2dfacef2-57f6-4b8d-a1ae-f1f7ada4ec22",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12305,7 +12403,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "77f644ef-6dbb-4f30-afef-5c3a6a26a665",
-            "UnlockOrder": 10
+            "UnlockOrder": 10,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12333,7 +12432,8 @@
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "482eca87-2340-43b2-bf8e-9f6dafb16b4c",
-            "UnlockOrder": 2
+            "UnlockOrder": 2,
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12354,7 +12454,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "15291f69-88d0-4a8f-b31b-71605ba5ff38"
+            "RepositoryId": "15291f69-88d0-4a8f-b31b-71605ba5ff38",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12375,7 +12476,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "f755f824-bdf6-4ace-b416-abf3bae4b6d5"
+            "RepositoryId": "f755f824-bdf6-4ace-b416-abf3bae4b6d5",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12396,7 +12498,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "b549ea89-e9cc-44f4-87ae-7145a7060028",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12571,7 +12674,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "d70c739a-6956-4771-ba9c-7f3c9206f762",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12592,7 +12696,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "ed45f927-589d-4bad-ac1b-67e41c32e5ee",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12613,7 +12718,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "e51bc878-281a-4711-b8a6-3088ebd1a27e",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12634,7 +12740,8 @@
             "LoadoutSlot": "carriedweapon",
             "Rarity": "common",
             "RepositoryId": "20f7ee3f-b261-4baa-8965-9b0b9061f27f",
-            "Quality": 4
+            "Quality": 4,
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -12725,7 +12832,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "f301f605-007c-4fe1-aa99-a8cd2cae033f"
+            "RepositoryId": "f301f605-007c-4fe1-aa99-a8cd2cae033f",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12747,7 +12855,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "8d22cea9-68db-458d-a8ee-9937128f1729"
+            "RepositoryId": "8d22cea9-68db-458d-a8ee-9937128f1729",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12769,7 +12878,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "0f9608e9-6e42-49b9-b4cd-9aaebba8458f"
+            "RepositoryId": "0f9608e9-6e42-49b9-b4cd-9aaebba8458f",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12791,7 +12901,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "d5f8e067-5b44-4ddf-91e2-3c29e9222eae"
+            "RepositoryId": "d5f8e067-5b44-4ddf-91e2-3c29e9222eae",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -12812,7 +12923,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "concealedweapon",
-            "RepositoryId": "8d7a3342-1229-4619-ae51-f4a462f9130d"
+            "RepositoryId": "8d7a3342-1229-4619-ae51-f4a462f9130d",
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -12834,7 +12946,8 @@
             "Quality": 4,
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
-            "RepositoryId": "0e3dc26a-9eed-4aa1-b81e-d0c597b36737"
+            "RepositoryId": "0e3dc26a-9eed-4aa1-b81e-d0c597b36737",
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -23483,7 +23596,8 @@
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "f417bfec-a999-4b2f-adef-510323c75ccf",
             "AllowUpSync": true,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -23535,7 +23649,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "23e1031b-879d-4b04-ada9-b684d9d16c22",
             "AllowUpSync": true,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -23587,7 +23702,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "613b24eb-fdc1-47a3-9157-e3d0c5464baf",
             "AllowUpSync": true,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -23639,7 +23755,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "4ad2be0d-e24f-47a2-bcc9-4c6d5f73d4ff",
             "AllowUpSync": true,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_MEDIUM"
         },
         "Rarity": "common"
     },
@@ -23691,7 +23808,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "2d0393e2-49a8-43c1-b8f3-110e4b0b0c83",
             "AllowUpSync": true,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -23734,7 +23852,8 @@
             "Rarity": "common",
             "RepositoryId": "af2b1a36-a7f0-4003-aae4-a6076402542d",
             "Quality": "1",
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -23809,7 +23928,8 @@
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "05ccbb96-a1a0-4ee5-9586-cb9d9c02085e",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"]
+            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -23860,7 +23980,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "9fcf5400-0784-4e71-ad57-a3e17cf88bc3",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"]
+            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -23911,7 +24032,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "cd7587d0-4dff-4df6-b435-6080379acb01",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"]
+            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -23962,7 +24084,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "30ebff97-f1e8-4fb1-9414-3e0911c29149",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"]
+            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -24013,7 +24136,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "3ec2d9e5-de9d-4ddc-969f-6f1565e5a291",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"]
+            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24056,7 +24180,8 @@
             "RepositoryId": "fecf585b-4bdb-4a9b-9ab0-2bc44c6bd84a",
             "Quality": "1",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"]
+            "Entitlements": ["H3_VANITY_MAKESHIFTSCRAP"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24130,7 +24255,8 @@
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "0f991e64-354a-403a-afa5-b30285889377",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_CONCRETEART"]
+            "Entitlements": ["H3_VANITY_CONCRETEART"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -24159,7 +24285,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "407df651-52d4-4871-a903-db677a7568ed",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_CONCRETEART"]
+            "Entitlements": ["H3_VANITY_CONCRETEART"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24188,7 +24315,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "f2465b79-a901-42f9-93f5-22f114530849",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_CONCRETEART"]
+            "Entitlements": ["H3_VANITY_CONCRETEART"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24217,7 +24345,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "a5d19e9f-8ca3-4c51-9d79-15d3ea2e7771",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_CONCRETEART"]
+            "Entitlements": ["H3_VANITY_CONCRETEART"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24246,7 +24375,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "6e5e27bf-6c27-4785-8cc4-ffebd0ec3494",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_CONCRETEART"]
+            "Entitlements": ["H3_VANITY_CONCRETEART"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24269,7 +24399,8 @@
             "RepositoryId": "1e2bc40b-505a-4cc6-a09c-94470470985b",
             "Quality": "1",
             "AllowUpSync": true,
-            "Entitlements": ["H3_VANITY_CONCRETEART"]
+            "Entitlements": ["H3_VANITY_CONCRETEART"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24455,7 +24586,8 @@
             "LoadoutSlot": "concealedweapon",
             "RepositoryId": "d3dc2ef7-da65-4cdf-bf47-771aa5797ae0",
             "UnlockOrder": 20,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_SMALL"
         },
         "Rarity": "common"
     },
@@ -24498,7 +24630,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "935fd34c-e58c-45d3-bc66-3144752b001b",
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24541,7 +24674,8 @@
             "Rarity": "common",
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "dd57a213-3e76-4a38-ba47-0ac5040ce5e4",
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },
@@ -24593,7 +24727,8 @@
             "LoadoutSlot": "carriedweapon",
             "RepositoryId": "cdf9db81-14a9-4047-9c95-8a3e65cd6a00",
             "UnlockOrder": 5,
-            "Entitlements": ["LOCATION_GOLDEN"]
+            "Entitlements": ["LOCATION_GOLDEN"],
+            "ItemSize": "ITEMSIZE_LARGE"
         },
         "Rarity": "common"
     },


### PR DESCRIPTION
Fixes https://github.com/thepeacockproject/Peacock/issues/333

Used rpkg cli to check itemSize as suggested by @grappigegovert

NodeJS / RPKG CLI script I used: https://github.com/solderq35/hitman-tech-tips/blob/main/modding/add_itemsize.js

The only item in allunlockables.json that I couldn't find in rpkg was "PROP_MELEE_EIFFELSOUVENIR_CLUB" (repository ID: 7257eaa1-c8f3-4e0c-acbf-74f73869c1b2). So feel free to update the itemsize for that if it's known.

Edit: Also realized later that Brine Damaged SMG (repository ID: 79f8c0e9-4690-4ebf-b2b3-fd8411a1407f) has "ItemSize: small" despite being a "carriedweapon", so I changed the logic in menuData.ts to reflect that. The Brine Damaged SMG is equippable to hidden stash, but not concealed weapon slot on vanilla servers.

Use cases tested:
- Normal gear slot: everything except large weapons ("carriedweapon")
- Concealed weapon slot: pistols, dak x2 smg
- Inside briefcase: everything
- Agency pickup: everything
- Hidden Stash: Pistols, dak x2 smg, small gear / tools, small melee. Large or medium melee like muffins, crowbar are excluded