### PR TITLE
Add Stingray & Opulent debriefings to the campaign menu

### DIFF
--- a/components/menus/campaigns.ts
+++ b/components/menus/campaigns.ts
@@ -205,10 +205,12 @@ export function makeCampaigns(
                 "7a03a97d-238c-48bd-bda0-e5f279569cce",
                 gameVersion,
             ),
+            genSingleVideo("debriefing_raccoon", gameVersion),
             genSingleMission(
                 "095261b5-e15b-4ca1-9bb7-001fb85c5aaa",
                 gameVersion,
             ),
+            genSingleVideo("debriefing_stingray", gameVersion),
         ]
 
         const s3StoryData: StoryData[] | undefined =

--- a/resources/locale.json
+++ b/resources/locale.json
@@ -270,7 +270,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "french": {
         "UI_DRP_001": "UI_DRP_001",
@@ -544,7 +546,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "italian": {
         "UI_DRP_001": "UI_DRP_001",
@@ -817,7 +821,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "german": {
         "UI_DRP_001": "",
@@ -1096,7 +1102,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "spanish": {
         "UI_DRP_001": "UI_DRP_001",
@@ -1370,7 +1378,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "russian": {
         "UI_DRP_001": "UI_DRP_001",
@@ -1643,7 +1653,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Кушать подано!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Перенести встречу и вызвать тревогу в комнате для встреч, в Дубаях.</li><li>Нейтрализовать Карла Инграма и Маркуса Стейвесанта с помощью Сковороды.</li><li>Выполнить задание.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "chineseSimplified": {
         "UI_DRP_001": "UI_DRP_001",
@@ -1916,7 +1928,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "晚餐就绪！",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>在迪拜重新安排会议并封锁会议室。</li><li>用平底锅制伏卡尔·英格拉姆和马库斯·斯图维森特。</li><li>完成任务。</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "仅限头部攻击",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "必须使用爆头或投掷致命近战武器消灭所有目标。"
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "必须使用爆头或投掷致命近战武器消灭所有目标。",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "chineseTraditional": {
         "UI_DRP_001": "UI_DRP_001",
@@ -2189,7 +2203,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "晚餐準備好了！",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>重新安排會議並封鎖杜拜的會議室。</li><li>用煎鍋擊暈卡爾·英格倫和馬克斯·史岱文森。</li><li>完成任務。</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "僅頭部攻擊",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "所有目標都必須透過爆頭或投擲致命的近戰武器的方式來消滅。"
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "所有目標都必須透過爆頭或投擲致命的近戰武器的方式來消滅。",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "japanese": {
         "UI_DRP_001": "UI_DRP_001",
@@ -2462,7 +2478,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "spanishMexican": {
         "UI_DRP_001": "UI_DRP_001",
@@ -2736,7 +2754,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "portugueseBrazil": {
         "UI_DRP_001": "UI_DRP_001",
@@ -2968,7 +2988,9 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     },
     "polish": {
         "UI_DRP_001": "UI_DRP_001",
@@ -3239,6 +3261,8 @@
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_NAME": "Dinner's Ready!",
         "UI_PEACOCK_CHALLENGEPACK_CHEESECAKE_DUBAIPANPACIFY_DESC": "<li>Rearrange the meeting and lockdown the meeting room in Dubai.</li><li>Pacify Carl Ingram and Marcus Stuyvesant with a Frying Pan.</li><li>Complete the mission.</li>",
         "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_NAME": "Head Attack Only",
-        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons."
+        "UI_PEACOCK_GAMECHANGERS_GLOBAL_HEADKILLONLY_DESC": "All targets must be eliminated by using headshots or throwing lethal melee weapons.",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE": "All According to Plan",
+        "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE": "A Trip to Paradise"
     }
 }

--- a/static/Videos.json
+++ b/static/Videos.json
@@ -332,6 +332,42 @@
         },
         "Entitlements": ["H2_LEGACY_STANDARD"]
     },
+    "debriefing_raccoon": {
+        "VideoTitle": "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_09_TITLE",
+        "VideoHeader": "UI_MENU_PAGE_STORY_CUTSCENE_HEADER",
+        "VideoId": "debriefing_raccoon",
+        "IsLocked": false,
+        "VideoType": null,
+        "VideoImage": "images/cinematics/tiles_s2/cinematic09.jpg",
+        "RequiredResources": [
+            "[assembly:/_pro/scenes/missions/Greedy/mission_raccoon/scene_raccoon_basic.entity].entitytemplate",
+            "[assembly:/_pro/scenes/missions/Greedy/mission_raccoon/mission_raccoon.brick].entitytype"
+        ],
+        "LockedReason": "",
+        "Data": {
+            "DlcName": "GAME_STORE_METADATA_S2_DLC16_TITLE",
+            "DlcImage": "images/livetile/dlc/greedy_wide_logo.png"
+        },
+        "Entitlements": ["H2_LEGACY_EXPANSION"]
+    },
+    "debriefing_stingray": {
+        "VideoTitle": "UI_MENU_PAGE_STORY_CUTSCENE_SEASON2_STORY_BLOCK_10_TITLE",
+        "VideoHeader": "UI_MENU_PAGE_STORY_CUTSCENE_HEADER",
+        "VideoId": "debriefing_stingray",
+        "IsLocked": false,
+        "VideoType": null,
+        "VideoImage": "images/cinematics/tiles_s2/cinematic10.jpg",
+        "RequiredResources": [
+            "[assembly:/_pro/scenes/missions/opulent/mission_stingray/scene_stingray_basic.entity].entitytemplate",
+            "[assembly:/_pro/scenes/missions/opulent/mission_stingray/mission_stingray.brick].entitytype"
+        ],
+        "LockedReason": "",
+        "Data": {
+            "DlcName": "GAME_STORE_METADATA_S2_DLC19_TITLE",
+            "DlcImage": "images/livetile/dlc/opulent_wide_logo.png"
+        },
+        "Entitlements": ["H2_LEGACY_EXPANSION"]
+    },
     "intro_gecko": {
         "VideoTitle": "UI_MENU_PAGE_STORY_CUTSCENE_SEASON3_STORY_BLOCK_00_TITLE",
         "VideoHeader": "UI_MENU_PAGE_STORY_CUTSCENE_HEADER",


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

Added the cutscenes to the campaign list so they show up in-game without having to play through the entire mission everytime you need to access it

## Test Plan

<!-- List how you have verified these changes work as intended. -->

I have not verified if these changes work or not. I made this PR using my shitty Samsung phone which probably cannot emulate WoA.

The only thing missing afaik is the tile images:
```
images/cinematics/tiles_s2/cinematic9.jpg
images/cinematics/tiles_s2/cinematic10.jpg
```
They can be made and added to ImagePack although I'm not sure if that will work or not immediately.

[Dribbleondo made images that could be used](https://discord.com/channels/555224628251852811/555224758837444632/1273265607974060116)

[Relevant discord conversation](https://discord.com/channels/555224628251852811/555224758837444632/1273226359879241769)

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

-   [x] I have run Prettier to reformat any changed files
-   [ ] I have verified my changes work

