### PR TITLE
fix: restore wrapper of challenge pack for separate locations

### DIFF
--- a/contractdata/AMBROSE/_AMBROSE_CHALLENGES.json
+++ b/contractdata/AMBROSE/_AMBROSE_CHALLENGES.json
@@ -3184,6 +3184,97 @@
             "OrderIndex": 6.1,
             "Challenges": [
                 {
+                    "Id": "0e08ee97-8f70-c82e-f04a-9d2cd60ae5b5",
+                    "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackCheesecake/tile.jpg",
+                    "Description": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_HERO_BUTCHER_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_CHEESECAKE",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 100000,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0570b6e5-3c27-e715-042a-59313b0a0916",
+                                "15dfb94e-72cc-9f43-5281-a0f7e5180f24",
+                                "eff06c02-2410-4226-1abc-076a2e71ee97",
+                                "b5386255-0e7e-2bd7-6c28-c1096d4902c5",
+                                "c098a7cf-8c49-02ce-475e-20beaed99712"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["cheesecake-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "179563a4-727a-4072-b354-c9fff4e8bff0",
+                            "b2aac100-dfc7-4f85-b9cd-528114436f6c"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_COASTALTOWN",
+                            "LOCATION_COASTALTOWN_NIGHT",
+                            "LOCATION_COASTALTOWN_MOVIESET",
+                            "LOCATION_WET",
+                            "LOCATION_GOLDEN"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "b5386255-0e7e-2bd7-6c28-c1096d4902c5",
                     "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_AMBROSEHOOK_NAME",
                     "ImageName": "images/challenges/categories/packcheesecake/cheesecake_ambrosehook.jpg",

--- a/contractdata/BANGKOK/_BANGKOK_CHALLENGES.json
+++ b/contractdata/BANGKOK/_BANGKOK_CHALLENGES.json
@@ -6004,6 +6004,97 @@
             "OrderIndex": 6.5,
             "Challenges": [
                 {
+                    "Id": "eca7ab97-c312-4d71-81ce-45146dd19123",
+                    "Name": "CHALLENGEPACK_ARGENTUM_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackArgentum/Argentum_Wrapper.jpg",
+                    "Description": "CHALLENGEPACK_ARGENTUM_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_REWARD_HERO_LEGACY47_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_ARGENTUM",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 1,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "f8ba2bd3-dcd7-453f-aa64-c0ed6992e24b",
+                                "86e11742-f0e6-4594-b914-9ab0d8f7ab1b",
+                                "5b943968-7142-406e-bd6c-9b9018554667",
+                                "2b9f479e-6789-4f23-9eef-e17f268a2b11",
+                                "1bcab2a7-626e-4bf2-a9af-7adb823cdd4a"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["argentum-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "ebcd14b2-0786-4ceb-a2a4-e771f60d0125",
+                            "a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_WET_RAT",
+                            "LOCATION_COLOMBIA",
+                            "LOCATION_COLOMBIA_ANACONDA",
+                            "LOCATION_BANGKOK",
+                            "LOCATION_BANGKOK_ZIKA"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "5b943968-7142-406e-bd6c-9b9018554667",
                     "Name": "CHALLENGEPACK_ARGENTUM_TIGERDROWNER_NAME",
                     "ImageName": "images/challenges/Categories/PackArgentum/Argentum_TigerDrowner.jpg",

--- a/contractdata/BERLIN/_BERLIN_CHALLENGES.json
+++ b/contractdata/BERLIN/_BERLIN_CHALLENGES.json
@@ -4116,6 +4116,97 @@
             "OrderIndex": 6.5,
             "Challenges": [
                 {
+                    "Id": "eca7ab97-c312-4d71-81ce-45146dd19123",
+                    "Name": "CHALLENGEPACK_ARGENTUM_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackArgentum/Argentum_Wrapper.jpg",
+                    "Description": "CHALLENGEPACK_ARGENTUM_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_REWARD_HERO_LEGACY47_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_ARGENTUM",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 1,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "f8ba2bd3-dcd7-453f-aa64-c0ed6992e24b",
+                                "86e11742-f0e6-4594-b914-9ab0d8f7ab1b",
+                                "5b943968-7142-406e-bd6c-9b9018554667",
+                                "2b9f479e-6789-4f23-9eef-e17f268a2b11",
+                                "1bcab2a7-626e-4bf2-a9af-7adb823cdd4a"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["argentum-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "ebcd14b2-0786-4ceb-a2a4-e771f60d0125",
+                            "a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_WET_RAT",
+                            "LOCATION_COLOMBIA",
+                            "LOCATION_COLOMBIA_ANACONDA",
+                            "LOCATION_BANGKOK",
+                            "LOCATION_BANGKOK_ZIKA"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "2b9f479e-6789-4f23-9eef-e17f268a2b11",
                     "Name": "CHALLENGEPACK_ARGENTUM_FOXEXPLODER_NAME",
                     "ImageName": "images/challenges/Categories/PackArgentum/Argentum_FoxExploder.jpg",

--- a/contractdata/CARPATHIAN/_CARPATHIAN_CHALLENGES.json
+++ b/contractdata/CARPATHIAN/_CARPATHIAN_CHALLENGES.json
@@ -1740,6 +1740,97 @@
             "OrderIndex": 6.5,
             "Challenges": [
                 {
+                    "Id": "eca7ab97-c312-4d71-81ce-45146dd19123",
+                    "Name": "CHALLENGEPACK_ARGENTUM_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackArgentum/Argentum_Wrapper.jpg",
+                    "Description": "CHALLENGEPACK_ARGENTUM_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_REWARD_HERO_LEGACY47_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_ARGENTUM",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 1,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "f8ba2bd3-dcd7-453f-aa64-c0ed6992e24b",
+                                "86e11742-f0e6-4594-b914-9ab0d8f7ab1b",
+                                "5b943968-7142-406e-bd6c-9b9018554667",
+                                "2b9f479e-6789-4f23-9eef-e17f268a2b11",
+                                "1bcab2a7-626e-4bf2-a9af-7adb823cdd4a"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["argentum-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "ebcd14b2-0786-4ceb-a2a4-e771f60d0125",
+                            "a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_WET_RAT",
+                            "LOCATION_COLOMBIA",
+                            "LOCATION_COLOMBIA_ANACONDA",
+                            "LOCATION_BANGKOK",
+                            "LOCATION_BANGKOK_ZIKA"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "1bcab2a7-626e-4bf2-a9af-7adb823cdd4a",
                     "Name": "CHALLENGEPACK_ARGENTUM_WOLVERINEFINISHER_NAME",
                     "ImageName": "images/challenges/Categories/PackArgentum/Argentum_WolverineFinisher.jpg",

--- a/contractdata/CHONGQING/_CHONGQING_CHALLENGES.json
+++ b/contractdata/CHONGQING/_CHONGQING_CHALLENGES.json
@@ -4331,6 +4331,97 @@
             "OrderIndex": 6.5,
             "Challenges": [
                 {
+                    "Id": "eca7ab97-c312-4d71-81ce-45146dd19123",
+                    "Name": "CHALLENGEPACK_ARGENTUM_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackArgentum/Argentum_Wrapper.jpg",
+                    "Description": "CHALLENGEPACK_ARGENTUM_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_REWARD_HERO_LEGACY47_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_ARGENTUM",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 1,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "f8ba2bd3-dcd7-453f-aa64-c0ed6992e24b",
+                                "86e11742-f0e6-4594-b914-9ab0d8f7ab1b",
+                                "5b943968-7142-406e-bd6c-9b9018554667",
+                                "2b9f479e-6789-4f23-9eef-e17f268a2b11",
+                                "1bcab2a7-626e-4bf2-a9af-7adb823cdd4a"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["argentum-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "ebcd14b2-0786-4ceb-a2a4-e771f60d0125",
+                            "a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_WET_RAT",
+                            "LOCATION_COLOMBIA",
+                            "LOCATION_COLOMBIA_ANACONDA",
+                            "LOCATION_BANGKOK",
+                            "LOCATION_BANGKOK_ZIKA"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "f8ba2bd3-dcd7-453f-aa64-c0ed6992e24b",
                     "Name": "CHALLENGEPACK_ARGENTUM_RATSNIPER_NAME",
                     "ImageName": "images/challenges/Categories/PackArgentum/Argentum_RatSniper.jpg",
@@ -4401,6 +4492,97 @@
             "Description": "",
             "OrderIndex": 6.1,
             "Challenges": [
+                {
+                    "Id": "0e08ee97-8f70-c82e-f04a-9d2cd60ae5b5",
+                    "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackCheesecake/tile.jpg",
+                    "Description": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_HERO_BUTCHER_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_CHEESECAKE",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 100000,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0570b6e5-3c27-e715-042a-59313b0a0916",
+                                "15dfb94e-72cc-9f43-5281-a0f7e5180f24",
+                                "eff06c02-2410-4226-1abc-076a2e71ee97",
+                                "b5386255-0e7e-2bd7-6c28-c1096d4902c5",
+                                "c098a7cf-8c49-02ce-475e-20beaed99712"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["cheesecake-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "179563a4-727a-4072-b354-c9fff4e8bff0",
+                            "b2aac100-dfc7-4f85-b9cd-528114436f6c"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_COASTALTOWN",
+                            "LOCATION_COASTALTOWN_NIGHT",
+                            "LOCATION_COASTALTOWN_MOVIESET",
+                            "LOCATION_WET",
+                            "LOCATION_GOLDEN"
+                        ],
+                        "GameModes": null
+                    }
+                },
                 {
                     "Id": "eff06c02-2410-4226-1abc-076a2e71ee97",
                     "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_CHONGQINGMARINATE_NAME",

--- a/contractdata/DUBAI/_DUBAI_CHALLENGES.json
+++ b/contractdata/DUBAI/_DUBAI_CHALLENGES.json
@@ -4217,6 +4217,97 @@
             "OrderIndex": 6.1,
             "Challenges": [
                 {
+                    "Id": "0e08ee97-8f70-c82e-f04a-9d2cd60ae5b5",
+                    "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackCheesecake/tile.jpg",
+                    "Description": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_HERO_BUTCHER_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_CHEESECAKE",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 100000,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0570b6e5-3c27-e715-042a-59313b0a0916",
+                                "15dfb94e-72cc-9f43-5281-a0f7e5180f24",
+                                "eff06c02-2410-4226-1abc-076a2e71ee97",
+                                "b5386255-0e7e-2bd7-6c28-c1096d4902c5",
+                                "c098a7cf-8c49-02ce-475e-20beaed99712"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["cheesecake-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "179563a4-727a-4072-b354-c9fff4e8bff0",
+                            "b2aac100-dfc7-4f85-b9cd-528114436f6c"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_COASTALTOWN",
+                            "LOCATION_COASTALTOWN_NIGHT",
+                            "LOCATION_COASTALTOWN_MOVIESET",
+                            "LOCATION_WET",
+                            "LOCATION_GOLDEN"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "c098a7cf-8c49-02ce-475e-20beaed99712",
                     "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME",
                     "ImageName": "images/challenges/categories/packcheesecake/cheesecake_dubaipanpacify.jpg",

--- a/contractdata/SANTAFORTUNA/_SANTAFORTUNA_CHALLENGES.json
+++ b/contractdata/SANTAFORTUNA/_SANTAFORTUNA_CHALLENGES.json
@@ -6035,6 +6035,97 @@
             "OrderIndex": 6.5,
             "Challenges": [
                 {
+                    "Id": "eca7ab97-c312-4d71-81ce-45146dd19123",
+                    "Name": "CHALLENGEPACK_ARGENTUM_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackArgentum/Argentum_Wrapper.jpg",
+                    "Description": "CHALLENGEPACK_ARGENTUM_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_REWARD_HERO_LEGACY47_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_ARGENTUM",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 1,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "f8ba2bd3-dcd7-453f-aa64-c0ed6992e24b",
+                                "86e11742-f0e6-4594-b914-9ab0d8f7ab1b",
+                                "5b943968-7142-406e-bd6c-9b9018554667",
+                                "2b9f479e-6789-4f23-9eef-e17f268a2b11",
+                                "1bcab2a7-626e-4bf2-a9af-7adb823cdd4a"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["argentum-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "ebcd14b2-0786-4ceb-a2a4-e771f60d0125",
+                            "a3e19d55-64a6-4282-bb3c-d18c3f3e6e29"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_WET_RAT",
+                            "LOCATION_COLOMBIA",
+                            "LOCATION_COLOMBIA_ANACONDA",
+                            "LOCATION_BANGKOK",
+                            "LOCATION_BANGKOK_ZIKA"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "86e11742-f0e6-4594-b914-9ab0d8f7ab1b",
                     "Name": "CHALLENGEPACK_ARGENTUM_HIPPOPACIFIER_NAME",
                     "ImageName": "images/challenges/Categories/PackArgentum/Argentum_HippoPacifier.jpg",
@@ -6098,6 +6189,97 @@
             "Description": "",
             "OrderIndex": 10000,
             "Challenges": [
+                {
+                    "Id": "0e08ee97-8f70-c82e-f04a-9d2cd60ae5b5",
+                    "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackCheesecake/tile.jpg",
+                    "Description": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_HERO_BUTCHER_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_CHEESECAKE",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 100000,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0570b6e5-3c27-e715-042a-59313b0a0916",
+                                "15dfb94e-72cc-9f43-5281-a0f7e5180f24",
+                                "eff06c02-2410-4226-1abc-076a2e71ee97",
+                                "b5386255-0e7e-2bd7-6c28-c1096d4902c5",
+                                "c098a7cf-8c49-02ce-475e-20beaed99712"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["cheesecake-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "179563a4-727a-4072-b354-c9fff4e8bff0",
+                            "b2aac100-dfc7-4f85-b9cd-528114436f6c"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_COASTALTOWN",
+                            "LOCATION_COASTALTOWN_NIGHT",
+                            "LOCATION_COASTALTOWN_MOVIESET",
+                            "LOCATION_WET",
+                            "LOCATION_GOLDEN"
+                        ],
+                        "GameModes": null
+                    }
+                },
                 {
                     "Id": "15dfb94e-72cc-9f43-5281-a0f7e5180f24",
                     "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_SANTAFORTUNABONEPACIFY_NAME",

--- a/contractdata/SAPIENZA/_SAPIENZA_CHALLENGES.json
+++ b/contractdata/SAPIENZA/_SAPIENZA_CHALLENGES.json
@@ -11467,6 +11467,97 @@
             "OrderIndex": 6.1,
             "Challenges": [
                 {
+                    "Id": "0e08ee97-8f70-c82e-f04a-9d2cd60ae5b5",
+                    "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_NAME",
+                    "ImageName": "images/challenges/Categories/PackCheesecake/tile.jpg",
+                    "Description": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_WRAPPER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 4000
+                    },
+                    "Drops": ["TOKEN_OUTFIT_HERO_BUTCHER_SUIT"],
+                    "IsPlayable": false,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_PACK_CHEESECAKE",
+                    "Icon": "challenge_category_feats",
+                    "LocationId": "",
+                    "ParentLocationId": "",
+                    "Type": "global",
+                    "DifficultyLevels": [],
+                    "OrderIndex": 100000,
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "profile",
+                        "Constants": {
+                            "RequiredChallenges": [
+                                "0570b6e5-3c27-e715-042a-59313b0a0916",
+                                "15dfb94e-72cc-9f43-5281-a0f7e5180f24",
+                                "eff06c02-2410-4226-1abc-076a2e71ee97",
+                                "b5386255-0e7e-2bd7-6c28-c1096d4902c5",
+                                "c098a7cf-8c49-02ce-475e-20beaed99712"
+                            ]
+                        },
+                        "Context": {
+                            "CompletedChallenges": []
+                        },
+                        "ContextListeners": {
+                            "CompletedChallenges": {
+                                "comparand": "$.RequiredChallenges",
+                                "type": "challengetree"
+                            }
+                        },
+                        "States": {
+                            "Start": {
+                                "ChallengeCompleted": [
+                                    {
+                                        "Condition": {
+                                            "$any": {
+                                                "?": {
+                                                    "$eq": [
+                                                        "$.#",
+                                                        "$Value.ChallengeId"
+                                                    ]
+                                                },
+                                                "in": "$.RequiredChallenges"
+                                            }
+                                        },
+                                        "$pushunique": [
+                                            "CompletedChallenges",
+                                            "$Value.ChallengeId"
+                                        ]
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "($.CompletedChallenges).Count",
+                                                "($.RequiredChallenges).Count"
+                                            ]
+                                        },
+                                        "Transition": "Success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Tags": ["cheesecake-pack", "story", "hard"],
+                    "InclusionData": {
+                        "ContractIds": [
+                            "179563a4-727a-4072-b354-c9fff4e8bff0",
+                            "b2aac100-dfc7-4f85-b9cd-528114436f6c"
+                        ],
+                        "ContractTypes": null,
+                        "Locations": [
+                            "LOCATION_COASTALTOWN",
+                            "LOCATION_COASTALTOWN_NIGHT",
+                            "LOCATION_COASTALTOWN_MOVIESET",
+                            "LOCATION_WET",
+                            "LOCATION_GOLDEN"
+                        ],
+                        "GameModes": null
+                    }
+                },
+                {
                     "Id": "0570b6e5-3c27-e715-042a-59313b0a0916",
                     "Name": "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_SAPIENZACLEAVERKILL_NAME",
                     "ImageName": "images/challenges/categories/packcheesecake/cheesecake_sapienzacleaverkill.jpg",


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->

fix #431 .

- [x] `argentum`
- [x] `argon` (it doesn't have that)
- [x] `cheesecake`

## Test Plan

<!-- List how you have verified these changes work as intended. -->

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

-   [x] I have run Prettier to reformat any changed files
-   [x] I have verified my changes work
