### PR TITLE
feat: Pro1 challenges, h6 & general mastery improvements

### DIFF
--- a/components/2016/legacyMenuData.ts
+++ b/components/2016/legacyMenuData.ts
@@ -33,6 +33,7 @@ legacyMenuDataRouter.get(
                 req.query.locationId,
                 req.gameVersion,
                 req.jwt.unique_name,
+                req.query.difficulty,
             )
 
         const location = getParentLocationByName(

--- a/components/2016/legacyProfileRouter.ts
+++ b/components/2016/legacyProfileRouter.ts
@@ -28,7 +28,7 @@ import { Router } from "express"
 import { controller } from "../controller"
 import { json as jsonMiddleware } from "body-parser"
 import { uuidRegex } from "../utils"
-import { compileRuntimeChallenge } from "../candle/challengeHelpers"
+import { compileRuntimeChallengeOnly } from "../candle/challengeHelpers"
 import { GetChallengeProgressionBody } from "../types/gameSchemas"
 
 const legacyProfileRouter = Router()
@@ -74,16 +74,8 @@ legacyProfileRouter.post(
                 ),
             )
                 .flat()
-                .map(
-                    (challengeData) =>
-                        compileRuntimeChallenge(
-                            challengeData,
-                            controller.challengeService.getPersistentChallengeProgression(
-                                req.jwt.unique_name,
-                                challengeData.Id,
-                                req.gameVersion,
-                            ),
-                        ).Challenge,
+                .map((challengeData) =>
+                    compileRuntimeChallengeOnly(challengeData),
                 ),
         )
 
@@ -155,7 +147,6 @@ legacyProfileRouter.post(
                 MustBeSaved: progression.MustBeSaved,
             })
         }
-        // TODO: HELP! Please DM rdil if you see this
 
         res.json(challenges)
     },

--- a/components/candle/challengeHelpers.ts
+++ b/components/candle/challengeHelpers.ts
@@ -18,6 +18,7 @@
 
 import {
     ChallengeProgressionData,
+    CompiledChallengeIngameData,
     CompiledChallengeRuntimeData,
     InclusionData,
     MissionManifest,
@@ -27,29 +28,47 @@ import { SavedChallengeGroup } from "../types/challenges"
 import { controller } from "../controller"
 import { gameDifficulty, isSniperLocation } from "../utils"
 
+/**
+ * Change a registry challenge to the runtime format (for GetActiveChallenges).
+ * @param challenge The challenge.
+ * @returns The runtime challenge.
+ * @see {@link compileRuntimeChallenge} for the modern variant with progression data.
+ */
+export function compileRuntimeChallengeOnly(
+    challenge: RegistryChallenge,
+): CompiledChallengeIngameData {
+    return {
+        Id: challenge.Id,
+        GroupId: challenge.inGroup,
+        Name: challenge.Name,
+        Type: challenge.RuntimeType || "contract",
+        Description: challenge.Description,
+        ImageName: challenge.ImageName,
+        InclusionData: challenge.InclusionData || undefined,
+        Definition: challenge.Definition,
+        Tags: challenge.Tags,
+        Drops: challenge.Drops,
+        LastModified: "2021-01-06T23:00:32.0117635", // this is a lie 👍
+        PlayableSince: null,
+        PlayableUntil: null,
+        Xp: challenge.Rewards.MasteryXP || 0,
+        XpModifier: challenge.XpModifier || {},
+    }
+}
+
+/**
+ * Change a registry challenge to the runtime format (for GetActiveChallengesAndProgression).
+ * @param challenge The challenge.
+ * @param progression The progression data.
+ * @returns The runtime challenge (including progression data).
+ * @see {@link compileRuntimeChallengeOnly} for when you only need the challenge data.
+ */
 export function compileRuntimeChallenge(
     challenge: RegistryChallenge,
     progression: ChallengeProgressionData,
 ): CompiledChallengeRuntimeData {
     return {
-        // GetActiveChallengesAndProgression
-        Challenge: {
-            Id: challenge.Id,
-            GroupId: challenge.inGroup,
-            Name: challenge.Name,
-            Type: challenge.RuntimeType || "contract",
-            Description: challenge.Description,
-            ImageName: challenge.ImageName,
-            InclusionData: challenge.InclusionData || undefined,
-            Definition: challenge.Definition,
-            Tags: challenge.Tags,
-            Drops: challenge.Drops,
-            LastModified: "2021-01-06T23:00:32.0117635", // this is a lie 👍
-            PlayableSince: null,
-            PlayableUntil: null,
-            Xp: challenge.Rewards.MasteryXP || 0,
-            XpModifier: challenge.XpModifier || {},
-        },
+        Challenge: compileRuntimeChallengeOnly(challenge),
         Progression: progression,
     }
 }

--- a/components/candle/challengeHelpers.ts
+++ b/components/candle/challengeHelpers.ts
@@ -54,14 +54,38 @@ export function compileRuntimeChallenge(
     }
 }
 
+/**
+ * How to handle filtering of challenges.
+ */
 export enum ChallengeFilterType {
     /** Note that this option will include global elusive and escalations challenges. */
     None = "None",
+    /** A single contract's challenges. */
     Contract = "Contract",
     /** Only used for the CAREER -> CHALLENGES page */
     Contracts = "Contracts",
     /** Only used for the location page, and when calculating location completion */
     ParentLocation = "ParentLocation",
+}
+
+/**
+ * How to handle filtering of pro1 challenges.
+ * Works in conjunction with {@link ChallengeFilterType}, but only if the
+ * challenge is tagged as pro1 and the challenge filter is met.
+ */
+export enum Pro1FilterType {
+    /**
+     * Only include pro1 challenges.
+     */
+    Only = "Only",
+    /**
+     * Include both pro1 and non-pro1 challenges.
+     */
+    Ignore = "Ignore",
+    /**
+     * Exclude pro1 challenges.
+     */
+    Exclude = "Exclude",
 }
 
 export type ChallengeFilterOptions =
@@ -74,15 +98,18 @@ export type ChallengeFilterOptions =
           locationId: string
           isFeatured?: boolean
           difficulty: number
+          pro1Filter: Pro1FilterType
       }
     | {
           type: ChallengeFilterType.Contracts
           contractIds: string[]
           locationId: string
+          pro1Filter: Pro1FilterType
       }
     | {
           type: ChallengeFilterType.ParentLocation
           parent: string
+          pro1Filter: Pro1FilterType
       }
 
 /**
@@ -127,6 +154,7 @@ export function isChallengeForDifficulty(
  * @param locationId The sublocation ID of the challenge.
  * @param difficulty The upper bound on the difficulty of the challenges to return.
  * @param challenge The challenge in question.
+ * @param pro1Filter Settings for handling pro1 challenges.
  * @param forCareer Whether the result is used to decide what is shown the CAREER -> CHALLENGES page. Defaulted to false.
  * @returns A boolean value, denoting the result.
  */
@@ -135,6 +163,7 @@ function isChallengeInContract(
     locationId: string,
     difficulty: number,
     challenge: RegistryChallenge,
+    pro1Filter: Pro1FilterType,
     forCareer = false,
 ): boolean {
     if (!contractId || !locationId) {
@@ -193,6 +222,14 @@ function isChallengeInContract(
         challenge.LocationId === locationId ||
         challenge.LocationId === challenge.ParentLocationId
 
+    const isPro1 = challenge.Tags.includes("pro1")
+
+    if (isPro1 && pro1Filter === Pro1FilterType.Exclude) {
+        return false
+    } else if (!isPro1 && pro1Filter === Pro1FilterType.Only) {
+        return false
+    }
+
     return (
         isForContract ||
         isForContractType ||
@@ -213,6 +250,7 @@ export function filterChallenge(
                 options.locationId,
                 options.difficulty,
                 challenge,
+                options.pro1Filter,
             )
         }
         case ChallengeFilterType.Contracts: {
@@ -223,6 +261,7 @@ export function filterChallenge(
                         options.locationId,
                         gameDifficulty.master, // Get challenges of all difficulties
                         challenge,
+                        options.pro1Filter,
                         true,
                     ),
                 )
@@ -255,10 +294,22 @@ export function filterChallenge(
             }
 
             if (challenge.Tags.includes("escalation")) {
+                if (options.pro1Filter === Pro1FilterType.Only) {
+                    return false
+                }
+
                 return (
                     !isSniperLocation(options.parent) &&
                     "LOCATION_PARENT_SNUG" !== options.parent
                 )
+            }
+
+            const isPro1 = challenge.Tags.includes("pro1")
+
+            if (isPro1 && options.pro1Filter === Pro1FilterType.Exclude) {
+                return false
+            } else if (!isPro1 && options.pro1Filter === Pro1FilterType.Only) {
+                return false
             }
 
             return true

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -597,6 +597,14 @@ export class ChallengeService extends ChallengeRegistry {
         return (progression?.Completed && !progression.Ticked) || false
     }
 
+    /**
+     * Get the persistent challenge progression data for a challenge.
+     * WARNING: slow! Use sparingly.
+     * @param userId The user's ID.
+     * @param challengeId The challenge ID.
+     * @param gameVersion The game version.
+     * @returns The challenge progression data.
+     */
     getPersistentChallengeProgression(
         userId: string,
         challengeId: string,
@@ -666,7 +674,7 @@ export class ChallengeService extends ChallengeRegistry {
         location: string,
         challenges: [string, RegistryChallenge[]][],
         gameVersion: GameVersion,
-    ) {
+    ): void {
         const groups = this.groups[gameVersion].get(location)?.keys() ?? []
 
         for (const groupId of groups) {

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -110,7 +110,7 @@ export type GlobalChallengeGroup = {
      *
      * This option is useful when challenge group has to be active for all locations,
      * but doesn't have any location-specific challenges.
-     * However it's advised to create location-specific challenges instead,
+     * However, it's advised to create location-specific challenges instead,
      * as this option will apply the challenge group to all locations and missions,
      * including Freelancer and Sniper modes.
      *

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -351,8 +351,8 @@ export abstract class ChallengeRegistry {
      * It iterates over all the challenges for the specified game version and for each challenge, it checks if there are any unlockables (Drops).
      * If there are unlockables, it adds them to the accumulator object with the dropId as the key and the challenge Id as the value.
      *
-     * @param gameVersion - The version of the game for which to retrieve the unlockables.
-     * @returns {Record<string, string>} - An object where each key is an unlockable's id (dropId) and the corresponding value is the id of the challenge that unlocks it.
+     * @param gameVersion The version of the game for which to retrieve the unlockables.
+     * @returns An object where each key is an unlockable's id (dropId) and the corresponding value is the id of the challenge that unlocks it.
      */
     getChallengesUnlockables(gameVersion: GameVersion): Record<string, string> {
         return [...this.challenges[gameVersion].values()].reduce(

--- a/components/candle/challengeService.ts
+++ b/components/candle/challengeService.ts
@@ -56,6 +56,7 @@ import {
     filterChallenge,
     inclusionDataCheck,
     mergeSavedChallengeGroups,
+    Pro1FilterType,
 } from "./challengeHelpers"
 import assert from "assert"
 import { getVersionedConfig } from "../configSwizzleManager"
@@ -849,6 +850,10 @@ export class ChallengeService extends ChallengeRegistry {
                         ? "LOCATION_ICA_FACILITY_SHIP"
                         : contract.Metadata.Location,
                 isFeatured: contractGroup.Metadata.Type === "featured",
+                pro1Filter:
+                    contract.Metadata.Difficulty === "pro1"
+                        ? Pro1FilterType.Only
+                        : Pro1FilterType.Exclude,
                 difficulty,
             },
             levelParentLocation,
@@ -890,6 +895,7 @@ export class ChallengeService extends ChallengeRegistry {
                 type: ChallengeFilterType.Contracts,
                 contractIds: contracts,
                 locationId: child,
+                pro1Filter: Pro1FilterType.Exclude,
             },
             parent,
             gameVersion,
@@ -1249,6 +1255,7 @@ export class ChallengeService extends ChallengeRegistry {
         locationParentId: string,
         gameVersion: GameVersion,
         userId: string,
+        isPro1: boolean,
     ): CompiledChallengeTreeCategory[] {
         const locationsData = getVersionedConfig<PeacockLocationsData>(
             "LocationsData",
@@ -1270,6 +1277,9 @@ export class ChallengeService extends ChallengeRegistry {
             {
                 type: ChallengeFilterType.ParentLocation,
                 parent: locationParentId,
+                pro1Filter: isPro1
+                    ? Pro1FilterType.Only
+                    : Pro1FilterType.Exclude,
             },
             locationParentId,
             gameVersion,

--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -24,6 +24,7 @@ import { log, LogLevel } from "../loggingInterop"
 import { getConfig } from "../configSwizzleManager"
 import { getUserData } from "../databaseHandler"
 import {
+    GenericCompletionData,
     LocationMasteryData,
     MasteryData,
     MasteryDrop,
@@ -123,23 +124,6 @@ export class MasteryService {
         return this.unlockableMasteryData[gameVersion].get(unlockable.Id)
     }
 
-    /**
-     * Exact same thing as {@link getMasteryData}.
-     */
-    getMasteryDataForDestination(
-        locationParentId: string,
-        gameVersion: GameVersion,
-        userId: string,
-        difficulty?: string,
-    ): MasteryData[] {
-        return this.getMasteryData(
-            locationParentId,
-            gameVersion,
-            userId,
-            difficulty,
-        )
-    }
-
     getMasteryDataForSubPackage(
         locationParentId: string,
         subPackageId: string,
@@ -148,7 +132,7 @@ export class MasteryService {
     ): MasteryData {
         // Since we're getting a subpackage, we know there will only be one entry in this array.
         // If the array is empty it will return undefined.
-        return this.getMasteryData(
+        return this.getMasteryDataForDestination(
             locationParentId,
             gameVersion,
             userId,
@@ -174,7 +158,7 @@ export class MasteryService {
 
         assert.ok(location, "cannot get mastery data for unknown location")
 
-        const masteryData = this.getMasteryData(
+        const masteryData = this.getMasteryDataForDestination(
             location.Properties.ParentLocation ?? location.Id,
             gameVersion,
             userId,
@@ -196,14 +180,14 @@ export class MasteryService {
      * @param subPackageId The subpackage id you want.
      * @returns The completion data, minus any location-specific fields.
      */
-    private getCompletionData(
+    private getGenericCompletionData(
         userId: string,
         gameVersion: GameVersion,
         locationParentId: string,
         maxLevel: number,
         levelToXpRequired: (level: number) => number,
         subPackageId?: string,
-    ) {
+    ): GenericCompletionData {
         // Get the user profile
         const userProfile = getUserData(userId, gameVersion)
 
@@ -343,7 +327,7 @@ export class MasteryService {
             })
     }
 
-    private getMasteryData(
+    getMasteryDataForDestination(
         locationParentId: string,
         gameVersion: GameVersion,
         userId: string,

--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -140,6 +140,13 @@ export class MasteryService {
         )[0]
     }
 
+    /**
+     * Returns mastery data for a location (either a parent or sub-location). For mastery data of a destination, use {@link getMasteryDataForDestination}.
+     * @param locationId The location's ID.
+     * @param gameVersion The game version.
+     * @param userId The user's ID.
+     * @returns The mastery data.
+     */
     getMasteryDataForLocation(
         locationId: string,
         gameVersion: GameVersion,
@@ -164,13 +171,14 @@ export class MasteryService {
     }
 
     /**
-     * Get generic completion data stored in a user's profile. Called by both `getLocationCompletion` and `getFirearmCompletion`.
+     * Get generic completion data stored in a user's profile.
      * @param userId The id of the user.
      * @param gameVersion The game version.
      * @param locationParentId The location's parent ID, used for progression storage @since v7.0.0
      * @param maxLevel The max level for this progression.
      * @param levelToXpRequired A function to get the XP required for a level.
      * @param subPackageId The subpackage id you want.
+     * @returns The completion data, minus any location-specific fields.
      */
     private getGenericCompletionData(
         userId: string,
@@ -183,8 +191,12 @@ export class MasteryService {
         // Get the user profile
         const userProfile = getUserData(userId, gameVersion)
 
+        assert.ok(userProfile, `user profile ${userId} not found`)
+
         const parent =
             userProfile.Extensions.progression.Locations[locationParentId]
+
+        assert.ok(parent, `parent ${locationParentId} not found`)
 
         const completionData: ProgressionData = subPackageId
             ? (parent[subPackageId as keyof typeof parent] as ProgressionData)
@@ -252,10 +264,14 @@ export class MasteryService {
             ? getConfig<Unlockable[]>("SniperUnlockables", false).find(
                   (unlockable) => unlockable.Id === subPackageId,
               )?.Properties.Name
-            : undefined
+            : null
+
+        if (isSniper) {
+            assert.ok(name, `unlockable ${subPackageId} not found`)
+        }
 
         return {
-            ...this.getCompletionData(
+            ...this.getGenericCompletionData(
                 userId,
                 gameVersion,
                 locationParentId,
@@ -344,7 +360,9 @@ export class MasteryService {
 
             // Add the main unlockable to the set to generate the page properly
             if (isSniper) {
-                masteryPkg.SubPackages.forEach((pkg) => dropIdSet.add(pkg.Id))
+                for (const pkg of masteryPkg.SubPackages) {
+                    dropIdSet.add(pkg.Id)
+                }
             }
 
             if (!dropIdSet || dropIdSet.size === 0) {

--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -156,6 +156,13 @@ export class MasteryService {
         )[0]
     }
 
+    /**
+     * Returns mastery data for a location (either a parent or sub-location). For mastery data of a destination, use {@link getMasteryDataForDestination}.
+     * @param locationId The location's ID.
+     * @param gameVersion The game version.
+     * @param userId The user's ID.
+     * @returns The mastery data.
+     */
     getMasteryDataForLocation(
         locationId: string,
         gameVersion: GameVersion,
@@ -180,13 +187,14 @@ export class MasteryService {
     }
 
     /**
-     * Get generic completion data stored in a user's profile. Called by both `getLocationCompletion` and `getFirearmCompletion`.
+     * Get generic completion data stored in a user's profile.
      * @param userId The id of the user.
      * @param gameVersion The game version.
      * @param locationParentId The location's parent ID, used for progression storage @since v7.0.0
      * @param maxLevel The max level for this progression.
      * @param levelToXpRequired A function to get the XP required for a level.
      * @param subPackageId The subpackage id you want.
+     * @returns The completion data, minus any location-specific fields.
      */
     private getCompletionData(
         userId: string,
@@ -199,8 +207,12 @@ export class MasteryService {
         // Get the user profile
         const userProfile = getUserData(userId, gameVersion)
 
+        assert.ok(userProfile, `user profile ${userId} not found`)
+
         const parent =
             userProfile.Extensions.progression.Locations[locationParentId]
+
+        assert.ok(parent, `parent ${locationParentId} not found`)
 
         const completionData: ProgressionData = subPackageId
             ? (parent[subPackageId as keyof typeof parent] as ProgressionData)
@@ -268,10 +280,14 @@ export class MasteryService {
             ? getConfig<Unlockable[]>("SniperUnlockables", false).find(
                   (unlockable) => unlockable.Id === subPackageId,
               )?.Properties.Name
-            : undefined
+            : null
+
+        if (isSniper) {
+            assert.ok(name, `unlockable ${subPackageId} not found`)
+        }
 
         return {
-            ...this.getCompletionData(
+            ...this.getGenericCompletionData(
                 userId,
                 gameVersion,
                 locationParentId,
@@ -360,7 +376,9 @@ export class MasteryService {
 
             // Add the main unlockable to the set to generate the page properly
             if (isSniper) {
-                masteryPkg.SubPackages.forEach((pkg) => dropIdSet.add(pkg.Id))
+                for (const pkg of masteryPkg.SubPackages) {
+                    dropIdSet.add(pkg.Id)
+                }
             }
 
             if (!dropIdSet || dropIdSet.size === 0) {

--- a/components/candle/progressionService.ts
+++ b/components/candle/progressionService.ts
@@ -49,14 +49,14 @@ export class ProgressionService {
         contractSession: ContractSession,
         userProfile: UserProfile,
         location: string,
-        sniperUnlockable?: string,
+        subPackage?: string,
     ): void {
         // Total XP for profile XP is the total sum of the action and mastery XP
         const xp = actionXp + masteryXp
 
         // Grants profile XP, if this is at contract end where we're adding the final
         // sniper score, don't grant it to the profile, otherwise you'll get 1,000+ levels.
-        if (!sniperUnlockable) {
+        if (!subPackage) {
             this.grantUserXp(xp, contractSession, userProfile)
         }
 
@@ -67,7 +67,7 @@ export class ProgressionService {
             contractSession,
             userProfile,
             location,
-            sniperUnlockable,
+            subPackage,
         )
 
         // Award provided drops. E.g. From challenges. Don't run this function
@@ -185,6 +185,7 @@ export class ProgressionService {
             const isEvergreenContract = contract.Metadata.Type === "evergreen"
 
             if (masteryData) {
+                assert.ok(locationData, `location ${location} not found`)
                 const previousLevel = locationData.Level
 
                 locationData.Xp = clampValue(

--- a/components/candle/progressionService.ts
+++ b/components/candle/progressionService.ts
@@ -22,6 +22,7 @@ import { getUnlockablesById, grantDrops } from "../inventory"
 import type {
     ContractSession,
     GameVersion,
+    ProgressionData,
     Unlockable,
     UserProfile,
 } from "../types/types"
@@ -90,11 +91,16 @@ export class ProgressionService {
         userProfile: UserProfile,
         location: string,
         subPkgId?: string,
-    ) {
+    ): ProgressionData | undefined {
+        const theLocation =
+            userProfile.Extensions.progression.Locations[location]
+
+        assert.ok(theLocation, `Location ${location} not found in user data`)
+
         return subPkgId
             ? // @ts-expect-error It is possible to index into an object with a string
-              userProfile.Extensions.progression.Locations[location][subPkgId]
-            : userProfile.Extensions.progression.Locations[location]
+              theLocation[subPkgId]
+            : theLocation
     }
 
     // Return mastery drops from location from a level range
@@ -234,7 +240,7 @@ export class ProgressionService {
 
                 userProfile.Extensions.CPD[contract.Metadata.CpdId][
                     "EvergreenLevel"
-                ] = locationData.Level
+                ] = locationData?.Level ?? 0
             }
         }
 

--- a/components/candle/progressionService.ts
+++ b/components/candle/progressionService.ts
@@ -50,7 +50,7 @@ export class ProgressionService {
         userProfile: UserProfile,
         location: string,
         sniperUnlockable?: string,
-    ) {
+    ): void {
         // Total XP for profile XP is the total sum of the action and mastery XP
         const xp = actionXp + masteryXp
 
@@ -104,7 +104,7 @@ export class ProgressionService {
         masteryLocationDrops: MasteryPackageDrop[],
         minLevel: number,
         maxLevel: number,
-    ) {
+    ): Unlockable[] {
         const unlockableIds = masteryLocationDrops
             .filter((drop) => drop.Level > minLevel && drop.Level <= maxLevel)
             .map((drop) => drop.Id)
@@ -135,7 +135,7 @@ export class ProgressionService {
             }
         }
 
-        return unlockables
+        return unlockables.filter((u) => !!u) as Unlockable[]
     }
 
     // Grants xp and rewards to mastery progression on contract location
@@ -146,11 +146,11 @@ export class ProgressionService {
         userProfile: UserProfile,
         location: string,
         sniperUnlockable?: string,
-    ): boolean {
+    ): void {
         const contract = controller.resolveContract(contractSession.contractId)
 
         if (!contract) {
-            return false
+            return
         }
 
         const subLocation = getSubLocationByName(
@@ -163,7 +163,7 @@ export class ProgressionService {
             : location ?? contract.Metadata.Location
 
         if (!parentLocationId) {
-            return false
+            return
         }
 
         // We can't grant sniper XP here as it's based on final score, so we skip updating mastery
@@ -248,8 +248,6 @@ export class ProgressionService {
         profileData.Sublocations[contract.Metadata.Location].Xp += masteryXp
         profileData.Sublocations[contract.Metadata.Location].ActionXp +=
             actionXp
-
-        return true
     }
 
     // Grants xp to user profile
@@ -258,7 +256,7 @@ export class ProgressionService {
         xp: number,
         contractSession: ContractSession,
         userProfile: UserProfile,
-    ): boolean {
+    ): void {
         const profileData = userProfile.Extensions.progression.PlayerProfileXP
 
         profileData.Total += xp
@@ -267,7 +265,5 @@ export class ProgressionService {
             1,
             getMaxProfileLevel(contractSession.gameVersion),
         )
-
-        return true
     }
 }

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -65,7 +65,7 @@ import { unpack } from "msgpackr"
 import { ChallengePackage, SavedChallengeGroup } from "./types/challenges"
 import assert from "assert"
 import { Response } from "express"
-import { ChallengeFilterType } from "./candle/challengeHelpers"
+import { ChallengeFilterType, Pro1FilterType } from "./candle/challengeHelpers"
 import { MasteryService } from "./candle/masteryService"
 import { MasteryPackage } from "./types/mastery"
 import { ProgressionService } from "./candle/progressionService"
@@ -1246,6 +1246,7 @@ export function contractIdToHitObject(
         {
             type: ChallengeFilterType.ParentLocation,
             parent: parentLocation?.Id,
+            pro1Filter: Pro1FilterType.Ignore,
         },
         parentLocation?.Id,
         gameVersion,

--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -162,6 +162,11 @@ function filterUnlockedContent(
                     unlockableMasteryData.SubPackageId,
                 )
 
+            assert.ok(
+                locationData,
+                `location ${unlockableMasteryData.Location} (subPackageId: ${unlockableMasteryData.SubPackageId}) not found`,
+            )
+
             const canUnlock = locationData.Level >= unlockableMasteryData.Level
 
             if (canUnlock && unlockable.Type !== "evergreenmastery") {

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -326,10 +326,14 @@ menuDataRouter.get(
                     LevelInfo:
                         missionEndData.MissionReward.LocationProgression
                             .LevelInfo,
-                    XP: missionEndData.ScoreOverview.XP,
-                    Level: missionEndData.ScoreOverview.Level,
-                    Completion: missionEndData.ScoreOverview.Completion,
-                    XPGain: missionEndData.ScoreOverview.XPGain,
+                    XP: missionEndData.MissionReward.LocationProgression.XP,
+                    Level: missionEndData.MissionReward.LocationProgression
+                        .Level,
+                    Completion:
+                        missionEndData.MissionReward.LocationProgression
+                            .Completion,
+                    XPGain: missionEndData.MissionReward.LocationProgression
+                        .XPGain,
                     Challenges: Object.values(
                         controller.challengeService.getChallengesForContract(
                             contractId,

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -320,6 +320,8 @@ menuDataRouter.get(
                 true,
             )
 
+            // TODO: Enqueue events to unlock PRO1
+
             res.json({
                 template: getConfig("MissionRewardsTemplate", false),
                 data: {

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -25,7 +25,7 @@ import {
     unlockOrderComparer,
     uuidRegex,
 } from "./utils"
-import { contractSessions, getSession } from "./eventHandler"
+import { contractSessions, enqueueEvent, getSession } from "./eventHandler"
 import { getConfig, getVersionedConfig } from "./configSwizzleManager"
 import { controller } from "./controller"
 import { createLocationsData, getDestination } from "./menus/destinations"
@@ -320,7 +320,25 @@ menuDataRouter.get(
                 true,
             )
 
-            // TODO: Enqueue events to unlock PRO1
+            // Send all the drops, we technically only need to send the pro1 drop, but this is best practise.
+            if (missionEndData.MissionReward.Drops.length) {
+                enqueueEvent(req.jwt.unique_name, {
+                    Name: "UnlockableAddedToInventory",
+                    Value: {
+                        Items: missionEndData.MissionReward.Drops.map(
+                            (drop) => {
+                                return { UnlockableId: drop.Unlockable.Id }
+                            },
+                        ),
+                    },
+                    Version: {
+                        _Build: 61,
+                        _Major: 6,
+                        _Minor: 74,
+                        _Revision: 0,
+                    },
+                })
+            }
 
             res.json({
                 template: getConfig("MissionRewardsTemplate", false),

--- a/components/menuData.ts
+++ b/components/menuData.ts
@@ -16,7 +16,7 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { getMissionEndData, MissionEndError } from "./scoreHandler"
+import { getMissionEndData } from "./scoreHandler"
 import { Response, Router } from "express"
 import {
     contractCreationTutorialId,
@@ -284,16 +284,21 @@ menuDataRouter.get(
 menuDataRouter.get(
     "/missionrewards",
     // @ts-expect-error Jwt props.
-    (
+    async (
         req: RequestWithJwt<{
             contractSessionId: string
         }>,
         res,
     ) => {
-        const s = getSession(req.jwt.unique_name)
+        const s = contractSessions.get(req.query.contractSessionId)
 
         if (!s) {
             res.status(400).send("no session")
+            return
+        }
+
+        if (s.userId !== req.jwt.unique_name) {
+            res.status(403).send("requested score for other user's session")
             return
         }
 
@@ -301,58 +306,65 @@ menuDataRouter.get(
         const contractData = controller.resolveContract(contractId, true)
         const userData = getUserData(req.jwt.unique_name, req.gameVersion)
 
-        res.json({
-            template: getConfig("MissionRewardsTemplate", false),
-            data: {
-                LevelInfo: [
-                    0, 6000, 12000, 18000, 24000, 30000, 36000, 42000, 48000,
-                    54000, 60000, 66000, 72000, 78000, 84000, 90000, 96000,
-                    102000, 108000, 114000,
-                ],
-                XP: 0,
-                Level: 1,
-                Completion: 0,
-                XPGain: 0,
-                Challenges: Object.values(
-                    controller.challengeService.getChallengesForContract(
-                        contractId,
-                        req.gameVersion,
-                        req.jwt.unique_name,
-                        // TODO: Should a difficulty be passed here?
-                    ),
-                )
-                    .flat()
-                    // FIXME: This behaviour may not be accurate to original server
-                    .filter((challengeData) =>
-                        controller.challengeService.fastGetIsCompleted(
-                            userData,
-                            challengeData.Id,
-                        ),
-                    )
-                    .map((challengeData) =>
-                        controller.challengeService.compileRegistryChallengeTreeData(
-                            challengeData,
-                            controller.challengeService.getPersistentChallengeProgression(
-                                req.jwt.unique_name,
-                                challengeData.Id,
-                                req.gameVersion,
-                            ),
+        try {
+            const missionEndData = await getMissionEndData(
+                req.query,
+                req.jwt,
+                req.gameVersion,
+                true,
+            )
+
+            res.json({
+                template: getConfig("MissionRewardsTemplate", false),
+                data: {
+                    LevelInfo: [
+                        0, 6000, 12000, 18000, 24000, 30000, 36000, 42000,
+                        48000, 54000, 60000, 66000, 72000, 78000, 84000, 90000,
+                        96000, 102000, 108000, 114000,
+                    ],
+                    XP: missionEndData.ScoreOverview.XP,
+                    Level: missionEndData.ScoreOverview.Level,
+                    Completion: missionEndData.ScoreOverview.Completion,
+                    XPGain: missionEndData.ScoreOverview.XPGain,
+                    Challenges: Object.values(
+                        controller.challengeService.getChallengesForContract(
+                            contractId,
                             req.gameVersion,
                             req.jwt.unique_name,
+                            // TODO: Should a difficulty be passed here?
                         ),
+                    )
+                        .flat()
+                        .filter((challengeData) =>
+                            controller.challengeService.fastGetIsUnticked(
+                                userData,
+                                challengeData.Id,
+                            ),
+                        )
+                        .map((challengeData) => ({
+                            ChallengeId: challengeData.Id,
+                            ChallengeName: challengeData.Name,
+                            ChallengeImageUrl: challengeData.ImageName,
+                            ChallengeDescription: challengeData.Description,
+                            XPGain: challengeData.Rewards.MasteryXP,
+                        })),
+                    Drops: [],
+                    ContractCompletionBonus: 0,
+                    GroupCompletionBonus: 0,
+                    LocationHideProgression: true,
+                    Difficulty: "normal", // FIXME: is this right?
+                    CompletionData: generateCompletionData(
+                        contractData?.Metadata.Location || "",
+                        req.jwt.unique_name,
+                        req.gameVersion,
                     ),
-                Drops: [],
-                ContractCompletionBonus: 0,
-                GroupCompletionBonus: 0,
-                LocationHideProgression: true,
-                Difficulty: "normal", // FIXME: is this right?
-                CompletionData: generateCompletionData(
-                    contractData?.Metadata.Location || "",
-                    req.jwt.unique_name,
-                    req.gameVersion,
-                ),
-            },
-        })
+                },
+            })
+        } catch (e) {
+            log(LogLevel.ERROR, e)
+            log(LogLevel.ERROR, (e as Error).stack)
+            res.status(400).send("error")
+        }
     },
 )
 
@@ -622,34 +634,30 @@ const missionEndRequest = async (
         return
     }
 
-    const missionEndOutput = await getMissionEndData(
-        req.query,
-        req.jwt,
-        req.gameVersion,
-    )
+    try {
+        const missionEndOutput = await getMissionEndData(
+            req.query,
+            req.jwt,
+            req.gameVersion,
+            false,
+        )
 
-    const isErrorPath = (
-        output: MissionEndResult | MissionEndError,
-    ): output is MissionEndError => {
-        return Boolean((output as MissionEndError).errorCode)
-    }
+        if (req.path.endsWith("/scoreoverview")) {
+            res.json({
+                template: getConfig("ScoreOverviewTemplate", false),
+                data: (missionEndOutput as MissionEndResult).ScoreOverview,
+            })
+            return
+        }
 
-    if (isErrorPath(missionEndOutput)) {
-        res.status(missionEndOutput.errorCode).send(missionEndOutput.error)
-    }
-
-    if (req.path.endsWith("/scoreoverview")) {
         res.json({
-            template: getConfig("ScoreOverviewTemplate", false),
-            data: (missionEndOutput as MissionEndResult).ScoreOverview,
+            template: null,
+            data: missionEndOutput,
         })
-        return
+    } catch (e) {
+        log(LogLevel.ERROR, e)
+        log(LogLevel.ERROR, (e as Error).stack)
     }
-
-    res.json({
-        template: null,
-        data: missionEndOutput,
-    })
 }
 
 // @ts-expect-error Has jwt props.

--- a/components/menus/destinations.ts
+++ b/components/menus/destinations.ts
@@ -92,15 +92,18 @@ type GameDestination = {
     }
     Location: Unlockable
     MasteryData: MasteryData | MasteryData[] | Record<string, never>
-    MissionData: {
-        ChallengeCompletion: ChallengeCompletion
-        Location: Unlockable
-        LocationCompletionPercent: number
-        OpportunityStatistics: {
-            Completed: number
-            Count: number
-        }
+    MissionData: DestinationBaseCompletionData & {
         SubLocationMissionsData: LocationMissionData[]
+    }
+}
+
+type DestinationBaseCompletionData = {
+    ChallengeCompletion: ChallengeCompletion
+    Location: Unlockable
+    LocationCompletionPercent: number
+    OpportunityStatistics: {
+        Completed: number
+        Count: number
     }
 }
 
@@ -109,7 +112,7 @@ export function getDestinationCompletion(
     child: Unlockable | undefined,
     gameVersion: GameVersion,
     userId: string,
-) {
+): DestinationBaseCompletionData {
     const missionStories = getConfig<Record<string, MissionStory>>(
         "MissionStories",
         false,

--- a/components/menus/destinations.ts
+++ b/components/menus/destinations.ts
@@ -33,7 +33,7 @@ import type { MasteryData } from "../types/mastery"
 import { contractIdToHitObject, controller } from "../controller"
 import { generateCompletionData } from "../contracts/dataGen"
 import { getUserData } from "../databaseHandler"
-import { ChallengeFilterType } from "../candle/challengeHelpers"
+import { ChallengeFilterType, Pro1FilterType } from "../candle/challengeHelpers"
 import { GetDestinationQuery } from "../types/gameSchemas"
 import { createInventory } from "../inventory"
 import { log, LogLevel } from "../loggingInterop"
@@ -123,6 +123,7 @@ export function getDestinationCompletion(
         {
             type: ChallengeFilterType.ParentLocation,
             parent: parent.Id,
+            pro1Filter: Pro1FilterType.Exclude,
         },
         parent.Id,
         gameVersion,
@@ -384,6 +385,7 @@ export function getDestination(
                     query.locationId,
                     gameVersion,
                     userId,
+                    query.difficulty === "pro1",
                 ),
         },
         MasteryData: resMasteryData,

--- a/components/profileHandler.ts
+++ b/components/profileHandler.ts
@@ -64,6 +64,7 @@ import {
     ResolveGamerTagsBody,
 } from "./types/gameSchemas"
 import assert from "assert"
+import { generateCompletionData } from "./contracts/dataGen"
 
 const profileRouter = Router()
 
@@ -653,6 +654,23 @@ profileRouter.post(
                     MaxLevel: getMaxProfileLevel(req.gameVersion),
                 },
             },
+        })
+    },
+)
+
+profileRouter.post(
+    "/HubPagesService/GetMasteryCompletionDataForLocation",
+    jsonMiddleware(),
+    // @ts-expect-error Has jwt props.
+    (req: RequestWithJwt<{ locationId: string; difficulty: string }>, res) => {
+        res.json({
+            CompletionData: generateCompletionData(
+                req.body.locationId,
+                req.jwt.unique_name,
+                req.gameVersion,
+                undefined,
+                req.body.difficulty,
+            ),
         })
     },
 )

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -845,7 +845,7 @@ export async function getMissionEndData(
         ].PreviouslySeenXp = newLocationXp
     }
 
-    writeUserData(jwt.unique_name, gameVersion)
+    if (!isDryRun) writeUserData(jwt.unique_name, gameVersion)
 
     const masteryData = controller.masteryService.getMasteryPackage(
         locationParentId,

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -724,11 +724,6 @@ export async function getMissionEndData(
         query.masteryUnlockableId = contractData.Metadata.Difficulty ?? "normal"
     }
 
-    if (gameVersion === "h1") {
-        // h1 has a separate mastery track for pro1 and normal
-        query.masteryUnlockableId = contractData.Metadata.Difficulty ?? "normal"
-    }
-
     // Resolve all opportunities for the location
     const opportunities: string[] | null | undefined =
         contractData.Metadata.Opportunities

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -719,6 +719,11 @@ export async function getMissionEndData(
         `location ${subLocation?.Properties?.ParentLocation || levelData.Metadata.Location} not found (trying to resolve parent)`,
     )
 
+    if (gameVersion === "h1") {
+        // h1 has a separate mastery track for pro1 and normal
+        query.masteryUnlockableId = contractData.Metadata.Difficulty ?? "normal"
+    }
+
     // Resolve all opportunities for the location
     const opportunities: string[] | null | undefined =
         contractData.Metadata.Opportunities

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -614,7 +614,6 @@ export async function getMissionEndData(
     gameVersion: GameVersion,
     isDryRun: boolean,
 ): Promise<MissionEndResult> {
-    // TODO: For this entire function, add support for 2016 difficulties
     const sessionDetails = contractSessions.get(query.contractSessionId || "")
 
     assert.ok(sessionDetails, "contract session not found")

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -658,9 +658,10 @@ export async function getMissionEndData(
             IsEscalation: true,
         }
 
-        if (
-            userData.Extensions.PeacockEscalations[eGroupId] ===
-            getLevelCount(controller.resolveContract(eGroupId))
+        const levelCount = getLevelCount(controller.resolveContract(eGroupId))
+
+        escalationCompletion: if (
+            userData.Extensions.PeacockEscalations[eGroupId] === levelCount
         ) {
             // we are on the final level, and the user completed this level
             if (
@@ -673,6 +674,25 @@ export async function getMissionEndData(
             }
 
             history.Completed = true
+
+            if ((gameVersion === "h1" && levelCount !== 5) || isDryRun) {
+                break escalationCompletion
+            }
+
+            // Send the AchievementEscalated event to the client
+            // for achievements.
+            enqueueEvent(jwt.unique_name, {
+                Name: "AchievementEscalated",
+                Value: {
+                    Location: contractData.Metadata.Location,
+                },
+                Version: {
+                    _Major: 8,
+                    _Minor: 15,
+                    _Build: 0,
+                    _Revision: 0,
+                },
+            })
         } else {
             // not the final level
             userData.Extensions.PeacockEscalations[eGroupId] += 1

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -58,7 +58,7 @@ import {
 import { liveSplitManager } from "./livesplit/liveSplitManager"
 import { ScoringHeadline } from "./types/scoring"
 import { MissionEndRequestQuery } from "./types/gameSchemas"
-import { ChallengeFilterType } from "./candle/challengeHelpers"
+import { ChallengeFilterType, Pro1FilterType } from "./candle/challengeHelpers"
 import { getCompletionPercent } from "./menus/destinations"
 import {
     CalculateScoreResult,
@@ -677,6 +677,10 @@ export async function getMissionEndData(
             {
                 type: ChallengeFilterType.ParentLocation,
                 parent: locationParentId,
+                pro1Filter:
+                    levelData.Metadata.Difficulty === "pro1"
+                        ? Pro1FilterType.Only
+                        : Pro1FilterType.Exclude,
             },
             locationParentId,
             gameVersion,

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -619,7 +619,7 @@ export async function getMissionEndData(
 
     assert.ok(sessionDetails, "contract session not found")
     assert(
-        sessionDetails.userId !== jwt.unique_name,
+        sessionDetails.userId === jwt.unique_name,
         "requested score for other user's session",
     )
 

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -26,6 +26,7 @@ import {
     isObjectiveActive,
     levelForXp,
     PEACOCKVERSTRING,
+    ServerVer,
     SNIPER_LEVEL_INFO,
     sniperLevelForXp,
     xpRequiredForLevel,
@@ -686,12 +687,7 @@ export async function getMissionEndData(
                 Value: {
                     Location: contractData.Metadata.Location,
                 },
-                Version: {
-                    _Major: 8,
-                    _Minor: 15,
-                    _Build: 0,
-                    _Revision: 0,
-                },
+                Version: ServerVer,
             })
         } else {
             // not the final level
@@ -1144,12 +1140,7 @@ export async function getMissionEndData(
                     Location: levelData.Metadata.Location,
                     NewLevel: newLocationLevel,
                 },
-                Version: {
-                    _Major: 8,
-                    _Minor: 15,
-                    _Build: 0,
-                    _Revision: 0,
-                },
+                Version: ServerVer,
             })
         }
     }

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -724,6 +724,11 @@ export async function getMissionEndData(
         query.masteryUnlockableId = contractData.Metadata.Difficulty ?? "normal"
     }
 
+    if (gameVersion === "h1") {
+        // h1 has a separate mastery track for pro1 and normal
+        query.masteryUnlockableId = contractData.Metadata.Difficulty ?? "normal"
+    }
+
     // Resolve all opportunities for the location
     const opportunities: string[] | null | undefined =
         contractData.Metadata.Opportunities

--- a/components/types/challenges.ts
+++ b/components/types/challenges.ts
@@ -42,7 +42,7 @@ export interface SavedChallenge {
     LocationId: string
     ParentLocationId: string
     // H1 challenges do not have Type
-    Type?: "contract" | string
+    Type?: "contract" | "global" | "location" | "parentlocation" | string
     RuntimeType: "Hit" | string
     Xp: number
     XpModifier?: unknown

--- a/components/types/challenges.ts
+++ b/components/types/challenges.ts
@@ -25,6 +25,14 @@ import {
 } from "./types"
 import { gameDifficulty } from "../utils"
 
+export type ChallengeType =
+    | "Statistic"
+    | "contract"
+    | "global"
+    | "location"
+    | "parentlocation"
+    | string
+
 export interface SavedChallenge {
     Id: string
     Name: string
@@ -42,11 +50,11 @@ export interface SavedChallenge {
     LocationId: string
     ParentLocationId: string
     // H1 challenges do not have Type
-    Type?: "contract" | "global" | "location" | "parentlocation" | string
+    Type?: ChallengeType
     RuntimeType: "Hit" | string
     Xp: number
     XpModifier?: unknown
-    DifficultyLevels: (keyof typeof gameDifficulty)[]
+    DifficultyLevels?: (keyof typeof gameDifficulty)[]
     OrderIndex: number
     Definition: MissionManifestObjective["Definition"] & {
         Scope: ContextScopedStorageLocation

--- a/components/types/mastery.ts
+++ b/components/types/mastery.ts
@@ -18,17 +18,17 @@
 
 import { CompletionData, GameVersion, Unlockable } from "./types"
 
-export interface LocationMasteryData {
+export type LocationMasteryData = {
     Location: Unlockable
     MasteryData: MasteryData[]
 }
 
-export interface MasteryPackageDrop {
+export type MasteryPackageDrop = {
     Id: string
     Level: number
 }
 
-interface MasterySubPackage {
+export type MasterySubPackage = {
     Id: string
     MaxLevel?: number
     Drops: MasteryPackageDrop[]
@@ -49,25 +49,31 @@ export type MasteryPackage = {
     GameVersions: GameVersion[]
     MaxLevel?: number
     HideProgression?: boolean
-} & (HasDrop | HasSubPackage)
+} & (MasteryPackageDropExt | MasteryPackageSubPackageExt)
 
-type HasDrop = {
+/**
+ * Extends {@link MasteryPackage} with the `Drops` field.
+ */
+export type MasteryPackageDropExt = {
     Drops: MasteryPackageDrop[]
     SubPackages?: never
 }
 
-type HasSubPackage = {
+/**
+ * Extends {@link MasteryPackage} with the `SubPackages` field.
+ */
+export type MasteryPackageSubPackageExt = {
     Drops?: never
     SubPackages: MasterySubPackage[]
 }
 
-export interface MasteryData {
+export type MasteryData = {
     CompletionData: CompletionData
     Drops: MasteryDrop[]
     Unlockable?: Unlockable
 }
 
-export interface MasteryDrop {
+export type MasteryDrop = {
     IsLevelMarker: boolean
     Unlockable: Unlockable
     Level: number
@@ -75,8 +81,17 @@ export interface MasteryDrop {
     TypeLocaKey: string
 }
 
-export interface UnlockableMasteryData {
+export type UnlockableMasteryData = {
     Location: string
     SubPackageId?: string
     Level: number
 }
+
+export type GenericCompletionData = Omit<
+    CompletionData,
+    | "Id"
+    | "SubLocationId"
+    | "HideProgression"
+    | "IsLocationProgression"
+    | "Name"
+>

--- a/contractdata/BANGKOK/_LEGACY_BANGKOK_CHALLENGES.json
+++ b/contractdata/BANGKOK/_LEGACY_BANGKOK_CHALLENGES.json
@@ -4502,6 +4502,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_BANGKOK_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4548,6 +4549,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_BANGKOK_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4660,6 +4662,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_BANGKOK_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4745,6 +4748,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_BANGKOK_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4874,6 +4878,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_BANGKOK_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4945,6 +4950,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_BANGKOK_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -5011,6 +5017,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_BANGKOK_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {

--- a/contractdata/BANGKOK/_LEGACY_BANGKOK_PRO1_CHALLENGES.json
+++ b/contractdata/BANGKOK/_LEGACY_BANGKOK_PRO1_CHALLENGES.json
@@ -1,0 +1,1796 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_BANGKOK",
+        "GameVersions": ["h1"]
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "OrderIndex": 0,
+            "Challenges": [
+                {
+                    "Id": "ca54a026-b31d-4160-a547-4a74365b76ad",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_NECK_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_cross_neck.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_NECK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Pacify": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    },
+                                                    "in": ["Poison"]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Check_Kill"
+                                }
+                            },
+                            "Check_Kill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    },
+                                                    "in": ["CoupDeGrace"]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "eeb66c70-0d58-4da3-9ca8-684e75e37671",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_DEATHDAY_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_deathday.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_DEATHDAY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "be8452d0-3ce9-4f41-b1c2-a381d7e95e15"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "385d1bcf-8d39-4192-ae2b-6a2174736f7f",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_MORGAN_BALCONY_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_morgan_balcony.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_MORGAN_BALCONY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Morgan_On_Balcony"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "f65fff84-6cad-4a11-9a0a-b89430c03397"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "PushOver"
+                                                        ]
+                                                    },
+                                                    "in": "$Value.DamageEvents"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "3773a1c5-1b9c-4a51-b0ef-71aa91270b69",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_POISON_CAKE_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_poison_cake.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_POISON_CAKE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "59903f83-a6e3-48dc-9933-b285c9dc6f71"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "d9714274-0a5a-46a7-9486-797121b16a80",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_MORGAN_DROWN_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_morgan_drown.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_MORGAN_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "f65fff84-6cad-4a11-9a0a-b89430c03397"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "fe396d19-8cc6-421a-bb2c-f6f778ba6bc0"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "1c53e21b-b542-4ae0-baf4-949fdc87c75b",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_BOTH_STALKER_KILL_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_exp_both_stalker_kill.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_BOTH_STALKER_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "TargetGoal": 2,
+                            "TargetKilled": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetKilled",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "f65fff84-6cad-4a11-9a0a-b89430c03397",
+                                                            "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.OutfitRepositoryId",
+                                                        "c5bf909f-66a5-4f19-9aee-aeb953172e45"
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$Value.RepositoryId"
+                                                                ]
+                                                            },
+                                                            "in": "$.TargetKilled"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "3fdea4b0-863c-4684-b6c5-9ab21c0f5717",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_SNIPE_WINDOW_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_window_snipe.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_SNIPE_WINDOW_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "47_At_Window"
+                                        ]
+                                    },
+                                    "Transition": "Sniper_Position"
+                                }
+                            },
+                            "Sniper_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "47_Not_At_Window"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$contains": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "a70f11ad-5593-4f1e-b1d5-a90162cd3fad",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_BOOTH_GUN_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_booth_gun.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_BOOTH_GUN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Cross_Singing"
+                                        ]
+                                    },
+                                    "Transition": "Cross_Singing"
+                                }
+                            },
+                            "Cross_Singing": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Cross_Stops_Singing"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "b14c558b-ac70-482c-ad32-aa073c8f99e3",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_BOTH_COCONUT_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_both_coconut.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_BOTH_COCONUT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Is_DoubleKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "f65fff84-6cad-4a11-9a0a-b89430c03397"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceType",
+                                                            "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceType",
+                                                            "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "f65fff84-6cad-4a11-9a0a-b89430c03397"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceType",
+                                                            "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceType",
+                                                            "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "521ec6fa-8d5f-4798-938f-b21dda8a2fbd",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "83f4f967-71bb-48a1-bc53-1e472a9a1b3e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "3d59f7ff-11b5-4498-925d-d3a2ea148a4e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "61f8efe4-7e9e-4add-b69e-bf40213209c2"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "c2302bad-8e77-4d72-88c2-36ac1ad8c1b4"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "3aa4388f-6f87-44a4-b3dc-ac015bf65264"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "b947c2dc-bd49-4f61-aed1-d641cc548241"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "b33ae290-5ea1-4229-b41f-680a76d40320"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "20f08d1c-d2d2-47da-a48c-b9b68fab4691",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_NO_EVIDENCE_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_47_no_evidence.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_NO_EVIDENCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "9b674c70-1787-48b6-ba13-be363f45db29",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_ELECTRICUTION_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_electricution.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_ELECTRICUTION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "1e94d1a2-a513-4d56-a122-30443b04ecdb"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "daed9da8-9dc7-4e01-82e8-c5df57b736ef",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_GLASS_ROOF_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_glass_roof.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_GLASS_ROOF_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "b9e9f8b0-65b9-4731-ae26-b2e26cac2caf"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "68550b59-219a-4fb1-9df9-c72be8712559",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_FAULTY_MIC_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_faulty_mic.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_FAULTY_MIC_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "36287bb9-5cd0-4b97-9baa-dad239cf3c37"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "ff3b14a5-15ce-44ad-8792-cc9b2cda37c9",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_CROSS_CHAIR_KILL_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_cross_chair_kill.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_CROSS_CHAIR_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "42cc6b76-500a-4433-8fec-6f3bf4827ff1"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "c08e5099-7c23-426d-bfe9-d3582c6c3682",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_MORGAN_AXE_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_morgan_axe.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_MORGAN_AXE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Morgan_In_Linnenroom"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Morgan_Out_Linnenroom"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "f65fff84-6cad-4a11-9a0a-b89430c03397"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemRepositoryId",
+                                                    "a8bc4325-718e-45ba-b0e4-000729c70ce4"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "64ec75c2-2c6e-4578-a0d4-d9d31d7cc70c",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_SA_SUIT_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_SA_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "83f4f967-71bb-48a1-bc53-1e472a9a1b3e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "3d59f7ff-11b5-4498-925d-d3a2ea148a4e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "61f8efe4-7e9e-4add-b69e-bf40213209c2"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "c2302bad-8e77-4d72-88c2-36ac1ad8c1b4"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "3aa4388f-6f87-44a4-b3dc-ac015bf65264"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "b947c2dc-bd49-4f61-aed1-d641cc548241"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "b33ae290-5ea1-4229-b41f-680a76d40320"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "8a017de7-d90e-4b7a-8b95-ddafaac6c000",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true,
+                            "SniperKills": [],
+                            "TargetDied": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            true,
+                                            "$.RecordingDestroyed",
+                                            "$.TargetDied"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "SniperKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$contains": [
+                                                "$Value.KillItemCategory",
+                                                "sniperrifle"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.SniperKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "ee3f55b8-12f8-4245-8ef2-3022b4f6f120",
+                                                    "f65fff84-6cad-4a11-9a0a-b89430c03397"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "5e5eee1e-a1d9-4e5f-9db5-f00830c56309",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_MORGAN_TUK_TUK_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_sign_morgan_tuk_tuk.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_MORGAN_TUK_TUK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Tuk_Tuk_Burning"
+                                        ]
+                                    },
+                                    "Transition": "Check_Kill"
+                                }
+                            },
+                            "Check_Kill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 1
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "f65fff84-6cad-4a11-9a0a-b89430c03397"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                },
+                {
+                    "Id": "a464f48d-5059-4559-9a00-fc2c59251672",
+                    "Name": "UI_CHALLENGES_TIGER_PRO1_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/bangkok/tiger_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_TIGER_PRO1_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_BANGKOK",
+                    "ParentLocationId": "LOCATION_PARENT_BANGKOK",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_TIGER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["ad5f9051-045d-4b8e-8a4d-d84429f467f8"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/COLORADO/_LEGACY_COLORADO_CHALLENGES.json
+++ b/contractdata/COLORADO/_LEGACY_COLORADO_CHALLENGES.json
@@ -3816,6 +3816,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COLORADO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -3886,6 +3887,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COLORADO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -3955,6 +3957,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COLORADO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4159,6 +4162,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COLORADO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4325,6 +4329,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COLORADO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4424,6 +4429,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COLORADO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4557,6 +4563,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COLORADO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {

--- a/contractdata/COLORADO/_LEGACY_COLORADO_PRO1_CHALLENGES.json
+++ b/contractdata/COLORADO/_LEGACY_COLORADO_PRO1_CHALLENGES.json
@@ -1,0 +1,1741 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_COLORADO",
+        "GameVersions": ["h1"]
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "OrderIndex": 0,
+            "Challenges": [
+                {
+                    "Id": "2bec7ae6-6d0f-4a07-b707-016cea97c7ba",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_PARVATI_FUELTANK_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_parvati_fueltank.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_PARVATI_FUELTANK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "e5356046-859c-4d72-b6d5-01767af84ad4"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "5d6cfbad-6a3c-45b2-8ea1-039cc81d1848",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_NO_EVIDENCE_NAME",
+                    "ImageName": "images/challenges/colorado/bull_47_no_evidence.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_NO_EVIDENCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "e7988e07-a5c9-4eb4-8f86-2f48e3c18088",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_BERG_LAWNMOWER_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_berg_lawnmower.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_BERG_LAWNMOWER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "1a8a827f-932e-49c0-a1b3-e3201795ae19"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "a82e5beb-ab03-460d-9171-6b0bc3e0754b"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "05c6ca04-5182-4265-8523-392f8e7d9366",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_GRAVES_DROWN_NAME",
+                    "ImageName": "images/challenges/colorado/bull_sign_graves_drown.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_GRAVES_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Graves_At_Pit"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Graves_Not_At_Pit"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "963c2774-cb9a-4b0c-ab69-210b2405383b"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "PushOver"
+                                                        ]
+                                                    },
+                                                    "in": "$Value.DamageEvents"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "a49ba55a-0793-4de7-8558-4d3982cdc518",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_ALL_ACCIDENT_KILL_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_all_accident_kill.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_ALL_ACCIDENT_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "TargetGoal": 4,
+                            "TargetKilled": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetKilled",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4",
+                                                            "1a8a827f-932e-49c0-a1b3-e3201795ae19",
+                                                            "963c2774-cb9a-4b0c-ab69-210b2405383b",
+                                                            "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$Value.RepositoryId"
+                                                                ]
+                                                            },
+                                                            "in": "$.TargetKilled"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "89762b1d-11b3-42cf-921c-4e27ea934dbc",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_ROSE_DROWN_NAME",
+                    "ImageName": "images/challenges/colorado/bull_sign_rose_drown.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_ROSE_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "5729e693-14ca-4283-b8c3-059a592d968f"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "d98dc826-1d86-4aa6-a42f-51be735c2e5c",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/colorado/bull_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "0cd2b917-eb26-4f19-90c2-a5e16eb18cef"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "e5c0d1a4-72b0-4cc0-857d-8bb155ea09f4"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "6c943798-8ca7-42cc-861a-becdb32017da"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "bd0cc571-e4a3-41f1-9b9b-608cdecc09c1"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "b97e71a9-0919-466e-8a09-5a1701af9645",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_BEGR_BLOWUP_NAME",
+                    "ImageName": "images/challenges/colorado/bull_sign_berg_blowup.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_BEGR_BLOWUP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "1a8a827f-932e-49c0-a1b3-e3201795ae19"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "7ac0cece-f9cf-4942-baa1-ed30469160a3"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "6a36e4a6-1e7e-47d0-a0bb-6b9772947158",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_POISON_ALL_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_poison_all.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_POISON_ALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "TargetGoal": 4,
+                            "TargetKilled": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetKilled",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4",
+                                                            "1a8a827f-932e-49c0-a1b3-e3201795ae19",
+                                                            "963c2774-cb9a-4b0c-ab69-210b2405383b",
+                                                            "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillClass",
+                                                        "poison"
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$Value.RepositoryId"
+                                                                ]
+                                                            },
+                                                            "in": "$.TargetKilled"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "12273614-8411-466b-b088-6e39880fc6af",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_PARVATI_CARLIFT_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_parvati_carlift.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_PARVATI_CARLIFT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "ed4ef3fe-4cd2-414d-993a-8c98e47cfc7a"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "9232950e-30e4-4ca9-87cf-920351d9789a",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/colorado/bull_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "8683b87f-781b-4044-9809-9718b1129461",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_DOUBLE_KILL_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_double_kill.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_DOUBLE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Is_DoubleKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "7e65da7a-9dfc-46e3-80c8-a8a79f95dba7"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "7e65da7a-9dfc-46e3-80c8-a8a79f95dba7"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "7e65da7a-9dfc-46e3-80c8-a8a79f95dba7"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "7e65da7a-9dfc-46e3-80c8-a8a79f95dba7"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "095c9b59-873a-4c5c-acba-a19f5f78b818",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_PARVATI_RAM_NAME",
+                    "ImageName": "images/challenges/colorado/bull_sign_parvati_ram.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_PARVATI_RAM_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "7e65da7a-9dfc-46e3-80c8-a8a79f95dba7"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "b638bd73-a1f1-43df-86cc-ad3b5777bdae",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_ROSE_BLOWUP_NAME",
+                    "ImageName": "images/challenges/colorado/bull_sign_rose_blowup.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_ROSE_BLOWUP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "f22c3477-996d-4cfd-88cd-50301bdcb3fb"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "507257e0-53b2-4385-9a88-c3a25637f008",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_SA_SUIT_NAME",
+                    "ImageName": "images/challenges/colorado/bull_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_SA_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "0cd2b917-eb26-4f19-90c2-a5e16eb18cef"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "e5c0d1a4-72b0-4cc0-857d-8bb155ea09f4"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "6c943798-8ca7-42cc-861a-becdb32017da"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "bd0cc571-e4a3-41f1-9b9b-608cdecc09c1"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "4425cdf4-3158-486b-bff2-cd6a3e7d7174",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_GRAVES_CHANDELIER_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_graves_chandelier.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_GRAVES_CHANDELIER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "963c2774-cb9a-4b0c-ab69-210b2405383b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "de28fae2-68c7-4f31-8690-8fe4f90995f9"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "671c4c9d-e586-405d-a211-d51831a87e13",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_ROSE_WATCH_NAME",
+                    "ImageName": "images/challenges/colorado/bull_sign_rose_watch.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_ROSE_WATCH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "66d7a0d3-7ee8-4065-9475-8765fca06faa"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "0700c419-2b8d-415c-99be-ddbb1120c55a",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/colorado/bull_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true,
+                            "SniperKills": [],
+                            "TargetDied": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            true,
+                                            "$.RecordingDestroyed",
+                                            "$.TargetDied"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "SniperKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$contains": [
+                                                "$Value.KillItemCategory",
+                                                "sniperrifle"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.SniperKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4",
+                                                    "1a8a827f-932e-49c0-a1b3-e3201795ae19",
+                                                    "963c2774-cb9a-4b0c-ab69-210b2405383b",
+                                                    "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "3e809a03-2437-4779-aa8a-decbd90f3cc3",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_FIBERWIRE_ALL_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_fiberwire_all.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_FIBERWIRE_ALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Count": 0,
+                            "TargetGoal": 4,
+                            "TargetKilled": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$inc": "Count",
+                                            "$pushunique": [
+                                                "TargetKilled",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$Value.RepositoryId"
+                                                            ]
+                                                        },
+                                                        "in": [
+                                                            "5b54d9fb-fa85-4302-a8d5-c5c5e97344c4",
+                                                            "1a8a827f-932e-49c0-a1b3-e3201795ae19",
+                                                            "963c2774-cb9a-4b0c-ab69-210b2405383b",
+                                                            "d94f3e83-36e3-453c-8d4b-28c93229826a"
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemRepositoryId",
+                                                        "1a11a060-358c-4054-98ec-d3491af1d7c6"
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$Value.RepositoryId"
+                                                                ]
+                                                            },
+                                                            "in": "$.TargetKilled"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$.Count", "$.TargetGoal"]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                },
+                {
+                    "Id": "fc85d6b7-0a97-429c-ad69-e28828c6c70a",
+                    "Name": "UI_CHALLENGES_BULL_PRO1_GRAVES_GAS_CANISTER_NAME",
+                    "ImageName": "images/challenges/colorado/bull_exp_graves_gas_canister.jpg",
+                    "Description": "UI_CHALLENGES_BULL_PRO1_GRAVES_GAS_CANISTER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COLORADO",
+                    "ParentLocationId": "LOCATION_PARENT_COLORADO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_BULL_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "963c2774-cb9a-4b0c-ab69-210b2405383b"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceType",
+                                                            "1464cb31-e00b-4adc-8430-b8592d29f701"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "963c2774-cb9a-4b0c-ab69-210b2405383b"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceType",
+                                                            "fab9eacb-dcc6-41e5-894b-4b14acc34b78"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["69b58abc-6535-4092-9afe-c046b26303e6"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/HOKKAIDO/_LEGACY_HOKKAIDO_CHALLENGES.json
+++ b/contractdata/HOKKAIDO/_LEGACY_HOKKAIDO_CHALLENGES.json
@@ -4310,6 +4310,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_HOKKAIDO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4492,6 +4493,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_HOKKAIDO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4547,6 +4549,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_HOKKAIDO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4593,6 +4596,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_HOKKAIDO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -5008,6 +5012,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_HOKKAIDO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -5100,6 +5105,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_HOKKAIDO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -5177,6 +5183,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_HOKKAIDO_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {

--- a/contractdata/HOKKAIDO/_LEGACY_HOKKAIDO_PRO1_CHALLENGES.json
+++ b/contractdata/HOKKAIDO/_LEGACY_HOKKAIDO_PRO1_CHALLENGES.json
@@ -1,0 +1,1773 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_HOKKAIDO",
+        "GameVersions": ["h1"]
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "OrderIndex": 0,
+            "Challenges": [
+                {
+                    "Id": "61ff5f2a-92ef-47d4-a5da-15d28665906b",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "a7eee40e-0fa0-418d-be84-22135176764f",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true,
+                            "SniperKills": [],
+                            "TargetDied": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            true,
+                                            "$.RecordingDestroyed",
+                                            "$.TargetDied"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "SniperKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$contains": [
+                                                "$Value.KillItemCategory",
+                                                "sniperrifle"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.SniperKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "9bebb40a-3746-4ba2-8bfc-a1fcabaec72c"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "a26f191d-c928-4115-8bd8-2c2e58adb1fe",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_YOGA_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_sign_yamazuki_yoga.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_YOGA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9bebb40a-3746-4ba2-8bfc-a1fcabaec72c"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "40237d59-f3c8-46a7-9760-49eac05315d6"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "afa06ca5-53f3-4022-992c-3206a37b2929",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_BRIDGESNIPE_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_exp_yamazaki_bridgesnipe.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_BRIDGESNIPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_On_Bridge"
+                                        ]
+                                    },
+                                    "Transition": "Sniper_Position"
+                                }
+                            },
+                            "Sniper_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_Off_Bridge"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9bebb40a-3746-4ba2-8bfc-a1fcabaec72c"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "sniperrifle"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "c7ba2212-581b-457d-b38e-6873e8f177ad",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_SPIDERMACHINE_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_soders_spidermachine.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_SPIDERMACHINE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Spidermachine_Kill"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Heart_Kill"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "87146cd3-8f9d-4f28-a3e2-6962b9f7ec9d",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_CLOSEKILL_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_exp_soder_closekill.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_CLOSEKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Body_Kill"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Heart_Kill"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "b7d311d8-c71a-4cfd-a768-7367f9b5e366",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SA_SUIT_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SA_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "0e7dd303-c9bb-42cc-aca0-70499931d098"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "2fc483c8-500c-4475-ba5d-e2cdd6ccc64c"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "74b1ad25-06cd-41a2-9cf5-9dd5dac7345d"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "fedf6cd3-d076-4037-b7d8-1449726b4c0a"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "cd0885e1-2d84-4af2-9640-7b684870d330",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_ELECTROCUTE_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_sign_soders_electrocute.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_ELECTROCUTE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Soder_Electrocuted"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Heart_Kill"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "ef34aebe-8401-47b4-9849-891f7714c186",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_HEART_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_sign_soders_heart.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_HEART_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Heart_Kill"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Event_metricvalue",
+                                                        "Poison_Kill"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Event_metricvalue",
+                                                        "Surgeon_Kills_Soders"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Event_metricvalue",
+                                                        "47_Performs_Surgery"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Event_metricvalue",
+                                                        "47_Reveal_Kill"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Event_metricvalue",
+                                                        "Body_Kill"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Event_metricvalue",
+                                                        "Spidermachine_Kill"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Event_metricvalue",
+                                                        "Soder_Electrocuted"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "9aff985a-1439-4904-b0b4-8b0f18177a7e",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SILENT_ASSASSINE_NINJA_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_silent_assassin_ninja.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SILENT_ASSASSINE_NINJA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "df752dfa-623d-4750-83a6-8b4aba1d8e08"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "85ef518f-0e94-4e5e-9fd2-66fb84d2d0bb"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "a786fc74-b379-41f4-a4ac-ce970ee88b2c"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "bdc80464-31dd-440d-ad79-2767b923a0a4"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "be6045fd-26ab-4a3b-a6ce-b1ccdf405d09"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "2fc483c8-500c-4475-ba5d-e2cdd6ccc64c"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "74b1ad25-06cd-41a2-9cf5-9dd5dac7345d"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "fedf6cd3-d076-4037-b7d8-1449726b4c0a"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "f5b7cdee-9f40-447e-856e-93d74734dec7",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_SUSHI_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_sign_yamazaki_sushi.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_SUSHI_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_Poisoned_Sushi"
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "1fe3637f-8f65-41cb-a840-9a5a2447c114",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_SURGERY_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_sign_soders_surgery.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_SURGERY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "47_Performs_Surgery"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Heart_Kill"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "3e641fd3-bc96-4776-9fd0-c01b22c81035",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_POISON_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_soders_poison.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Poison_Kill"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Heart_Kill"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "714fe4d8-a9ae-4119-ab86-d7a0f2d8ddae",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_SMOKE_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_sign_yamazaki_smoke.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_SMOKE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_Smoking"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_Not_Smoking"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9bebb40a-3746-4ba2-8bfc-a1fcabaec72c"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "PushOver"
+                                                        ]
+                                                    },
+                                                    "in": "$Value.DamageEvents"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "004e2910-6ba1-4f91-9e97-e5ec3f0cdd7a",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_GASLAMP_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_exp_yamazaki_gaslamp.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_GASLAMP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9bebb40a-3746-4ba2-8bfc-a1fcabaec72c"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "518b6c2d-2a3d-4f87-afbf-2e84393d260d"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "5107484a-9736-418d-b239-e8270f712a62",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_NO_EVIDENCE_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_47_no_evidence.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_NO_EVIDENCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "7463f02a-8bcf-4c4f-84fe-ee1dc0413d2a",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "0e7dd303-c9bb-42cc-aca0-70499931d098"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "2fc483c8-500c-4475-ba5d-e2cdd6ccc64c"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "74b1ad25-06cd-41a2-9cf5-9dd5dac7345d"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "df752dfa-623d-4750-83a6-8b4aba1d8e08"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "fedf6cd3-d076-4037-b7d8-1449726b4c0a"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "ba2180d1-c012-4c44-b740-eeb00d7d1e11",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_SAUNA_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_exp_yamazaki_sauna.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_SAUNA_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_Killed"
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "57dac589-bffb-4f0e-92a1-f6aab3f52ae1",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_REVEALKILL_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_sign_soders_revealkill.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_SODERS_REVEALKILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "47_Reveal_Kill"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Heart_Kill"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                },
+                {
+                    "Id": "3c0daea3-624b-4404-b083-f8ee9f6259d2",
+                    "Name": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_DIRECTORPUSH_NAME",
+                    "ImageName": "images/challenges/hokkaido/snowcrane_exp_yamazaki_directorpush.jpg",
+                    "Description": "UI_CHALLENGES_SNOWCRANE_PRO1_YAMAZAKI_DIRECTORPUSH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "ParentLocationId": "LOCATION_PARENT_HOKKAIDO",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SNOW_CRANE_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_On_Platform"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Yuki_Off_Platform"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "9bebb40a-3746-4ba2-8bfc-a1fcabaec72c"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "f6f53c39-17f9-48cf-9594-7a696b036d61"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "PushOver"
+                                                        ]
+                                                    },
+                                                    "in": "$Value.DamageEvents"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "pro1", "assassination"],
+                    "InclusionData": {
+                        "ContractIds": ["3d885714-fa9a-4438-9e0f-c58dbcaab8b8"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/MARRAKESH/_LEGACY_MARRAKECH_PRO1_CHALLENGES.json
+++ b/contractdata/MARRAKESH/_LEGACY_MARRAKECH_PRO1_CHALLENGES.json
@@ -1,0 +1,1799 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_MARRAKECH",
+        "GameVersions": ["h1"]
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "OrderIndex": 0,
+            "Challenges": [
+                {
+                    "Id": "e749fae5-357f-44eb-898a-0901257539a3",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_PRINTINGPRESS_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_zaydan_printingpress.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_PRINTINGPRESS_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "6ab594fe-bab7-4ed3-a71c-b9b3433d453f"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "d53b6f4a-a334-41d1-b4a9-09e756fa6365",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "54918249-f3b7-431c-a47a-0f7d67a5815f",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_PRISONER_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_zaydan_prisoner.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_PRISONER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "d0fb94fa-e219-4c06-a4f9-3150083a8421"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "ab2af277-0908-4dc7-92f5-175af473426a",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_ELECTRICUTE_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_stranberg_electricute.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_ELECTRICUTE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "b10a4de0-cd26-4f35-8d63-97f255d5f637"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "f8921431-3b99-4c4b-b904-1d3c94a976c1",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_MASSEUSE_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_stranberg_masseuse.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_MASSEUSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "18914414-5f69-4f3d-856e-a6b4a61415bf"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "47707cff-4125-4380-9eeb-38d7546636a5",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "565614ab-213e-4277-8429-950267941d5e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "de8c6844-9d28-4cfc-a165-baa3373ae811"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "70f9c93c-57fa-4d61-9cb8-6fcaa0651b0e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "66ff5ba4-8ebc-4526-8e05-cdb8a055a4c8"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "52598840-4d4d-46de-9446-5f9c64760105"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "529dbda2-c03e-4702-83be-45ec5c892d04",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_SA_SUIT_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_SA_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "565614ab-213e-4277-8429-950267941d5e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "de8c6844-9d28-4cfc-a165-baa3373ae811"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "70f9c93c-57fa-4d61-9cb8-6fcaa0651b0e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "66ff5ba4-8ebc-4526-8e05-cdb8a055a4c8"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "52598840-4d4d-46de-9446-5f9c64760105"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "533ffb36-f6ab-4c4f-952c-4f8394fcc28c",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_MOOSE_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_stranberg_moose.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_MOOSE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "0b27b195-6c10-438e-8eb9-812d4ffa35af"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "d16cf33e-4345-46b5-bfa5-5585c74420d9",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_EXPLOSSION_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_zaydan_explossion.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_EXPLOSSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "733df50d-10dc-4d00-a8d2-b5941c6f3358"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "af60e15a-8ddd-4d02-9b1e-6256c4f0cfd0",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_DANCE_KILL_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_exp_zaydan_dance_kill.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_DANCE_KILL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Dance_Party"
+                                        ]
+                                    },
+                                    "Transition": "Check_Kill"
+                                }
+                            },
+                            "Check_Kill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "ca31c88f-d15e-407b-8407-231f1b068402"
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Dance_Party_End"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "02c83486-6a4e-4c0c-9aa5-7bc92e503646",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_BOTH_TURRET_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_both_turret.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_BOTH_TURRET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Is_DoubleKill": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "dc3c70a0-9f34-48a4-9828-3fa2ba8493bd"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "dc3c70a0-9f34-48a4-9828-3fa2ba8493bd"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "dc3c70a0-9f34-48a4-9828-3fa2ba8493bd"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.SetPieceId",
+                                                            "dc3c70a0-9f34-48a4-9828-3fa2ba8493bd"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "00cc0c8d-79eb-45bd-8b9b-8164834dadd1",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_INTERVIEW_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_stranberg_camexplossion.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_INTERVIEW_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Signature_Interview_Explosive_Kill"
+                                        ]
+                                    },
+                                    "Transition": "Interview_Start"
+                                }
+                            },
+                            "Interview_Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "explosive"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "e0fc86fb-a852-4652-bb5c-b591f7bfeb29"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Signature_Interview_End"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "07ded0ad-2449-44e3-b618-9f238ad71ac0",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_NO_EVIDENCE_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_47_no_evidence.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_NO_EVIDENCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "f3e8ac60-1419-4a91-a861-c6108a3dffde",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_INTERN_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_stranberg_intern.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_INTERN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "65f23b45-f5ab-4ede-82ec-46e4de38c0e9"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillItemCategory",
+                                                    "fiberwire"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "b930882c-c7a7-4d07-9d44-ca305834f307",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_BOTH_NEUTRAL_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_both_neutral.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_BOTH_NEUTRAL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Zaydan_killed": false,
+                            "Stranberg_killed": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceType",
+                                                        "93f3b249-1a2c-46e0-a575-1136a4d00e58"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$set": ["Zaydan_killed", true]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceType",
+                                                        "93f3b249-1a2c-46e0-a575-1136a4d00e58"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Actions": {
+                                            "$set": ["Stranberg_killed", true]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                true,
+                                                "$.Zaydan_killed",
+                                                "$.Stranberg_killed"
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "e07e5d49-5090-4c8a-93b1-ce92c867600d",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_KIDS_PAINTING_NAME",
+                    "ImageName": "images/challenges/marrakech/marrakech_all_kids_paintings.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_KIDS_PAINTING_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "Painting_A": false,
+                            "Painting_B": false,
+                            "Painting_C": false,
+                            "Painting_D": false,
+                            "Painting_E": false,
+                            "Painting_F": false,
+                            "Painting_G": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "ValidDisguise": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Actions": {
+                                            "$set": ["Painting_A", true]
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Painting_A"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["Painting_B", true]
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Painting_B"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["Painting_C", true]
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Painting_C"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["Painting_D", true]
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Painting_D"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["Painting_E", true]
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Painting_E"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["Painting_F", true]
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Painting_F"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["Painting_G", true]
+                                        },
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Painting_G"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                true,
+                                                "$.Painting_A",
+                                                "$.Painting_B",
+                                                "$.Painting_C",
+                                                "$.Painting_D",
+                                                "$.Painting_E",
+                                                "$.Painting_F",
+                                                "$.Painting_G"
+                                            ]
+                                        },
+                                        "Transition": "FounAllPaintings"
+                                    }
+                                ]
+                            },
+                            "Start": {
+                                "Disguise": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value",
+                                            "6136fa6a-3f1f-4606-9b87-fde9538966dc"
+                                        ]
+                                    },
+                                    "Transition": "ValidDisguise"
+                                }
+                            },
+                            "FounAllPaintings": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "ca31c88f-d15e-407b-8407-231f1b068402"
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "9e4f1ecc-9b05-47b9-add6-dcd654a7c27b",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_DROWN_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_stranberg_drown.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_STRANBERG_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "b38b0b62-8071-4761-b2a5-2f635cd8da1b"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "cb0b0bc6-c237-45e7-8345-e3882fec01a2",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_TOILET_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_zaydans_toilet.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_TOILET_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "1cf9e68a-c7a0-49d7-af89-a699dad2c805"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "88beba9f-7e12-40ca-a2ea-ead9a861e759",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_OILLAMP_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_sign_zaydan_oilamp.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_ZAYDAN_OILLAMP_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.setpieceType_metricvalue",
+                                            "DistractionFixed"
+                                        ]
+                                    },
+                                    "Transition": "Trap_Set"
+                                }
+                            },
+                            "Trap_Set": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 2
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "e4bc6f9e-def7-4155-9524-16da8d68d4ad"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                },
+                {
+                    "Id": "c88429f2-481d-46cc-b479-ffdabe0e0e34",
+                    "Name": "UI_CHALLENGES_SPIDER_PRO1_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/marrakech/spider_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_SPIDER_PRO1_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_MARRAKECH",
+                    "ParentLocationId": "LOCATION_PARENT_MARRAKECH",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_SPIDER_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true,
+                            "SniperKills": [],
+                            "TargetDied": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            true,
+                                            "$.RecordingDestroyed",
+                                            "$.TargetDied"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "SniperKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$contains": [
+                                                "$Value.KillItemCategory",
+                                                "sniperrifle"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.SniperKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "b38b0b62-8071-4761-b2a5-2f635cd8da1b",
+                                                    "ca31c88f-d15e-407b-8407-231f1b068402"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", false]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["7b2d5500-7853-4ad0-b68a-14be791cfba2"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/MARRAKESH/_LEGACY_MARRAKESH_CHALLENGES.json
+++ b/contractdata/MARRAKESH/_LEGACY_MARRAKESH_CHALLENGES.json
@@ -5919,6 +5919,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_MARRAKECH_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -6129,6 +6130,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_MARRAKECH_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -6215,6 +6217,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_MARRAKECH_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -6310,6 +6313,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_MARRAKECH_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -6356,6 +6360,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_MARRAKECH_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -6399,6 +6404,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_MARRAKECH_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -6573,6 +6579,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_MARRAKECH_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {

--- a/contractdata/PARIS/_LEGACY_PARIS_CHALLENGES.json
+++ b/contractdata/PARIS/_LEGACY_PARIS_CHALLENGES.json
@@ -4833,6 +4833,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_PARIS_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4876,6 +4877,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_PARIS_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4942,6 +4944,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_PARIS_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -4988,6 +4991,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_PARIS_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -5059,6 +5063,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_PARIS_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -5105,6 +5110,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_PARIS_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -5151,6 +5157,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_PARIS_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {

--- a/contractdata/PARIS/_LEGACY_PARIS_PRO1_CHALLENGES.json
+++ b/contractdata/PARIS/_LEGACY_PARIS_PRO1_CHALLENGES.json
@@ -1,0 +1,1906 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_PARIS",
+        "GameVersions": ["h1"]
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "OrderIndex": 0,
+            "Challenges": [
+                {
+                    "Id": "29042c88-fdbf-4990-bde7-0584027edb7f",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "b0d020ed-2e32-4f78-862a-07e500e84210",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_EXPLOSION_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_both_explosion.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_EXPLOSION_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Is_DoubleKill": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 0.1
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillClass",
+                                                            "explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillClass",
+                                                            "explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$or": [
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillClass",
+                                                            "explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "$and": [
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.RepositoryId",
+                                                            "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$eq": [
+                                                            "$Value.KillClass",
+                                                            "explosion"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Is_DoubleKill"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "6f685377-c690-4fae-8a9d-09ab995f9d4a",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_IN_CHAND_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_both_in_chand1.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_IN_CHAND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "ChandlierKills": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "ChandlierKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "06244a0c-c4a5-450a-8b9f-a5645e38acfa"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.ChandlierKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0",
+                                                    "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                ]
+                                            }
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "90f03fbd-54f6-49f5-8313-118d54158065",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_DROWN_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_dahlia_drown.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "24a2ac1e-4dd7-4883-8cc9-1979f9e4ef48",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_IAGOHACK_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_dahlia_iagohack.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_IAGOHACK_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "IagoHacked": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$any": {
+                                                            "?": {
+                                                                "$eq": [
+                                                                    "$.#",
+                                                                    "$.##"
+                                                                ]
+                                                            },
+                                                            "in": "$Value.DamageEvents"
+                                                        }
+                                                    },
+                                                    "in": [
+                                                        "Subdue",
+                                                        "CoupDeGrace"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Iago_HackFixed"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                }
+                            },
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Iago_Hack_Response"
+                                        ]
+                                    },
+                                    "Transition": "IagoHacked"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "7fb6e4dc-aabd-4f98-b35d-2f0a839b716f",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true,
+                            "SniperKills": [],
+                            "TargetDied": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            true,
+                                            "$.RecordingDestroyed",
+                                            "$.TargetDied"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "SniperKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$contains": [
+                                                "$Value.KillItemCategory",
+                                                "sniperrifle"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.SniperKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0",
+                                                    "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", false]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "sniper", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "78209921-103a-4867-b2cf-358d67a2d54f",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_INTERVIEW_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_novikov_interview.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_INTERVIEW_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "CameraDestoryed": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 5
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "InterviewStart_State": {
+                                "Level_Setup_Events": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Novikov_Interview_Done"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.Event_metricvalue",
+                                                "Camera_destoryed"
+                                            ]
+                                        },
+                                        "Transition": "CameraDestoryed"
+                                    }
+                                ]
+                            },
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Novikov_Interview_start"
+                                        ]
+                                    },
+                                    "Transition": "InterviewStart_State"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "1098ef9d-9cc5-4071-adf8-36ea3cb86621",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_CHAND_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_dahlia_chand1.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_CHAND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "c09be259-2823-4568-b4ea-7cb83093cf97"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "7a4d3095-cbfb-4a28-940c-ceddec7ee27a"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "9e626463-f1f3-409c-b40b-3ee202333ee3",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_CHAND_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_novikov_chand1.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_CHAND_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "Collection": [
+                                "966a8c88-76eb-4cfa-a50a-b927618b22f5",
+                                "69495224-e982-4a79-989c-afff7e980490",
+                                "e3c339ce-b390-45d4-ae37-7151947c3fe1",
+                                "0612c231-65f3-43a8-a6f6-a0f2805ce234"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceType"
+                                                        ]
+                                                    },
+                                                    "in": "$.Collection"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "d19a68be-3119-466f-8d07-3fb86f99bfc0",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_both_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "FiberWireKills": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "FiberWireKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "fiberwire"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.FiberWireKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0",
+                                                    "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                ]
+                                            }
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "5ba0a3cc-ca89-42eb-a20f-44549ef466ae",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "aa4cdd0b-8fcf-4160-a049-c15a19c82af1"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "04834714-406b-444e-b0d8-2f1054c1f8b5"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "c6765d3e-4031-4778-a5c5-a6d875131ea4"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "be610298-cbe8-47ce-9e90-951d2aae6f39"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "79cf3c19-7c25-402d-b883-480e659a3d04",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_POISON_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_dahlia_poison1.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "Collection": [
+                                "e37f114a-13d4-479a-8da4-205db7dec084",
+                                "3b65524a-0b68-4d17-841b-221c1e637560"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "poison"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceId"
+                                                        ]
+                                                    },
+                                                    "in": "$.Collection"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "981b0a3a-820e-4116-b8d4-48b83f876b20",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_FALL_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_both_fall.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_FALL_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "8f241099-1afa-4950-8a4a-54b13e8d5a14"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "119553ef-4ea6-4366-8303-49fb3d082eea",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_SA_SUIT_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_47_sa_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_SA_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "aa4cdd0b-8fcf-4160-a049-c15a19c82af1"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "04834714-406b-444e-b0d8-2f1054c1f8b5"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "c6765d3e-4031-4778-a5c5-a6d875131ea4"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "be610298-cbe8-47ce-9e90-951d2aae6f39"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "suitonly", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "2c2611f4-29f5-4b1b-9173-57be715e9b38",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_DROWN_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_novikov_drown.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "8d25d4da-0969-456f-99e8-6f794af3d462",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_LIGHTRIG_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_novikov_lightrig.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_LIGHTRIG_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "675e4629-a251-4597-bf60-a93fe8d5a0f6"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "af42a3c4-4e08-49fa-bedc-8e48058693bf",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_NO_EVIDENCE_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_47_no_evidence.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_NO_EVIDENCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "4a0e364e-35a2-4884-b683-992270b46642",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_KRUGER_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_dahlia_kruger.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_DAHLIA_KRUGER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "MeetigStart": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "642c20f9-bf41-41b4-b0bb-2491b5be938a"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "47Kruger_Dahlia_End"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "47Kruger_Dahlia"
+                                        ]
+                                    },
+                                    "Transition": "MeetigStart"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "a3e749d6-2979-4326-a2db-f87343a66d6f",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_SEINE_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_novikov_seine.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_NOVIKOV_SEINE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Novikov_SnapKill"
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                },
+                {
+                    "Id": "03cc4c40-f1bb-400a-9a9b-fc4d90f1fcb5",
+                    "Name": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_SNIPE_NAME",
+                    "ImageName": "images/challenges/paris/peacock_c_sign_both_snipe.jpg",
+                    "Description": "UI_CHALLENGES_PEACOCK_PRO1_BOTH_SNIPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_PARIS",
+                    "ParentLocationId": "LOCATION_PARENT_PARIS",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_PEACOCK_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "MagolisKilled": false,
+                            "NovikovKilled": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "FireworkStart"
+                                        ]
+                                    },
+                                    "Transition": "Triggered"
+                                }
+                            },
+                            "StartTimer": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 11
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "AmbientChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value.Ambient", "Combat"]
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "FireworkEnd"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "Triggered": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "FireworkEnd"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "AmbientChanged": {
+                                    "Condition": {
+                                        "$eq": ["$Value.Ambient", "Combat"]
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "052434e7-f451-462f-a9d7-13657cb047c0"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "StartTimer"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "edad702b-5b37-4dc1-a47c-36a1588f1d3f"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "sniperrifle"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "StartTimer"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["5ee4d771-6ab3-41fa-ab4f-04970d0ca327"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/contractdata/SAPIENZA/_LEGACY_SAPIENZA_CHALLENGES.json
+++ b/contractdata/SAPIENZA/_LEGACY_SAPIENZA_CHALLENGES.json
@@ -9037,6 +9037,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COASTALTOWN_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -9137,6 +9138,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COASTALTOWN_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -9230,6 +9232,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COASTALTOWN_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -9329,6 +9332,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COASTALTOWN_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -9395,6 +9399,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COASTALTOWN_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -9438,6 +9443,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COASTALTOWN_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {
@@ -9524,6 +9530,7 @@
                     "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_LOCATION",
                     "TypeTitle": "UI_LOCATION_PARENT_COASTALTOWN_CITY",
                     "TypeIcon": "arrowright",
+                    "Type": "location",
                     "XpModifier": {},
                     "RuntimeType": "Hit",
                     "Definition": {

--- a/contractdata/SAPIENZA/_LEGACY_SAPIENZA_PRO1_CHALLENGES.json
+++ b/contractdata/SAPIENZA/_LEGACY_SAPIENZA_PRO1_CHALLENGES.json
@@ -1,0 +1,1748 @@
+{
+    "meta": {
+        "Location": "LOCATION_PARENT_COASTALTOWN",
+        "GameVersions": ["h1"]
+    },
+    "groups": [
+        {
+            "Name": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+            "Image": "images/challenges/categories/assassination/tile.jpg",
+            "Icon": "challenge_category_assassination",
+            "CategoryId": "assassination",
+            "Description": "UI_MENU_PAGE_CHALLENGE_CATEGORY_DESCRIPTION_SIGNATUREKILL",
+            "OrderIndex": 0,
+            "Challenges": [
+                {
+                    "Id": "ac01eb2f-1f5f-4151-9324-01e31f06945f",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_STALACTITE_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_francesca_stalactite.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_STALACTITE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "24704419-6f21-4c0b-a4ff-ecf26f247cfc"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "25ac046a-4c12-4905-823a-099fc2965a81",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_PUSH_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_silvio_push.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_PUSH_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Silvio_At_Cliff"
+                                        ]
+                                    },
+                                    "Transition": "Kill_Position"
+                                }
+                            },
+                            "Kill_Position": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Silvio_Not_At_Cliff"
+                                        ]
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "PushOver"
+                                                        ]
+                                                    },
+                                                    "in": "$Value.DamageEvents"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "dd0b94a4-bc53-44f2-bef6-12de2637c4da",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SA_SUIT_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_47_sa_suit.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SA_SUIT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "249659f3-8989-4ffc-b727-4902e954605f"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "8fd339e1-ea06-4aee-bd65-0c89b34e4e7e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "1021798e-cec1-4b43-ba33-69b7d53da867"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "495222ec-e8c9-416a-a41f-4bdfc3e6b80e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "suitonly", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "f38e1739-0386-428d-bff1-18501b04cbdb",
+                    "Name": "UI_CHALLENGES_OCTOPUS_SIGN_SILVIO_TELESCOPE_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_silvio_telescope.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_TELESCOPE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "a84ba351-285a-4f07-8758-2d7640401aad"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "167b52d4-444e-4cc7-91d9-3f83436ac376",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_ELECTROCUTE_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_francesca_electrocute.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_ELECTROCUTE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "6260478d-0a5e-4d0b-bd06-9184bbf93289"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "21cb23c5-405c-4eb6-95a4-477ace8f9e9f",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_SHOOT_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_silvio_shoot.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_SHOOT_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Silvio_LieDown"
+                                        ]
+                                    },
+                                    "Transition": "Therapy_session"
+                                }
+                            },
+                            "Therapy_session": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.IsHeadshot",
+                                                    true
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "fbf69e85-da3c-423b-bef9-da1b64f35f6b"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "silvio_session_over"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "37faedc3-5ad8-4eba-94ff-484abddb395d",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SNIPER_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_47_sniper_assassin.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SNIPER_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true,
+                            "SniperKills": [],
+                            "TargetDied": false
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [
+                                            true,
+                                            "$.RecordingDestroyed",
+                                            "$.TargetDied"
+                                        ]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "SniperKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$contains": [
+                                                "$Value.KillItemCategory",
+                                                "sniperrifle"
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "SniperKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.RepositoryId",
+                                                        "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.SetPieceId",
+                                                        "a84ba351-285a-4f07-8758-2d7640401aad"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.SniperKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "0dfaea51-3c36-4722-9eff-f1e7ef139878",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": ["$Value.IsTarget", false]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["assassination", "sniper", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "3f6e41f5-e982-4ab9-b005-4a246bdeabf6",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_NO_EVIDENCE_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_47_no_evidence.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_NO_EVIDENCE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "655da1b2-bdae-4fcf-ad67-4b4f40b43066",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SILENT_ASSASSIN_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_47_silent_assassin.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILENT_ASSASSIN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "RecordingDestroyed": true
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "ContractEnd": {
+                                    "Condition": {
+                                        "$eq": [true, "$.RecordingDestroyed"]
+                                    },
+                                    "Transition": "Success"
+                                },
+                                "Kill": [
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    "$not": {
+                                                        "$eq": [
+                                                            "$Value.KillContext",
+                                                            1
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.Accident",
+                                                        false
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "Transition": "CheckNoticedKill"
+                                    }
+                                ],
+                                "CrowdNPC_Died": {
+                                    "Transition": "Failure"
+                                },
+                                "BodyFound": {
+                                    "Transition": "Failure"
+                                },
+                                "SecuritySystemRecorder": [
+                                    {
+                                        "Actions": {
+                                            "$set": [
+                                                "RecordingDestroyed",
+                                                false
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$eq": ["$Value.event", "spotted"]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["RecordingDestroyed", true]
+                                        },
+                                        "Condition": {
+                                            "$or": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "erased"
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.event",
+                                                        "destroyed"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "CheckNoticedKill": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "Start"
+                                },
+                                "DeadBodySeen": {
+                                    "Transition": "Failure"
+                                },
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "38308093-1c6f-4189-b215-5073aa3d0b18",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_DROWN_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_francesca_drown.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_DROWN_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceType",
+                                                    "7b28519a-3c66-4498-a61b-ae6926a85594"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "19b52d05-4177-4f25-85ae-51be5fc87bb7",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_BIOLAB_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_francesca_biolab.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_BIOLAB_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "86cdac5f-3064-4391-9602-098bf33acee5"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "b8bd44dd-683d-4249-89ab-94ff6fd291d7",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_PROPANE_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_francesca_propane.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_PROPANE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "DumpedShaft": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 4
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "setpieces": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.name_metricvalue",
+                                            "PropaneFlask"
+                                        ]
+                                    },
+                                    "Transition": "PropaneExploded"
+                                }
+                            },
+                            "PropaneExploded": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 3
+                                    },
+                                    "Transition": "Start"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.KillClass",
+                                                    "explosion"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "Start": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "ce43f926-6490-4f8f-b9bd-5d232a325e67"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.name_metricvalue",
+                                                    "ShaftDump"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "DumpedShaft"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "0205802c-86dc-4493-97a7-9cc936f61d27",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_POISON_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_francesca_poison.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "80c178f2-3aa2-44b5-ac60-04bb2dcbb319"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "b00bd1e7-bcbf-4cc7-83c5-9d4907be0c34",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_SMOTHER_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_silvio_smother.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_SMOTHER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Silvio_SmoothKill"
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "3d2fe7f0-46d0-45e4-b5e7-da067f9b9697",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_CHANDLIER_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_silvio_chandelier.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_CHANDLIER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {
+                            "Collection": [
+                                "2387d2a1-c3a9-4671-9894-6f9afbc6f84d",
+                                "725fc8a7-ca9a-414e-897a-601e21c141e6"
+                            ]
+                        },
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                                ]
+                                            },
+                                            {
+                                                "$any": {
+                                                    "?": {
+                                                        "$eq": [
+                                                            "$.#",
+                                                            "$Value.SetPieceType"
+                                                        ]
+                                                    },
+                                                    "in": "$.Collection"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "c24aa31c-13ea-48bc-b7d2-e4482d10d609",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_POISON_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_silvio_poison.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_POISON_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.SetPieceId",
+                                                    "959b204c-212b-4e5b-9ec2-93e096e42905"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "479116d3-333e-42b9-ab6b-e6a6f0040eda",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_SHREDDER_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_silvio_shredder.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SILVIO_SHREDDER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {},
+                        "Scope": "session",
+                        "States": {
+                            "IsBodyFlushed": {
+                                "setpieces": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.name_metricvalue",
+                                                    "BodyFlushed"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "58c3b7bc-8d89-48f8-927a-d9b4b7fdd8e4"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "End_Contract"
+                                },
+                                "spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "Start": {
+                                "BodyHidden": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.RepositoryId",
+                                            "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                        ]
+                                    },
+                                    "Transition": "ValidContainer"
+                                }
+                            },
+                            "ValidContainer": {
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 3
+                                    },
+                                    "Transition": "Failure"
+                                },
+                                "setpieces": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.name_metricvalue",
+                                                    "HideBody"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "58c3b7bc-8d89-48f8-927a-d9b4b7fdd8e4"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "IsBodyFlushed"
+                                },
+                                "spotted": {
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "f8b29a12-3189-4845-92d3-f4093da7657d",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_BOTH_FIBERWIRE_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_both_fiberwire.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_BOTH_FIBERWIRE_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Context": {
+                            "FiberWireKills": []
+                        },
+                        "Scope": "session",
+                        "States": {
+                            "Start": {
+                                "Kill": [
+                                    {
+                                        "Actions": {
+                                            "$pushunique": [
+                                                "FiberWireKills",
+                                                "$Value.RepositoryId"
+                                            ]
+                                        },
+                                        "Condition": {
+                                            "$and": [
+                                                {
+                                                    "$eq": [
+                                                        "$Value.IsTarget",
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "$eq": [
+                                                        "$Value.KillItemCategory",
+                                                        "fiberwire"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Actions": {
+                                            "$set": ["TargetDied", true]
+                                        },
+                                        "Condition": {
+                                            "$all": {
+                                                "?": {
+                                                    "$any": {
+                                                        "?": {
+                                                            "$eq": [
+                                                                "$.#",
+                                                                "$.##"
+                                                            ]
+                                                        },
+                                                        "in": "$.FiberWireKills"
+                                                    }
+                                                },
+                                                "in": [
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456",
+                                                    "0dfaea51-3c36-4722-9eff-f1e7ef139878"
+                                                ]
+                                            }
+                                        },
+                                        "Transition": "End_Contract"
+                                    }
+                                ]
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "67512ead-f2d0-44d6-bce4-f866af77d796",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_PIER_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_sign_francesca_pier.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_FRANCESCA_PIER_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "States": {
+                            "FrancescaAtPier": {
+                                "Spotted": {
+                                    "Transition": "Failure"
+                                },
+                                "Kill": {
+                                    "Condition": {
+                                        "$and": [
+                                            {
+                                                "$eq": [
+                                                    "$Value.RepositoryId",
+                                                    "94ab740b-b30f-4086-9aea-5c9c0de28456"
+                                                ]
+                                            },
+                                            {
+                                                "$eq": [
+                                                    "$Value.OutfitRepositoryId",
+                                                    "02a9f8e4-3ed1-4c29-9f73-88e0cf2d7b5e"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "Transition": "Check_unnoticed"
+                                },
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Francesca_NotAt_Pier"
+                                        ]
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "Start": {
+                                "Level_Setup_Events": {
+                                    "Condition": {
+                                        "$eq": [
+                                            "$Value.Event_metricvalue",
+                                            "Francesca_At_Pier"
+                                        ]
+                                    },
+                                    "Transition": "FrancescaAtPier"
+                                }
+                            },
+                            "Check_unnoticed": {
+                                "Unnoticed_Kill": {
+                                    "Transition": "End_Contract"
+                                },
+                                "$timer": {
+                                    "Condition": {
+                                        "$after": 5
+                                    },
+                                    "Transition": "Failure"
+                                }
+                            },
+                            "End_Contract": {
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                },
+                {
+                    "Id": "b02f3c2c-057e-4dd9-8997-ff5114c6c65d",
+                    "Name": "UI_CHALLENGES_OCTOPUS_PRO1_SUIT_ONLY_NAME",
+                    "ImageName": "images/challenges/sapienza/octopus_47_suit_only.jpg",
+                    "Description": "UI_CHALLENGES_OCTOPUS_PRO1_SUIT_ONLY_DESC",
+                    "Rewards": {
+                        "MasteryXP": 5000
+                    },
+                    "Drops": [],
+                    "IsPlayable": true,
+                    "IsLocked": false,
+                    "HideProgression": false,
+                    "CategoryName": "UI_MENU_PAGE_PROFILE_CHALLENGES_CATEGORY_SIGNATUREKILL",
+                    "Icon": "challenge_category_assassination",
+                    "LocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "ParentLocationId": "LOCATION_PARENT_COASTALTOWN",
+                    "TypeHeader": "UI_MENU_PAGE_CHALLENGE_HEADER_MISSION",
+                    "TypeTitle": "UI_CONTRACT_OCTOPUS_TITLE",
+                    "TypeIcon": "mission",
+                    "XpModifier": {},
+                    "RuntimeType": "Hit",
+                    "Definition": {
+                        "Scope": "session",
+                        "Context": {},
+                        "States": {
+                            "Start": {
+                                "HeroSpawn_Location": [
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "249659f3-8989-4ffc-b727-4902e954605f"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "8fd339e1-ea06-4aee-bd65-0c89b34e4e7e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "1021798e-cec1-4b43-ba33-69b7d53da867"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    },
+                                    {
+                                        "Condition": {
+                                            "$eq": [
+                                                "$Value.RepositoryId",
+                                                "495222ec-e8c9-416a-a41f-4bdfc3e6b80e"
+                                            ]
+                                        },
+                                        "Transition": "Failure"
+                                    }
+                                ],
+                                "Disguise": {
+                                    "Transition": "Failure"
+                                },
+                                "ContractEnd": {
+                                    "Transition": "Success"
+                                }
+                            }
+                        }
+                    },
+                    "Tags": ["story", "assassination", "pro1"],
+                    "InclusionData": {
+                        "ContractIds": ["644d36bd-1f88-44f9-9fed-14a51e5e3f6b"]
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->
- Add h6's professional mode challenges
- Some refactoring to the services that power all this to improve clarity.

### Remaining to-do(?)

- [X] Normal and pro1 mastery getting conflated
- [x] Progress bar at mission end is very incorrect
- [x] Can't use pro mode until signing out and signing back in once unlocking it (probably #509)

## Test Plan

<!-- List how you have verified these changes work as intended. -->
I have in fact tested the code works on 2016. maybe some extra regression testing is needed for newer game versions, but hey, that's what betas are for

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

-   [x] I have run Prettier to reformat any changed files
-   [x] I have verified my changes work
