### PR TITLE
fix: hokkaido and haven default suit unlockable

### DIFF
--- a/components/utils.ts
+++ b/components/utils.ts
@@ -559,7 +559,9 @@ export function attainableDefaults(gameVersion: GameVersion): string[] {
     } else {
         return [
             "TOKEN_OUTFIT_GREENLAND_HERO_TRAININGSUIT",
+            "TOKEN_OUTFIT_HOKKAIDO_HERO_HOKKAIDOSUIT",
             "TOKEN_OUTFIT_WET_SUIT",
+            "TOKEN_OUTFIT_OPULENT_HERO_OPULENTSUIT",
             "TOKEN_OUTFIT_HERO_DUGONG_SUIT",
         ]
     }

--- a/static/StashpointTemplate.json
+++ b/static/StashpointTemplate.json
@@ -435,12 +435,6 @@
                                                                                 },
                                                                                 "do": {
                                                                                     "$if ": {
-                                                                                        "$condition": {
-                                                                                            "$or": [
-                                                                                                "$not $eqs ($.Item.Unlockable.Id,TOKEN_OUTFIT_WET_SUIT)",
-                                                                                                "$not $eqs ($arg location,LOCATION_NEWZEALAND)"
-                                                                                            ]
-                                                                                        },
                                                                                         "$then": {
                                                                                             "$mergeobjects": [
                                                                                                 {

--- a/static/StashpointTemplate.json
+++ b/static/StashpointTemplate.json
@@ -435,6 +435,12 @@
                                                                                 },
                                                                                 "do": {
                                                                                     "$if ": {
+                                                                                        "$condition": {
+                                                                                            "$or": [
+                                                                                                "$not $eqs ($.Item.Unlockable.Id,TOKEN_OUTFIT_NEWZEALAND_HERO_NEWZEALANDSUIT)",
+                                                                                                "$not $eqs ($arg location,LOCATION_NEWZEALAND)"
+                                                                                            ]
+                                                                                        },
                                                                                         "$then": {
                                                                                             "$mergeobjects": [
                                                                                                 {


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->

- [x] Fix #442 . But cannot figure out why Tactical Wetsuit can be unlocked but can only be accessible everywhere but in Hawke's.
- [ ] May close #469 . For reviewers: please check if the violating way is acceptable.

## Test Plan

<!-- List how you have verified these changes work as intended. -->

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

-   [x] I have run Prettier to reformat any changed files
-   [x] I have verified my changes work
