### PR TITLE
Fix Evergreen and Sniper max level progression reset

### DIFF
--- a/components/utils.ts
+++ b/components/utils.ts
@@ -181,14 +181,12 @@ export const EVERGREEN_LEVEL_INFO: number[] = [
 
 export function evergreenLevelForXp(xp: number): number {
     for (let i = 1; i < EVERGREEN_LEVEL_INFO.length; i++) {
-        if (xp >= EVERGREEN_LEVEL_INFO[i]) {
-            continue
+        if (xp < EVERGREEN_LEVEL_INFO[i]) {
+            return i
         }
-
-        return i
     }
 
-    return 1
+    return EVERGREEN_LEVEL_INFO.length
 }
 
 /**
@@ -209,14 +207,12 @@ export const SNIPER_LEVEL_INFO: number[] = [
 
 export function sniperLevelForXp(xp: number): number {
     for (let i = 1; i < SNIPER_LEVEL_INFO.length; i++) {
-        if (xp >= SNIPER_LEVEL_INFO[i]) {
-            continue
+        if (xp < SNIPER_LEVEL_INFO[i]) {
+            return i
         }
-
-        return i
     }
 
-    return 1
+    return SNIPER_LEVEL_INFO.length
 }
 
 /**


### PR DESCRIPTION
Upon reaching maximum level, the XP value gets clamped to maximum level XP value, and that caused entire for loop to fall through and return `1`, permanently resetting the player level to 1.
It now returns correct level when player reached the maximum.

Same bug was present in sniper map progression.