### PR TITLE
Added support for running node server in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ DEBUG_PROFILE.zip
 packaging/add_itemsize/*
 !packaging/add_itemsize/add_itemsize.js
 /.idea/AIAssistantCustomInstructionsStorage.xml
+
+config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.21.3
+
+RUN apk add --update nodejs npm su-exec shadow
+
+RUN rm -rf /var/cache/apk/*
+
+RUN mkdir /app_build
+WORKDIR /app_build
+RUN npm i -g yarn
+
+COPY . .
+
+RUN yarn install && yarn run build
+
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+mkdir -p /app
+
+cp /app_build/chunk0* /app
+cp -r /app_build/resources /app
+cp -r /app_build/webui /app
+
+cd /app
+
+if [ -z "$PUID" ] || [ -z "$PGID" ]; then
+  exec node chunk0.js
+else
+  adduser -u $PUID -D abc
+  groupmod -g $PGID abc
+
+  chown abc:abc -R /app
+
+  su-exec abc node chunk0.js
+fi


### PR DESCRIPTION
## Scope

This is the initial work to allow a user to run the server in a Docker/Podman container. This can be automated with Github Actions to deploy images to Docker Hub or GHCR automatically on release.

Would be a big help for those of us who run all self-hosted software on a dedicated server.

Once this is approved, it'd be willing to help with adding instructions so that it's easy to run for people. I can also help getting the Github actions setup (for autopublishing and multi-arch build).

## Test Plan

I've run this locally and it seemed to work okay. I just discovered this project yesterday so I'll need to put it through its paces more

## Checklist

- [x] I have run Prettier to reformat any changed files
- [x] I have verified my changes work
