### PR TITLE
Fix some challenges not being ticked on mission end page

### DIFF
--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -720,6 +720,7 @@ export async function getMissionEndData(
     // Calculate XP based on non-global challenges. Remember to add elusive challenges of the contract
     Object.values({
         ...locationChallenges,
+        ...contractChallenges,
         ...(Object.keys(contractChallenges).includes("elusive") && {
             elusive: contractChallenges.elusive,
         }),


### PR DESCRIPTION
If a challenge is not in the current location, it will not appear as "ticked" on the mission end page even if it is completed. This PR fixes that.