### PR TITLE
revert(compat): Reintroduce smf checks in controller

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -408,6 +408,34 @@ export class Controller {
     }
 
     /**
+     * You should use {@link smf.modIsInstalled} instead!
+     *
+     * Returns whether a mod is UNAVAILABLE.
+     *
+     * @param modId The mod's ID.
+     * @returns If the mod is unavailable. You should probably abort initialization if true is returned. Also returns true if the `overrideFrameworkChecks` flag is set.
+     * @deprecated since v5.5.0, use `!controller.smf.modIsInstalled`
+     */
+    public addClientSideModDependency(modId: string): boolean {
+        log(LogLevel.WARN, "controller.addClientSideModDependency is deprecated, use !controller.smf.modIsInstalled instead!", "plugins")
+        return getFlag('overrideFrameworkChecks') === true || !this.smf.modIsInstalled(modId)
+    }
+
+    /**
+     * You should use {@link smf.modIsInstalled} instead!
+     * 
+     * Returns whether a mod is available and installed.
+     *
+     * @param modId The mod's ID.
+     * @returns If the mod is available (or the `overrideFrameworkChecks` flag is set). You should probably abort initialisation if false is returned.
+     * @deprecated since v7.0.0, use `controller.smf.modIsInstalled`
+     */
+    public modIsInstalled(modId: string): boolean {
+        log(LogLevel.WARN, "controller.modIsInstalled is deprecated, use controller.smf.modIsInstalled instead!", "plugins")
+        return this.smf.modIsInstalled(modId)
+    }
+
+    /**
      * Starts the service and loads in all contracts.
      *
      * @throws {Error} If all hope is lost. (In theory, this should never happen)


### PR DESCRIPTION
Adds back the `addClientSideModDependency` and `modIsInstalled` to `controller` instance with an explicit deprecation warning in console and an path to intended API.

Reasoning provided in [Discord](https://discord.com/channels/826809653181808651/837776581694193754/1225778610363826208);

> Imma be honest, "months" is a very small timeframe and the way it currently handles breaking change is not very obvious to plugin developers. I'm all for better API, but breaking changes like that seem excessive.
My proposal woudl be to bring those back with one of:
> * Log a warning about deprecation (and show intended API), but retain bad behavior.
> * Log an error about deprecation and always return not installed
> * Throw an error with more descriptive message pointing at the right API.
>
> Not saying to keep it indefinitely, but at least provide a better window to spot the deprecation issue.