### PR TITLE
Briefcase saved loadout fix

### DIFF
--- a/components/menus/planning.ts
+++ b/components/menus/planning.ts
@@ -238,7 +238,7 @@ export async function planningView(
     let suit = getDefaultSuitFor(sublocation)
     let tool1 = "TOKEN_FIBERWIRE"
     let tool2 = "PROP_TOOL_COIN"
-    let briefcaseProp: string | undefined = undefined
+    let briefcaseContainedItemId: string | undefined = undefined
     let briefcaseId: string | undefined = undefined
 
     const hasOwn = Object.prototype.hasOwnProperty.bind(currentLoadout.data)
@@ -266,11 +266,13 @@ export async function planningView(
             }
 
             briefcaseId = key
-            briefcaseProp = dlForLocation[key]
+            briefcaseContainedItemId = dlForLocation[key]
         }
     }
 
-    const i = typedInv.find((item) => item.Unlockable.Id === briefcaseProp)
+    const briefcaseContainedItem = typedInv.find(
+        (item) => item.Unlockable.Id === briefcaseContainedItemId,
+    )
 
     const userCentric = generateUserCentric(
         contractData,
@@ -350,19 +352,20 @@ export async function planningView(
             SlotId: "6",
             Recommended: null,
         },
-        briefcaseId && i && {
-            SlotName: briefcaseProp,
-            SlotId: briefcaseId,
-            Recommended: {
-                item: {
-                    ...i,
-                    Properties: {},
+        briefcaseId &&
+            briefcaseContainedItem && {
+                SlotName: briefcaseContainedItemId,
+                SlotId: briefcaseId,
+                Recommended: {
+                    item: {
+                        ...briefcaseContainedItem,
+                        Properties: {},
+                    },
+                    type: briefcaseContainedItem.Unlockable.Id,
+                    owned: true,
                 },
-                type: i.Unlockable.Id,
-                owned: true,
+                IsContainer: true,
             },
-            IsContainer: true,
-        },
     ].filter(Boolean)
 
     /**

--- a/components/menus/planning.ts
+++ b/components/menus/planning.ts
@@ -350,7 +350,7 @@ export async function planningView(
             SlotId: "6",
             Recommended: null,
         },
-        briefcaseId && {
+        briefcaseId && i && {
             SlotName: briefcaseProp,
             SlotId: briefcaseId,
             Recommended: {


### PR DESCRIPTION
This should fix the error reported here: https://discord.com/channels/826809653181808651/1197928917290451014, where the planning page breaks because it tries to load a saved loadout with a briefcase that contains an item that is not in the user's inventory. (At least I think that was the issue, the user hasn't responded yet)
This can occur if you save a loadout, and then enable mastery progression or lose access to a dlc.

This targets v6 because I fear that v7 might not release for a while