### PR TITLE
Fix Part One users having access to Evergreen through the destination tile in the dashboard

### DIFF
--- a/static/EiderDashboard.json
+++ b/static/EiderDashboard.json
@@ -340,29 +340,10 @@
                 "actions": {
                     "accept": [
                         {
-                            "set-menu-context": {
-                                "value": {
-                                    "onpageopened": {
-                                        "set-selected": {
-                                            "target": "PLANNING_BUTTON_PLAY"
-                                        },
-                                        "trigger-input": {
-                                            "action": "accept"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
                             "link": {
-                                "page": "planning",
+                                "page": "gamemode_evergreen",
                                 "args": {
-                                    "url": "planning",
-                                    "args": {
-                                        "contractid": "f8ec92c2-4fa2-471e-ae08-545480c746ee",
-                                        "resetescalation": false
-                                    },
-                                    "contractid": "f8ec92c2-4fa2-471e-ae08-545480c746ee"
+                                    "locationId": "LOCATION_PARENT_SNUG"
                                 }
                             }
                         }
@@ -388,15 +369,6 @@
                         "replace-children": {
                             "target": "headline_container",
                             "children": []
-                        }
-                    },
-                    "actiony": {
-                        "prompt_label": "$loc UI_PEACOCK_GO_TO_DESTINATION",
-                        "link": {
-                            "page": "gamemode_evergreen",
-                            "args": {
-                                "locationId": "LOCATION_PARENT_SNUG"
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

If you're using Part One with the latest version of Peacock (7.3.1) and you click on the Freelancer game mode tile in the dashboard, it lets you play Freelancer freely without any restrictions with all Hitman 2 and 3 locations working.
This fixes that. 

I just changed the tile to redirect to the locations page instead of the planning page, just like what pressing "Freelancer" in the game modes tab does.

I also removed the "auto-click" but I can add that back if the maintainers want to keep that.

## Test Plan

Made my changes, ran `yarn run-dev` and checked that the game wasn't letting me play Freelancer through the dashboard tile anymore.

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

-   [x] I have run Prettier to reformat any changed files
-   [x] I have verified my changes work
