### PR TITLE
Change image paths of certain escalation challenges

### DIFF
--- a/contractdata/BERLIN/_BERLIN_CHALLENGES.json
+++ b/contractdata/BERLIN/_BERLIN_CHALLENGES.json
@@ -2700,7 +2700,7 @@
                 {
                     "Id": "54ddadb4-edc7-47eb-a442-9c9536626168",
                     "Name": "UI_PEACOCK_SHANGRILA",
-                    "ImageName": "images/contracts/escalation/contractescalation-shangrila.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_shangrila.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/DARTMOOR/_DARTMOOR_CHALLENGES.json
+++ b/contractdata/DARTMOOR/_DARTMOOR_CHALLENGES.json
@@ -4590,7 +4590,7 @@
                 {
                     "Id": "2934a0ea-8e0a-4aee-bc38-f3a015274746",
                     "Name": "UI_PEACOCK_ROSEBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_rosebush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_rosebush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/MENDOZA/_MENDOZA_CHALLENGES.json
+++ b/contractdata/MENDOZA/_MENDOZA_CHALLENGES.json
@@ -4126,7 +4126,7 @@
                 {
                     "Id": "22461270-6adf-4ce3-9e1f-c288e0671d36",
                     "Name": "UI_PEACOCK_GRAPEBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_grapebush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_grapebush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000
@@ -4169,7 +4169,7 @@
                 {
                     "Id": "6c29c2b8-3c1e-456c-98f3-132ec0e136c3",
                     "Name": "UI_PEACOCK_YANNINI_YEARNING",
-                    "ImageName": "images/contracts/escalation/contractescalation-yannini-yearning.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_yannini_yearning.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/MUMBAI/_H2_MUMBAI_CHALLENGES.json
+++ b/contractdata/MUMBAI/_H2_MUMBAI_CHALLENGES.json
@@ -4360,7 +4360,7 @@
                 {
                     "Id": "15dc9912-c734-4993-a40c-97e7cfd558bb",
                     "Name": "UI_PEACOCK_KHAKIASP_DOCUMENTATION",
-                    "ImageName": "images/contracts/escalation/contractescalation_khakiasp_documentation.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_khakiasp_documentation.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/MUMBAI/_MUMBAI_CHALLENGES.json
+++ b/contractdata/MUMBAI/_MUMBAI_CHALLENGES.json
@@ -4596,7 +4596,7 @@
                 {
                     "Id": "15dc9912-c734-4993-a40c-97e7cfd558bb",
                     "Name": "UI_PEACOCK_KHAKIASP_DOCUMENTATION",
-                    "ImageName": "images/contracts/escalation/contractescalation_khakiasp_documentation.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_khakiasp_documentation.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/NEWYORK/_H2_NEWYORK_CHALLENGES.json
+++ b/contractdata/NEWYORK/_H2_NEWYORK_CHALLENGES.json
@@ -2335,7 +2335,7 @@
                 {
                     "Id": "40350248-2cd9-4203-aa0b-156e711bb1b3",
                     "Name": "UI_PEACOCK_HEDGEBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_hedgebush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_hedgebush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/NEWYORK/_NEWYORK_CHALLENGES.json
+++ b/contractdata/NEWYORK/_NEWYORK_CHALLENGES.json
@@ -2417,7 +2417,7 @@
                 {
                     "Id": "40350248-2cd9-4203-aa0b-156e711bb1b3",
                     "Name": "UI_PEACOCK_HEDGEBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_hedgebush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_hedgebush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/SAPIENZA/_H2_SAPIENZA_CHALLENGES.json
+++ b/contractdata/SAPIENZA/_H2_SAPIENZA_CHALLENGES.json
@@ -7535,7 +7535,7 @@
                 {
                     "Id": "bc3b5d91-55f5-49d0-8e71-ddbbbda337e4",
                     "Name": "UI_PEACOCK_BLUEBERRYBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_blueberrybush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_blueberrybush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000
@@ -7750,7 +7750,7 @@
                 {
                     "Id": "9d0b6ae7-381d-4494-a1c3-81e722704c83",
                     "Name": "UI_PEACOCK_SATANTA",
-                    "ImageName": "images/contracts/escalation/contractescalation-author-satanta.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_satanta.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000
@@ -7965,7 +7965,7 @@
                 {
                     "Id": "d9d8953b-1493-400a-b90c-5288fc7d51a1",
                     "Name": "UI_PEACOCK_ROCCO",
-                    "ImageName": "images/contracts/escalation/contractescalation_rocco.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_rocco.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/SAPIENZA/_SAPIENZA_CHALLENGES.json
+++ b/contractdata/SAPIENZA/_SAPIENZA_CHALLENGES.json
@@ -7772,7 +7772,7 @@
                 {
                     "Id": "bc3b5d91-55f5-49d0-8e71-ddbbbda337e4",
                     "Name": "UI_PEACOCK_BLUEBERRYBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_blueberrybush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_blueberrybush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000
@@ -7987,7 +7987,7 @@
                 {
                     "Id": "9d0b6ae7-381d-4494-a1c3-81e722704c83",
                     "Name": "UI_PEACOCK_SATANTA",
-                    "ImageName": "images/contracts/escalation/contractescalation-author-satanta.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_satanta.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000
@@ -8202,7 +8202,7 @@
                 {
                     "Id": "d9d8953b-1493-400a-b90c-5288fc7d51a1",
                     "Name": "UI_PEACOCK_ROCCO",
-                    "ImageName": "images/contracts/escalation/contractescalation_rocco.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_rocco.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/WHITTLETON/_H2_WHITTLETON_CHALLENGES.json
+++ b/contractdata/WHITTLETON/_H2_WHITTLETON_CHALLENGES.json
@@ -4161,7 +4161,7 @@
                 {
                     "Id": "5859d182-9798-4d50-86e1-5864f37ed809",
                     "Name": "UI_PEACOCK_THORNBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_thornbush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_thornbush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000

--- a/contractdata/WHITTLETON/_WHITTLETON_CHALLENGES.json
+++ b/contractdata/WHITTLETON/_WHITTLETON_CHALLENGES.json
@@ -4648,7 +4648,7 @@
                 {
                     "Id": "5859d182-9798-4d50-86e1-5864f37ed809",
                     "Name": "UI_PEACOCK_THORNBUSH",
-                    "ImageName": "images/contracts/escalation/contractescalation_thornbush.png",
+                    "ImageName": "images/contracts/escalation/contractescalation_thornbush.jpg",
                     "Description": "UI_CHALLENGES_ESCLATION_COMPLETE_DESC",
                     "Rewards": {
                         "MasteryXP": 4000


### PR DESCRIPTION
I was wondering why it'd still download old `.png` images with PR #347 merged. It turns out the paths here haven't been changed.