### PR TITLE
Fix #437

### DIFF
--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -194,6 +194,7 @@ export abstract class ChallengeRegistry {
     ): void {
         const gameChallenges = this.groupContents[gameVersion]
         challenge.inGroup = groupId
+        challenge.inLocation = location
         this.challenges[gameVersion].set(challenge.Id, challenge)
 
         if (!gameChallenges.has(location)) {
@@ -244,7 +245,7 @@ export abstract class ChallengeRegistry {
         return (
             this.challenges[gameVersion].delete(challengeId) &&
             this.groupContents[gameVersion]
-                .get(challenge.ParentLocationId)!
+                .get(challenge.inLocation!)!
                 .get(challenge.inGroup!)!
                 .delete(challengeId)
         )
@@ -1243,7 +1244,7 @@ export class ChallengeService extends ChallengeRegistry {
 
                 const groupData = this.getGroupByIdLoc(
                     groupId,
-                    challenges[0].ParentLocationId,
+                    challenges[0].inLocation!,
                     gameVersion,
                 )
 

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -1378,9 +1378,19 @@ export interface RegistryChallenge extends SavedChallenge {
     /**
      * Warning: this property is INTERNAL and should NOT BE SPECIFIED by API users.
      *
+     * The parent challenge group this challenge belongs to.
+     *
      * @internal
      */
     inGroup?: string
+    /**
+     * Warning: this property is INTERNAL and should NOT BE SPECIFIED by API users.
+     *
+     * The location ID this challenge belongs to, may mismatch ParentLocationId field.
+     *
+     * @internal
+     */
+    inLocation?: string
 }
 
 /**


### PR DESCRIPTION
## Scope

This PR fixed #437 by introducing an `inLocation` field along with `inGroup` field. This fixes ability to remove global challenges, as their `ParentLocationId` is `""`, not their virtual location scope.
As a consequence it fixes the challenge packs where first registered challenge is a global challenge.

This PR can be safely cherry-picked to v7, as it's a fix intended for plugin developers.

## Checklist

-   [x] I have run Prettier to reformat any changed files
-   [x] I have verified my changes work
