### PR TITLE
fix: New York uniquely requires 4500XP per level instead of 6000

### DIFF
--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -189,6 +189,7 @@ export class MasteryService {
      * @param maxLevel The max level for this progression.
      * @param levelToXpRequired A function to get the XP required for a level.
      * @param subPackageId The subpackage id you want.
+     * @param xpPerLevel The amount of XP required to level up, passed to `levelToXpRequired` function.
      * @returns The completion data, minus any location-specific fields.
      */
     private getGenericCompletionData(
@@ -196,8 +197,9 @@ export class MasteryService {
         gameVersion: GameVersion,
         locationParentId: string,
         maxLevel: number,
-        levelToXpRequired: (level: number) => number,
+        levelToXpRequired: (level: number, xpPerLevel?: number) => number,
         subPackageId?: string,
+        xpPerLevel?: number,
     ): GenericCompletionData {
         // Get the user profile
         const userProfile = getUserData(userId, gameVersion)
@@ -219,9 +221,9 @@ export class MasteryService {
             maxLevel,
         )
 
-        const nextLevelXp: number = levelToXpRequired(nextLevel)
+        const nextLevelXp: number = levelToXpRequired(nextLevel, xpPerLevel)
 
-        const thisLevelXp: number = levelToXpRequired(completionData.Level)
+        const thisLevelXp: number = levelToXpRequired(completionData.Level, xpPerLevel)
 
         return {
             Level: completionData.Level,
@@ -294,6 +296,7 @@ export class MasteryService {
                       ? xpRequiredForEvergreenLevel
                       : xpRequiredForLevel,
                 subPackageId,
+                masteryPkg.XpPerLevel,
             ),
             Id: isSniper ? subPackageId! : masteryPkg.LocationId,
             SubLocationId: isSniper ? "" : subLocationId,

--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -223,7 +223,10 @@ export class MasteryService {
 
         const nextLevelXp: number = levelToXpRequired(nextLevel, xpPerLevel)
 
-        const thisLevelXp: number = levelToXpRequired(completionData.Level, xpPerLevel)
+        const thisLevelXp: number = levelToXpRequired(
+            completionData.Level,
+            xpPerLevel,
+        )
 
         return {
             Level: completionData.Level,

--- a/components/candle/progressionService.ts
+++ b/components/candle/progressionService.ts
@@ -205,7 +205,10 @@ export class ProgressionService {
                         ? xpRequiredForEvergreenLevel(maxLevel)
                         : sniperUnlockable
                           ? xpRequiredForSniperLevel(maxLevel)
-                          : xpRequiredForLevel(maxLevel, masteryData.XpPerLevel),
+                          : xpRequiredForLevel(
+                                maxLevel,
+                                masteryData.XpPerLevel,
+                            ),
                 )
 
                 locationData.Level = clampValue(

--- a/components/candle/progressionService.ts
+++ b/components/candle/progressionService.ts
@@ -205,7 +205,7 @@ export class ProgressionService {
                         ? xpRequiredForEvergreenLevel(maxLevel)
                         : sniperUnlockable
                           ? xpRequiredForSniperLevel(maxLevel)
-                          : xpRequiredForLevel(maxLevel),
+                          : xpRequiredForLevel(maxLevel, masteryData.XpPerLevel),
                 )
 
                 locationData.Level = clampValue(
@@ -213,7 +213,7 @@ export class ProgressionService {
                         ? evergreenLevelForXp(locationData.Xp)
                         : sniperUnlockable
                           ? sniperLevelForXp(locationData.Xp)
-                          : levelForXp(locationData.Xp),
+                          : levelForXp(locationData.Xp, masteryData.XpPerLevel),
                     1,
                     maxLevel,
                 )

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -909,9 +909,15 @@ export async function getMissionEndData(
 
     // Calculate the old playerprofile progression based on the current one and process it
     const oldPlayerProfileXp = playerProgressionData.Total - totalXpGain
-    const oldPlayerProfileLevel = levelForXp(oldPlayerProfileXp, masteryData?.XpPerLevel)
+    const oldPlayerProfileLevel = levelForXp(
+        oldPlayerProfileXp,
+        masteryData?.XpPerLevel,
+    )
     const newPlayerProfileXp = playerProgressionData.Total
-    const newPlayerProfileLevel = levelForXp(newPlayerProfileXp, masteryData?.XpPerLevel)
+    const newPlayerProfileLevel = levelForXp(
+        newPlayerProfileXp,
+        masteryData?.XpPerLevel,
+    )
 
     // NOTE: We assume the ProfileLevel is currently already up-to-date
     const profileLevelInfo = []
@@ -921,7 +927,9 @@ export async function getMissionEndData(
         level <= newPlayerProfileLevel + 1;
         level++
     ) {
-        profileLevelInfo.push(xpRequiredForLevel(level, masteryData?.XpPerLevel))
+        profileLevelInfo.push(
+            xpRequiredForLevel(level, masteryData?.XpPerLevel),
+        )
     }
 
     const profileLevelInfoOffset = oldPlayerProfileLevel - 1

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -869,14 +869,19 @@ export async function getMissionEndData(
         query.masteryUnlockableId,
     )
 
+    const masteryData = controller.masteryService.getMasteryPackage(
+        locationParentId,
+        gameVersion,
+    )
+
     // Calculate the old location progression based on the current one and process it
     const oldLocationXp = completionData.PreviouslySeenXp
         ? completionData.PreviouslySeenXp
         : completionData.XP - totalXpGain
-    let oldLocationLevel = levelForXp(oldLocationXp)
+    let oldLocationLevel = levelForXp(oldLocationXp, masteryData?.XpPerLevel)
 
     const newLocationXp = completionData.XP
-    let newLocationLevel = levelForXp(newLocationXp)
+    let newLocationLevel = levelForXp(newLocationXp, masteryData?.XpPerLevel)
 
     if (!query.masteryUnlockableId) {
         userData.Extensions.progression.Locations[
@@ -885,11 +890,6 @@ export async function getMissionEndData(
     }
 
     if (!isDryRun) writeUserData(jwt.unique_name, gameVersion)
-
-    const masteryData = controller.masteryService.getMasteryPackage(
-        locationParentId,
-        gameVersion,
-    )
 
     let maxLevel = 1
     let locationLevelInfo = [0]
@@ -903,15 +903,15 @@ export async function getMissionEndData(
                 : masteryData.MaxLevel) || DEFAULT_MASTERY_MAXLEVEL
 
         locationLevelInfo = Array.from({ length: maxLevel }, (_, i) => {
-            return xpRequiredForLevel(i + 1)
+            return xpRequiredForLevel(i + 1, masteryData.XpPerLevel)
         })
     }
 
     // Calculate the old playerprofile progression based on the current one and process it
     const oldPlayerProfileXp = playerProgressionData.Total - totalXpGain
-    const oldPlayerProfileLevel = levelForXp(oldPlayerProfileXp)
+    const oldPlayerProfileLevel = levelForXp(oldPlayerProfileXp, masteryData?.XpPerLevel)
     const newPlayerProfileXp = playerProgressionData.Total
-    const newPlayerProfileLevel = levelForXp(newPlayerProfileXp)
+    const newPlayerProfileLevel = levelForXp(newPlayerProfileXp, masteryData?.XpPerLevel)
 
     // NOTE: We assume the ProfileLevel is currently already up-to-date
     const profileLevelInfo = []
@@ -921,7 +921,7 @@ export async function getMissionEndData(
         level <= newPlayerProfileLevel + 1;
         level++
     ) {
-        profileLevelInfo.push(xpRequiredForLevel(level))
+        profileLevelInfo.push(xpRequiredForLevel(level, masteryData?.XpPerLevel))
     }
 
     const profileLevelInfoOffset = oldPlayerProfileLevel - 1

--- a/components/types/mastery.ts
+++ b/components/types/mastery.ts
@@ -48,6 +48,7 @@ export type MasteryPackage = {
     LocationId: string
     GameVersions: GameVersion[]
     MaxLevel?: number
+    XpPerLevel?: number
     HideProgression?: boolean
 } & (MasteryPackageDropExt | MasteryPackageSubPackageExt)
 

--- a/components/utils.ts
+++ b/components/utils.ts
@@ -162,19 +162,19 @@ export function getMaxProfileLevel(gameVersion: GameVersion): number {
 }
 
 /**
- * Calculates the level for the given XP based on XP_PER_LEVEL.
+ * Calculates the level for the given XP based on xpPerLevel (defaults to XP_PER_LEVEL).
  * Minimum level returned is 1.
  */
-export function levelForXp(xp: number): number {
-    return Math.max(1, Math.floor(xp / XP_PER_LEVEL) + 1)
+export function levelForXp(xp: number, xpPerLevel = XP_PER_LEVEL): number {
+    return Math.max(1, Math.floor(xp / xpPerLevel) + 1)
 }
 
 /**
- * Calculates the required XP for the given level based on XP_PER_LEVEL.
+ * Calculates the required XP for the given level based on xpPerLevel (defaults to XP_PER_LEVEL).
  * Minimum XP returned is 0.
  */
-export function xpRequiredForLevel(level: number): number {
-    return Math.max(0, (level - 1) * XP_PER_LEVEL)
+export function xpRequiredForLevel(level: number, xpPerLevel = XP_PER_LEVEL): number {
+    return Math.max(0, (level - 1) * xpPerLevel)
 }
 
 export const EVERGREEN_LEVEL_INFO: number[] = [

--- a/components/utils.ts
+++ b/components/utils.ts
@@ -173,7 +173,10 @@ export function levelForXp(xp: number, xpPerLevel = XP_PER_LEVEL): number {
  * Calculates the required XP for the given level based on xpPerLevel (defaults to XP_PER_LEVEL).
  * Minimum XP returned is 0.
  */
-export function xpRequiredForLevel(level: number, xpPerLevel = XP_PER_LEVEL): number {
+export function xpRequiredForLevel(
+    level: number,
+    xpPerLevel = XP_PER_LEVEL,
+): number {
     return Math.max(0, (level - 1) * xpPerLevel)
 }
 

--- a/contractdata/NEWYORK/_NEWYORK_MASTERY.json
+++ b/contractdata/NEWYORK/_NEWYORK_MASTERY.json
@@ -1,6 +1,7 @@
 {
     "LocationId": "LOCATION_PARENT_GREEDY",
     "GameVersions": ["h3"],
+    "XpPerLevel": 4500,
     "Drops": [
         {
             "Id": "PROP_TOOL_GOLD_BAR_SMALL",


### PR DESCRIPTION
## Scope

As we discovered, official servers require only 4500 XP for New York per level in H3, making it possible to reach level 20 with challenges it has (it's impossible with 6k per level).
Updates xp calculation to accept optional xpPerLevel argument, used exclusively by New York. Mastery data now has `XpPerLevel` nullable field similar to `MaxLevel`.

## Test Plan

Go to New York, get levels. Level up at 4500XP.

## Checklist

- [x] I have verified my changes work
