### PR TITLE
Fix: ambergris complication

### DIFF
--- a/contractdata/ARCADE/AMBERGRIS/AMBERGRIS.json
+++ b/contractdata/ARCADE/AMBERGRIS/AMBERGRIS.json
@@ -19,7 +19,7 @@
         "CreatorUserId": "fadb923c-e6bb-4283-a537-eb4d1150262e",
         "TileImage": "images/contracts/arcade/Arcade_Ambergris_Group.jpg",
         "Title": "UI_PEACOCK_AMBERGRIS",
-        "Description": "UI_CONTRACT_LEMON_GROUP_DESC",
+        "Description": "UI_CONTRACT_NECTARINE_GROUP_DESC",
         "CodeName_Hint": "[PEACOCK] Arcade Ambergris - Group",
         "Location": "LOCATION_NORTHAMERICA",
         "ScenePath": "assembly:/_pro/scenes/missions/skunk/scene_skunk.entity",

--- a/contractdata/ARCADE/AMBERGRIS/AMBERGRIS1.json
+++ b/contractdata/ARCADE/AMBERGRIS/AMBERGRIS1.json
@@ -41,7 +41,7 @@
                 ]
             }
         ],
-        "GameChangers": ["1efef5c0-7381-4e22-ac04-ffbd0822cc96"]
+        "GameChangers": ["98223196-71ea-60c3-962c-b856ee8cc2e7"]
     },
     "Metadata": {
         "Id": "039aa9fc-d5b0-5ae6-2eb1-940d7da1a6f1",
@@ -58,7 +58,7 @@
         "Entitlements": ["LOCATION_GOLDEN"],
         "InGroup": "27e54c45-d5e8-fe2e-6f6c-f3e3d8239f46",
         "GroupObjectiveDisplayOrder": [
-            { "Id": "1efef5c0-7381-4e22-ac04-ffbd0822cc96", "IsNew": true },
+            { "Id": "98223196-71ea-60c3-962c-b856ee8cc2e7", "IsNew": true },
             { "Id": "7eabd1c9-bf88-4d96-86f1-ea089492414c" }
         ],
         "LastUpdate": "2024-06-29T07:21:06.758Z"

--- a/contractdata/ARCADE/AMBERGRIS/AMBERGRIS2.json
+++ b/contractdata/ARCADE/AMBERGRIS/AMBERGRIS2.json
@@ -5,7 +5,7 @@
             "assembly:/_pro/scenes/missions/wet/elusive_redsnapper.brick"
         ],
         "DevOnlyBricks": [],
-        "GameChangers": ["1efef5c0-7381-4e22-ac04-ffbd0822cc96"],
+        "GameChangers": ["98223196-71EA-60c3-962c-b856ee8cc2e7"],
         "VR": [
             {
                 "Quality": "base",
@@ -62,7 +62,7 @@
         "Entitlements": ["LOCATION_WET"],
         "InGroup": "27e54c45-d5e8-fe2e-6f6c-f3e3d8239f46",
         "GroupObjectiveDisplayOrder": [
-            { "Id": "1efef5c0-7381-4e22-ac04-ffbd0822cc96" },
+            { "Id": "98223196-71EA-60c3-962c-b856ee8cc2e7" },
             { "Id": "9acf0918-a05d-41e8-8721-03293a99d5a1" }
         ],
         "LastUpdate": "2024-06-29T07:21:06.758Z"

--- a/contractdata/ARCADE/AMBERGRIS/AMBERGRIS3.json
+++ b/contractdata/ARCADE/AMBERGRIS/AMBERGRIS3.json
@@ -197,7 +197,7 @@
             }
         ],
         "Bricks": [],
-        "GameChangers": ["1efef5c0-7381-4e22-ac04-ffbd0822cc96"]
+        "GameChangers": ["98223196-71EA-60c3-962c-b856ee8cc2e7"]
     },
     "Metadata": {
         "Id": "27977fd9-732a-18b7-d986-a416ffbc19d5",
@@ -216,7 +216,7 @@
         "Entitlements": ["LOCATION_GOLDEN"],
         "InGroup": "27e54c45-d5e8-fe2e-6f6c-f3e3d8239f46",
         "GroupObjectiveDisplayOrder": [
-            { "Id": "1efef5c0-7381-4e22-ac04-ffbd0822cc96" },
+            { "Id": "98223196-71EA-60c3-962c-b856ee8cc2e7" },
             { "Id": "c12bb13e-f20d-406f-be39-bcab179ea3d5" },
             { "Id": "f965e220-bfe0-4b2f-8c47-40472dedfbd6" }
         ],

--- a/contractdata/ARCADE/KASTURI/KASTURI.json
+++ b/contractdata/ARCADE/KASTURI/KASTURI.json
@@ -19,7 +19,7 @@
         "CreatorUserId": "fadb923c-e6bb-4283-a537-eb4d1150262e",
         "TileImage": "images/contracts/arcade/Arcade_Kasturi_Group.jpg",
         "Title": "UI_PEACOCK_KASTURI",
-        "Description": "UI_CONTRACT_LEMON_GROUP_DESC",
+        "Description": "UI_CONTRACT_NECTARINE_GROUP_DESC",
         "CodeName_Hint": "[PEACOCK] Arcade Kasturi - Group",
         "Location": "LOCATION_EDGY_FOX",
         "ScenePath": "assembly:/_pro/scenes/missions/edgy/mission_fox/scene_fox_tomorrowland.entity",

--- a/resources/locale.json
+++ b/resources/locale.json
@@ -273,6 +273,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -552,6 +553,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -830,6 +832,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -1114,6 +1117,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -1393,6 +1397,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -1671,6 +1676,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -1949,6 +1955,7 @@
         "UI_PEACOCK_AMBERGRIS1": "嗜血者 - 第1关",
         "UI_PEACOCK_AMBERGRIS2": "嗜血者 - 第2关",
         "UI_PEACOCK_AMBERGRIS3": "嗜血者 - 第3关",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "仅限头部攻击",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "必须使用爆头或投掷致命近战武器消灭所有目标。",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "消灭“嗜血者”",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>消灭组成“嗜血者”的全部行踪不定的目标。</li>"
@@ -2227,6 +2234,7 @@
         "UI_PEACOCK_AMBERGRIS1": "血腥狂人——關卡1",
         "UI_PEACOCK_AMBERGRIS2": "血腥狂人——關卡2",
         "UI_PEACOCK_AMBERGRIS3": "血腥狂人——關卡3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "僅頭部攻擊",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "所有目標都必須透過爆頭或投擲致命的近戰武器的方式來消滅。",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "消滅血腥狂人",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>消滅組成血腥狂人的所有隱密目標。</li>"
@@ -2505,6 +2513,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -2784,6 +2793,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -3021,6 +3031,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
@@ -3297,6 +3308,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"

--- a/resources/locale.json
+++ b/resources/locale.json
@@ -273,6 +273,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -551,6 +552,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -828,6 +830,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -1111,6 +1114,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -1389,6 +1393,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -1666,6 +1671,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -1943,6 +1949,7 @@
         "UI_PEACOCK_AMBERGRIS1": "嗜血者 - 第1关",
         "UI_PEACOCK_AMBERGRIS2": "嗜血者 - 第2关",
         "UI_PEACOCK_AMBERGRIS3": "嗜血者 - 第3关",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "必须使用爆头或投掷致命近战武器消灭所有目标。",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "消灭“嗜血者”",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>消灭组成“嗜血者”的全部行踪不定的目标。</li>"
     },
@@ -2207,19 +2214,20 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_NAME": "美食誘惑",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_DESC": "完成屠夫之樂的所有挑戰。<li>磨練切肉技能</li><li>骨頭味道如何？</li><li>離開醃料</li><li>淬火鉤</li><li>晚餐準備好了！</li>",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_SAPIENZACLEAVERKILL_NAME": "磨練切肉技能",
-        "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_SAPIENZACLEAVERKILL_DESC": "<li>在羅馬大學使用偽裝成廚房助理的切肉刀消滅目標。</li><li>不要被發現。</li>",
+        "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_SAPIENZACLEAVERKILL_DESC": "<li>在羅馬大學使用偽裝成廚房助理的切肉刀來消滅目標。</li><li>不要被發現。</li>",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_SANTAFORTUNABONEPACIFY_NAME": "骨頭味道如何？",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_SANTAFORTUNABONEPACIFY_DESC": "<li>在聖福爾圖納用肉骨擊暈布萊爾·雷丁頓。</li><li>完成任務。</li>",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_CHONGQINGMARINATE_NAME": "離開醃料",
-        "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_CHONGQINGMARINATE_DESC": "<li>在重慶裝扮成餃子師傅用毒藥消滅一個目標。</li><li>將目標的身體浸入水中。</li>",
+        "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_CHONGQINGMARINATE_DESC": "<li>在重慶裝扮成餃子師傅用毒藥來消滅一個目標。</li><li>將目標的身體浸入水中。</li>",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_AMBROSEHOOK_NAME": "淬火鉤",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_AMBROSEHOOK_DESC": "<li>在安布羅斯島透過燒死卡爾頓·史密斯來消滅他，並用鉤子消滅他的獄友。</li><li>啟動淋浴。</li>",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "晚餐準備好了！",
-        "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>重新安排會議並封鎖杜拜的會議室。</li><li>用煎鍋擊暈卡爾·英格拉姆和馬庫斯·史岱文森。</li><li>完成任務。</li>",
+        "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>重新安排會議並封鎖杜拜的會議室。</li><li>用煎鍋擊暈卡爾·英格倫和馬克斯·史岱文森。</li><li>完成任務。</li>",
         "UI_PEACOCK_AMBERGRIS": "血腥狂人",
         "UI_PEACOCK_AMBERGRIS1": "血腥狂人——關卡1",
         "UI_PEACOCK_AMBERGRIS2": "血腥狂人——關卡2",
         "UI_PEACOCK_AMBERGRIS3": "血腥狂人——關卡3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "所有目標都必須透過爆頭或投擲致命的近戰武器的方式來消滅。",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "消滅血腥狂人",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>消滅組成血腥狂人的所有隱密目標。</li>"
     },
@@ -2497,6 +2505,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -2775,6 +2784,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -3011,6 +3021,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     },
@@ -3286,6 +3297,7 @@
         "UI_PEACOCK_AMBERGRIS1": "The Bloodlusts - Level 1",
         "UI_PEACOCK_AMBERGRIS2": "The Bloodlusts - Level 2",
         "UI_PEACOCK_AMBERGRIS3": "The Bloodlusts - Level 3",
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_NAME": "Eliminate The Bloodlusts",
         "UI_PEACOCK_AMBERGRIS_COMPLETED_DESC": "<li>Eliminate all Elusive Targets that are part of The Bloodlusts.</li>"
     }

--- a/static/PeacockGameChangerProperties.json
+++ b/static/PeacockGameChangerProperties.json
@@ -206,5 +206,69 @@
                 }
             }
         ]
+    },
+    "98223196-71ea-60c3-962c-b856ee8cc2e7": {
+        "Name": "UI_GAMECHANGERS_GLOBAL_CONTRACTCONDITION_HEADSHOTS_ONLY_SECONDARY_NAME",
+        "Description": "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC",
+        "Icon": null,
+        "IsHidden": null,
+        "TileImage": "images/contractconditions/condition_contrac_headshots_only.jpg",
+        "ObjectivesCategory": "primary",
+        "Resource": [],
+        "Objectives": [
+            {
+                "Id": "0b4e7a06-c544-987a-e0bd-8f6ad23406a4",
+                "Category": "secondary",
+                "AllowEtRestartOnSuccess": true,
+                "BriefingText": "$loc UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC",
+                "HUDTemplate": {
+                    "display": "$loc UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC",
+                    "iconType": 17
+                },
+                "Type": "statemachine",
+                "Definition": {
+                    "Scope": "session",
+                    "States": {
+                        "Start": {
+                            "-": {
+                                "Transition": "Success"
+                            }
+                        },
+                        "Success": {
+                            "Kill": {
+                                "Condition": {
+                                    "$and": [
+                                        {
+                                            "$eq": ["$Value.IsTarget", true]
+                                        },
+                                        {
+                                            "$not": {
+                                                "$or": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillMethodBroad",
+                                                            "throw"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.IsHeadshot",
+                                                            true
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Transition": "Failure"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "ShowBasedOnObjectives": null,
+        "IsPrestigeObjective": null
     }
 }

--- a/static/PeacockGameChangerProperties.json
+++ b/static/PeacockGameChangerProperties.json
@@ -208,7 +208,7 @@
         ]
     },
     "98223196-71ea-60c3-962c-b856ee8cc2e7": {
-        "Name": "UI_GAMECHANGERS_GLOBAL_CONTRACTCONDITION_HEADSHOTS_ONLY_SECONDARY_NAME",
+        "Name": "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME",
         "Description": "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC",
         "Icon": null,
         "IsHidden": null,


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->

* [x] Create a new complication for `ambergris`: **head attacks only**, which requires players to kill a target only with headshot or lethal throw.
* [x] Change the descriptions of our two exclusive arcades, which formerly reads "Three level Arcade contract containing HITMAN 3 Elusive Targets" and now "...containing Elusive Targets from across the Trilogy".

## Test Plan

<!-- List how you have verified these changes work as intended. -->

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

-   [x] I have run Prettier to reformat any changed files
-   [x] I have verified my changes work
