### PR TITLE
Remove redundant sloth challenge

### DIFF
--- a/contractdata/DARTMOOR/_DARTMOOR_CHALLENGES.json
+++ b/contractdata/DARTMOOR/_DARTMOOR_CHALLENGES.json
@@ -4626,49 +4626,6 @@
                     "InclusionData": {
                         "ContractIds": ["78628e05-93ce-4f87-8a17-b910d32df51f"]
                     }
-                },
-                {
-                    "Id": "81bb119e-abeb-4c77-9e67-5726615091e0",
-                    "Name": "UI_CONTRACT_HAREBELL_GROUP_TITLE",
-                    "ImageName": "images/contracts/escalation/ContractEscalation_Ancestral_Harebell.jpg",
-                    "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
-                    "Rewards": {
-                        "MasteryXP": 4000
-                    },
-                    "Drops": [],
-                    "IsPlayable": true,
-                    "IsLocked": false,
-                    "HideProgression": false,
-                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_COMMUNITY",
-                    "Icon": "challenge_category_feats",
-                    "LocationId": "LOCATION_ANCESTRAL_BULLDOG",
-                    "ParentLocationId": "LOCATION_PARENT_ANCESTRAL",
-                    "Type": "contract",
-                    "DifficultyLevels": [],
-                    "OrderIndex": 10000,
-                    "XpModifier": {},
-                    "RuntimeType": "Hit",
-                    "Definition": {
-                        "Context": {},
-                        "Scope": "session",
-                        "States": {
-                            "Start": {
-                                "ContractEnd": {
-                                    "Condition": {
-                                        "$eq": [
-                                            "$ContractId",
-                                            "b8201747-5bb5-47d4-9a9b-1bd851317206"
-                                        ]
-                                    },
-                                    "Transition": "Success"
-                                }
-                            }
-                        }
-                    },
-                    "Tags": ["feats", "hard"],
-                    "InclusionData": {
-                        "ContractIds": ["a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"]
-                    }
                 }
             ]
         },


### PR DESCRIPTION
I must have added an end-of-escalation challenge for The Sloth Depletion via a script, despite there originally being one under a different name. It is rectified in this PR. 