### PR TITLE
Some scoring fixes

### DIFF
--- a/components/eventHandler.ts
+++ b/components/eventHandler.ts
@@ -368,6 +368,7 @@ export function newSession(
             IsWinner: false,
             timerEnd: null,
         },
+        silentAssassinLost: false,
         challengeContexts: {},
     })
     userIdToTempSession.set(userId, sessionId)
@@ -989,6 +990,12 @@ function saveEvents(
                     session.bodiesFoundBy.add(
                         (<MurderedBodySeenC2SEvent>event).Value.Witness,
                     )
+
+                    if (
+                        !(<MurderedBodySeenC2SEvent>event).Value.IsWitnessTarget
+                    ) {
+                        session.silentAssassinLost = true
+                    }
                 }
 
                 break

--- a/components/eventHandler.ts
+++ b/components/eventHandler.ts
@@ -931,6 +931,7 @@ function saveEvents(
             case "Witnesses":
                 for (const actor of (event as WitnessesC2SEvent).Value) {
                     session.witnesses.add(actor)
+                    session.killsNoticedBy.add(actor)
                 }
 
                 break
@@ -988,12 +989,6 @@ function saveEvents(
                     session.bodiesFoundBy.add(
                         (<MurderedBodySeenC2SEvent>event).Value.Witness,
                     )
-
-                    if (event.Timestamp === session.lastKill.timestamp) {
-                        session.killsNoticedBy.add(
-                            (<MurderedBodySeenC2SEvent>event).Value.Witness,
-                        )
-                    }
                 }
 
                 break

--- a/components/profileHandler.ts
+++ b/components/profileHandler.ts
@@ -528,22 +528,11 @@ profileRouter.post(
                 }),
         )
 
-        if (json.Metadata.AllowNonTargetKills) {
+        if (json.Metadata.NonTargetKillsAllowed) {
             challenges = challenges.filter(
                 (c) =>
                     c.Challenge.Id !== "f929efad-5d5e-4fcb-9c4e-6eb61a01412c",
             )
-
-            challenges.forEach((val) => {
-                // prettier-ignore
-                if (val.Challenge.Id === "b1a85feb-55af-4707-8271-b3522661c0b1") {
-                    // @ts-expect-error State machines impossible to type.
-                    // prettier-ignore
-                    val.Challenge.Definition!["States"]["Start"][
-                        "CrowdNPC_Died"
-                    ]["Transition"] = "Success"
-                }
-            })
         }
 
         const unlockAllShortcuts = getFlag("gameplayUnlockAllShortcuts")

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -217,12 +217,12 @@ export function calculateScore(
     ]
 
     // Non-target kills
+    const allowNonTargetKills =
+        contractData?.Metadata.NonTargetKillsAllowed === true
     const nonTargetKills =
-        contractData?.Metadata.AllowNonTargetKills === true
-            ? 0
-            : contractSession.npcKills.size + contractSession.crowdNpcKills
+        contractSession.npcKills.size + contractSession.crowdNpcKills
 
-    let totalScore = -5000 * nonTargetKills
+    let totalScore = 0
 
     // Headlines and bonuses
     const scoringHeadlines = []
@@ -268,13 +268,24 @@ export function calculateScore(
 
     totalScore = Math.max(0, totalScore)
 
-    scoringHeadlines.push(
-        Object.assign(Object.assign({}, headlineObjTemplate), {
-            headline: "UI_SCORING_SUMMARY_KILL_PENALTY",
-            count: nonTargetKills > 0 ? `${nonTargetKills}x-5000` : "",
-            scoreTotal: -5000 * nonTargetKills,
-        }) as ScoringHeadline,
-    )
+    if (nonTargetKills === 0 || allowNonTargetKills) {
+        scoringHeadlines.push(
+            Object.assign(Object.assign({}, headlineObjTemplate), {
+                headline: "UI_SCORING_SUMMARY_KILL_PENALTY",
+                count: "",
+                scoreTotal: 0,
+            }) as ScoringHeadline,
+        )
+    } else {
+        scoringHeadlines.push(
+            Object.assign(Object.assign({}, headlineObjTemplate), {
+                headline: "UI_SCORING_SUMMARY_KILL_PENALTY",
+                count: `${nonTargetKills}x-5000`,
+                scoreTotal: -5000 * nonTargetKills,
+            }) as ScoringHeadline,
+        )
+        totalScore += -5000 * nonTargetKills
+    }
 
     const timeHours = Math.floor(timeTotal / 3600)
     const timeMinutes = Math.floor((timeTotal - timeHours * 3600) / 60)
@@ -344,9 +355,10 @@ export function calculateScore(
     // Stars
     let stars =
         5 -
-        [...bonuses, { condition: nonTargetKills === 0 }].filter(
-            (x) => !x!.condition,
-        ).length // one star less for each bonus missed
+        [
+            ...bonuses,
+            { condition: nonTargetKills === 0 || allowNonTargetKills },
+        ].filter((x) => !x!.condition).length // one star less for each bonus missed
 
     stars = stars < 0 ? 0 : stars // clamp to 0
 

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -374,10 +374,10 @@ export function calculateScore(
     ]
 
     // NOTE: need to have all bonuses except objectives for SA
-    const silentAssassin = [
-        ...bonuses.slice(1),
-        { condition: nonTargetKills === 0 },
-    ].every((x) => x.condition)
+    const silentAssassin =
+        [...bonuses.slice(1), { condition: nonTargetKills === 0 }].every(
+            (x) => x.condition,
+        ) && !contractSession.silentAssassinLost
 
     return {
         stars: stars,

--- a/components/types/events.ts
+++ b/components/types/events.ts
@@ -153,7 +153,7 @@ export type PacifyC2SEvent = KillC2SEvent
 
 export type MurderedBodySeenC2SEvent = ClientToServerEvent<{
     Witness: string
-    /** `true` iff the witness is a target */
+    /** `true` if the witness is a target */
     IsWitnessTarget: boolean
     DeadBody: {
         RepositoryId: RepositoryId

--- a/components/types/events.ts
+++ b/components/types/events.ts
@@ -153,6 +153,7 @@ export type PacifyC2SEvent = KillC2SEvent
 
 export type MurderedBodySeenC2SEvent = ClientToServerEvent<{
     Witness: string
+    /** `true` iff the witness is a target */
     IsWitnessTarget: boolean
     DeadBody: {
         RepositoryId: RepositoryId

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -310,6 +310,11 @@ export interface ContractSession {
      * @since v7.0.0
      */
     firstKillTimestamp?: number
+    /**
+     * If true, it is not possible anymore to get an SA rating.
+     * @since v8.0.0
+     */
+    silentAssassinLost?: boolean
 }
 
 /**

--- a/components/types/types.ts
+++ b/components/types/types.ts
@@ -947,7 +947,7 @@ export interface MissionManifestMetadata {
     GroupObjectiveDisplayOrder?: GroupObjectiveDisplayOrderItem[] | null
     GameVersion?: string | null
     ServerVersion?: string | null
-    AllowNonTargetKills?: boolean | null
+    NonTargetKillsAllowed?: boolean | null
     Difficulty?: "pro1" | string | null
     CharacterSetup?:
         | {

--- a/static/GlobalChallenges.json
+++ b/static/GlobalChallenges.json
@@ -5416,5 +5416,53 @@
             "GameModes": null
         },
         "OrderIndex": 10000
+    },
+    {
+        "Id": "4cc4da85-7b77-4ee7-a2c8-610c93f6d0a5",
+        "GroupId": "00000000-0000-0000-0000-000000000000",
+        "Name": "UI_CHALLENGES_TRAPPED_ACTIONXP_PROVIDENCE_MEMBER_KILLED",
+        "Type": "Hit",
+        "Description": "",
+        "ImageName": null,
+        "Definition": {
+            "ResetOnCycleCompletion": false,
+            "Context": {
+                "_SessionRewards": []
+            },
+            "Repeatable": {
+                "Base": 1,
+                "Delta": 0
+            },
+            "Scope": "session",
+            "States": {
+                "Start": {
+                    "Kill": {
+                        "Condition": {
+                            "$eq": ["$Value.IsTarget", false]
+                        },
+                        "Actions": {
+                            "$pushunique": [
+                                "_SessionRewards",
+                                "$Value.RepositoryId"
+                            ]
+                        },
+                        "Transition": "Success"
+                    }
+                }
+            }
+        },
+        "Tags": ["actionreward", "very-low", "elimination"],
+        "Drops": [],
+        "LastModified": "2021-01-06T23:00:38.3092409",
+        "Xp": 5,
+        "XpModifier": {},
+        "PlayableSince": null,
+        "PlayableUntil": null,
+        "InclusionData": {
+            "ContractIds": null,
+            "ContractTypes": ["mission", "escalation"],
+            "Locations": ["LOCATION_TRAPPED_WOLVERINE"],
+            "GameModes": null
+        }
     }
 ]

--- a/tests/src/__snapshots__/databaseHandler.test.ts.snap
+++ b/tests/src/__snapshots__/databaseHandler.test.ts.snap
@@ -41,6 +41,7 @@ exports[`contract session storage > can read and write a basic contract session 
   "pacifications": [],
   "recording": "NOT_SPOTTED",
   "sessionStart": 1234,
+  "silentAssassinLost": false,
   "spottedBy": [],
   "targetKills": [],
   "timerEnd": 0,

--- a/tests/src/databaseHandler.test.ts
+++ b/tests/src/databaseHandler.test.ts
@@ -83,6 +83,7 @@ const basicFakeSession: ContractSession = {
         timerEnd: null,
     },
     challengeContexts: {},
+    silentAssassinLost: false,
 }
 
 describe("contract session storage", () => {


### PR DESCRIPTION
It turns out that Peacock's "no noticed kill" bonus logic was wrong. It checked if a `MurderedBodyFound` event happened at the same time as a `Kill` event, which sounds logical, but that's not how IOI does it.

IOI just listens to the `Witnesses` event, which means that whenever you get "compromised", you lose the no noticed kill bonus.
Yes, that means that you can lose the bonus without even killing anybody. Thanks IOI.

Anyways, I've also fixed some edge-cases relating to 5-star no-sa scores, and added the "providence member eliminated" actionreward for carpathian, which was not in peacock yet?
In fact, the `NonTargetKillsAllowed` contract metadata typedef was even wrong? Not sure how that happened.

The "providence member eliminated" challenge is a bit odd to be in the global challenges I think, but I couldn't find a way to add it to the location challenge file without it appearing in the list of challenges in-game. (this is the only location-specific actionreward afaik)