### PR TITLE
Fix bad URLs caused by 2016

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -122,6 +122,10 @@ process.on("uncaughtException", uncaught)
 
 const app = express()
 
+app.use(function badPathRewritingMiddleware(req, _, next) {
+    req.url = req.url.replaceAll("//", "/")
+    next()
+})
 app.use(loggingMiddleware)
 
 if (getFlag("developmentLogRequests")) {


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

Fixes #580 

When we upgraded express to v5, we also updated the `path-to-regexp` package, which is less permissive then it used to be. As a result, when the game requested the malformed URL `/profiles/page//Hub`, it wasn't matching any route. This PR solves this by adding a middleware to fix any invalid URLs that the game tries to throw at us.

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->

## Test Plan

<!-- List how you have verified these changes work as intended. -->
Log in on 2016 and confirm everything works properly.

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

- [X] I have run Prettier to reformat any changed files
- [X] I have verified my changes work
