### PR TITLE
Print stacktrace for uncaught errors in plugins

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -1106,8 +1106,13 @@ export class Controller {
 
             await (plugin as (controller: Controller) => Promise<void>)(this)
         } catch (e) {
-            log(LogLevel.ERROR, `Error while evaluating plugin ${pluginName}!`)
-            log(LogLevel.ERROR, e)
+            log(
+                LogLevel.ERROR,
+                `Error while evaluating plugin ${pluginName}!`,
+                "plugins",
+            )
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            log(LogLevel.ERROR, (e as any)?.stack ?? e, "plugins")
         }
     }
 


### PR DESCRIPTION
There have been a few people trying to make plugins recently that are (I assume) beginning coders, posting some errors with their plugins.
Currently, we only print `Error while evaluating plugin`, and the error message, which is not super helpful.

This PR changes that to include a stack trace for the error.
Example:
![example1](https://github.com/thepeacockproject/Peacock/assets/1353729/d53971a6-3eae-4bea-9539-b2648a02f6ff)

I thought about trimming the stack trace to only call sites in the plugin, but I'm not sure if that's a good idea.