### PR TITLE
Livesplit updates for reset timer penalties

### DIFF
--- a/components/livesplit/liveSplitManager.ts
+++ b/components/livesplit/liveSplitManager.ts
@@ -64,14 +64,15 @@ export class LiveSplitManager {
 
     missionIntentResolved(contractId: string, startId: string): void {
         if (
-            LiveSplitManager._isClub27(contractId) &&
-            LiveSplitManager._isBangkokDefaultStartLocation(startId)
+            (LiveSplitManager._isClub27(contractId) &&
+                LiveSplitManager._isBangkokDefaultStartLocation(startId)) ||
+            LiveSplitManager._isSarajevoSixLevel(contractId)
         ) {
             this._resetMinimum = 10
             return
         }
 
-        this._resetMinimum = 0
+        this._resetMinimum = 1
     }
 
     async startMission(
@@ -393,6 +394,13 @@ export class LiveSplitManager {
         ].includes(startLocationId)
     }
 
+    private static _isSarajevoSixLevel(contractId: string): boolean {
+        return [
+            "*contractId*",
+            // TODO: Add S6 level contract IDs
+        ].includes(contractId)
+    }
+
     private async _setGameTime(totalTime: Seconds): Promise<void> {
         // IMPORTANT to floor to int before sending to livesplit or else parsing will fail silently...
         const flooredTime = Math.floor(totalTime)
@@ -412,13 +420,10 @@ export class LiveSplitManager {
     private _addMissionTime(time: Seconds): Seconds {
         let computedTime = Math.floor(time)
 
-        // always add at least minimum, which is usually 0 except on cutscenes where
+        // always add a minimum reset penalty, which is 1s except on cutscenes where
         // you can gain an advantage by restarting in cs (bangkok, sgail specific starts)
         if (time <= this._resetMinimum) {
             computedTime = this._resetMinimum
-        } else if (time > 0 && time <= 1) {
-            // if in game time is between 0 and 1, add full second
-            computedTime = 1
         }
 
         this._currentMissionTotalTime += computedTime


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

- Update the base resetMinimum penalty from 0 to 1s
- Add support for Sarajevo Six campaign and check for 10s penalty

## Test Plan

<!-- List how you have verified these changes work as intended. -->

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

-   [x] Update the base resetMinimum penalty from 0 to 1s
-   [ ] Add support for Sarajevo Six campaign
-   [ ] Add reset penalty check for Sarajevo Six levels
-   [x] I have run Prettier to reformat any changed files
-   [ ] I have verified my changes work
