### PR TITLE
Add/fix some plugin hooks

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -1122,6 +1122,7 @@ export class Controller {
             process,
             fetch,
             require: createPeacockRequire(pluginName),
+            __filename: pluginPath,
         })
 
         let theExports

--- a/components/controller.ts
+++ b/components/controller.ts
@@ -351,6 +351,7 @@ export class Controller {
         >
         onMissionEnd: SyncHook<[session: ContractSession]>
         onEscalationReset: SyncHook<[groupId: string]>
+        onUserLogin: SyncHook<[gameVersion: GameVersion, userId: string]>
     }
     public configManager: typeof configManagerType = {
         getConfig,
@@ -396,6 +397,7 @@ export class Controller {
             getNextCampaignMission: new SyncBailHook(),
             onMissionEnd: new SyncHook(),
             onEscalationReset: new SyncHook(),
+            onUserLogin: new SyncHook(),
         }
     }
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -370,6 +370,8 @@ app.get(
             servertimeutc: new Date().toISOString(),
             ias: 2,
         })
+
+        controller.hooks.onUserLogin.call(req.gameVersion, req.jwt.unique_name)
     },
 )
 

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -642,6 +642,9 @@ export async function getMissionEndData(
         "requested score for other user's session",
     )
 
+    // call hook
+    controller.hooks.onMissionEnd.call(sessionDetails)
+
     const realData = getUserData(jwt.unique_name, gameVersion)
     // Resolve userdata
     const userData = isDryRun ? structuredClone(realData) : realData


### PR DESCRIPTION
This PR adds some small things useful for plugins that I was missing:
 - Adds an extra hook `onUserLogin` that gets called when a user logs in (requests `/configuration/Init`);
 - Adds back functionality to the `onMissionEnd` hook that already existed but was never called;
 - Passes a plugin's filename to the plugin, which can especially be useful for SMF-added plugins. (Basically just https://nodejs.org/api/modules.html#__filename)
 
Relevant issue: #21 