### PR TITLE
fix(scoring): Un-patch the noticed kill bug in 2016

### DIFF
--- a/components/eventHandler.ts
+++ b/components/eventHandler.ts
@@ -86,7 +86,6 @@ const pushMessageQueue = new Map<string, PushMessage[]>()
  * @param userId The push message's target user.
  * @param message The raw push message to send.
  * @see enqueueEvent
- * @author grappigegovert
  */
 export function enqueuePushMessage(userId: string, message: unknown): void {
     let userQueue
@@ -113,7 +112,6 @@ export function enqueuePushMessage(userId: string, message: unknown): void {
  *
  * @param session The contract session.
  * @param objective The objective object.
- * @author Reece Dunham
  */
 export function registerObjectiveListener(
     session: ContractSession,
@@ -225,7 +223,6 @@ export function setupScoring(
  * @param userId The event's target user.
  * @param event The event to send.
  * @see enqueuePushMessage
- * @author grappigegovert
  */
 export function enqueueEvent(userId: string, event: ServerToClientEvent): void {
     let userQueue: S2CEventWithTimestamp[] | undefined
@@ -352,7 +349,9 @@ export function newSession(
         failedObjectives: new Set(),
         recording: PeacockCameraStatus.NotSpotted,
         lastAccident: 0,
-        lastKill: {},
+        lastKill: {
+            legacyIsUnnoticed: true,
+        },
         kills: new Set(),
         compat: doScoring,
         markedTargets: new Set(),
@@ -520,7 +519,6 @@ eventRouter.post(
  *
  * @param uId The user's ID.
  * @returns The ID for the user's active session.
- * @author Reece Dunham
  */
 export function getActiveSessionIdForUser(uId: string): string | undefined {
     return userIdToTempSession.get(uId)
@@ -531,7 +529,6 @@ export function getActiveSessionIdForUser(uId: string): string | undefined {
  *
  * @param uId The user's ID.
  * @returns The user's active contract session.
- * @author Reece Dunham
  */
 export function getSession(uId: string): ContractSession | undefined {
     const currentSession = getActiveSessionIdForUser(uId)
@@ -643,7 +640,8 @@ function saveEvents(
     const response: string[] = []
     const processed: string[] = []
     const userData = getUserData(userId, gameVersion)
-    events.forEach((event) => {
+
+    for (const event of events) {
         let session = contractSessions.get(event.ContractSessionId)
 
         if (!session) {
@@ -673,7 +671,7 @@ function saveEvents(
             logDebug(session)
             logDebug(event)
 
-            return // session does not exist or contractid/userid doesn't match
+            continue // session does not exist or contractid/userid doesn't match
         }
 
         session.duration = event.Timestamp
@@ -770,7 +768,7 @@ function saveEvents(
             processed.push(event.Name)
             response.push(process.hrtime.bigint().toString())
 
-            return
+            continue
         }
 
         // these events are important but may be fired after the timer is over
@@ -788,14 +786,14 @@ function saveEvents(
         ) {
             // Do not handle events that occur after exiting the level
             response.push(process.hrtime.bigint().toString())
-            return
+            continue
         }
 
         if (handleMultiplayerEvent(event, session)) {
             processed.push(event.Name)
             response.push(process.hrtime.bigint().toString())
 
-            return
+            continue
         }
 
         switch (event.Name) {
@@ -806,6 +804,8 @@ function saveEvents(
                 )
                 break
             case "Kill": {
+                let couldCauseNoticedKill = true
+
                 const killValue = (event as KillC2SEvent).Value
 
                 if (session.firstKillTimestamp === undefined) {
@@ -819,6 +819,12 @@ function saveEvents(
                         timestamp: event.Timestamp,
                         repositoryIds: [killValue.RepositoryId],
                     }
+
+                    if (gameVersion === "h1" && killValue.Accident) {
+                        // this was an accident, can't be a noticed kill
+                        session.lastKill.legacyIsUnnoticed = true
+                        couldCauseNoticedKill = false
+                    }
                 }
 
                 if (killValue.KillContext === EDeathContext.eDC_NOT_HERO) {
@@ -828,13 +834,19 @@ function saveEvents(
                         `${killValue.RepositoryId} eliminated, 47 not responsible`,
                     )
                     response.push(process.hrtime.bigint().toString())
-                    return
+                    session.lastKill.legacyIsUnnoticed = true
+                    couldCauseNoticedKill = false
+                    continue
                 }
 
                 log(
                     LogLevel.DEBUG,
                     `Actor ${killValue.RepositoryId} eliminated.`,
                 )
+
+                if (couldCauseNoticedKill) {
+                    session.lastKill.legacyIsUnnoticed = false
+                }
 
                 if (killValue.IsTarget || contractType === "creation") {
                     const kill: RatingKill = {
@@ -857,6 +869,9 @@ function saveEvents(
 
                 break
             }
+            case "Unnoticed_Kill":
+                session.lastKill.legacyIsUnnoticed = true
+                break
             case "CrowdNPC_Died":
                 session.crowdNpcKills += 1
                 break
@@ -1118,7 +1133,7 @@ function saveEvents(
         processed.push(event.Name)
 
         response.push(process.hrtime.bigint().toString())
-    })
+    }
 
     if (processed.length > 0) {
         log(

--- a/components/flags.ts
+++ b/components/flags.ts
@@ -45,6 +45,10 @@ const defaultFlags: Flags = {
         desc: "[Gameplay] Show elusive targets in instinct like normal targets would appear on normal missions. (for speedrunners who are submitting to speedrun.com, just as a reminder, this tool is for practice only!)",
         default: false,
     },
+    legacyNoticedKillScoring: {
+        desc: '[Gameplay] In the HITMAN 2016 engine, if noticed kills should behave in the official way ("vanilla"), or how they were previously handled by Peacock ("sane")',
+        default: "vanilla",
+    },
     jokes: {
         desc: "[Services] The Peacock server window will tell you a joke on startup if this is set to true.",
         default: false,

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -71,7 +71,7 @@ import {
     MissionEndResult,
 } from "./types/score"
 import { MasteryData } from "./types/mastery"
-import { createInventory, InventoryItem, getUnlockablesById } from "./inventory"
+import { createInventory, getUnlockablesById, InventoryItem } from "./inventory"
 import { calculatePlaystyle } from "./playStyles"
 import assert from "assert"
 
@@ -173,13 +173,14 @@ export function calculateScore(
         {
             headline: "UI_SCORING_SUMMARY_NO_NOTICED_KILLS",
             bonusId: "NoWitnessedKillsBonus",
-            condition: [...contractSession.killsNoticedBy].every(
-                (witness) =>
-                    (gameVersion === "h1"
-                        ? true
-                        : contractSession.targetKills.has(witness)) ||
-                    contractSession.npcKills.has(witness),
-            ),
+            condition:
+                gameVersion === "h1"
+                    ? contractSession.lastKill.legacyIsUnnoticed
+                    : [...contractSession.killsNoticedBy].every(
+                          (witness) =>
+                              contractSession.targetKills.has(witness) ||
+                              contractSession.npcKills.has(witness),
+                      ),
         },
         {
             headline: "UI_SCORING_SUMMARY_NO_BODIES_FOUND",

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -132,6 +132,9 @@ export function calculateScore(
     contractData: MissionManifest,
     timeTotal: Seconds,
 ): CalculateScoreResult {
+    const noticedKillsAreVanilla =
+        getFlag("legacyNoticedKillScoring") === "vanilla"
+
     // Bonuses
     const bonuses = [
         {
@@ -174,7 +177,7 @@ export function calculateScore(
             headline: "UI_SCORING_SUMMARY_NO_NOTICED_KILLS",
             bonusId: "NoWitnessedKillsBonus",
             condition:
-                gameVersion === "h1"
+                gameVersion === "h1" && noticedKillsAreVanilla
                     ? contractSession.lastKill.legacyIsUnnoticed
                     : [...contractSession.killsNoticedBy].every(
                           (witness) =>

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -213,6 +213,7 @@ export interface ContractSearchResult {
 export interface ContractSessionLastKill {
     timestamp?: Date | number
     repositoryIds?: RepositoryId[]
+    legacyIsUnnoticed?: boolean
 }
 
 /**

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -213,6 +213,10 @@ export interface ContractSearchResult {
 export interface ContractSessionLastKill {
     timestamp?: Date | number
     repositoryIds?: RepositoryId[]
+    /**
+     * If the last kill was unnoticed in H2016.
+     * See [this video](https://www.youtube.com/watch?v=4fMDqRZg3Ik) for an explanation on how it's supposed to work.
+     */
     legacyIsUnnoticed?: boolean
 }
 


### PR DESCRIPTION
Fixes #396

Aligns the behavior with the official servers by default, optionally falling back to the logic that we used to use depending on the flag value.

Drive by: remove author jsdoc tags as we don't really use them anywhere else