### PR TITLE
fix: serve webui relative to the current module

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -122,6 +122,8 @@ process.on("uncaughtException", uncaught)
 
 const app = express()
 
+const baseDir = __dirname
+
 app.use(function badPathRewritingMiddleware(req, _, next) {
     req.url = req.url.replaceAll("//", "/")
     next()
@@ -143,7 +145,7 @@ app.get("/", (_: Request, res) => {
         return
     }
 
-    const data = readFileSync("webui/dist/index.html").toString()
+    const data = readFileSync(`${baseDir}/webui/dist/index.html`).toString()
 
     res.contentType("text/html")
     res.send(data)
@@ -151,7 +153,7 @@ app.get("/", (_: Request, res) => {
 
 app.use(
     "/assets",
-    serveStatic("webui/dist/assets", {
+    serveStatic(`${baseDir}/webui/dist/assets`, {
         setHeaders: (res: Response, path) => {
             if (path.includes(".js")) res.contentType("application/javascript")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->
This allows running peacock from different directory than where peacock lives.
This allows peacock to run on Linux distributions like NixOS where peacock's directory is read-only.

Related: https://github.com/thepeacockproject/Peacock/issues/552

## Test Plan

<!-- List how you have verified these changes work as intended. -->
Ran peacock from the same and a different directory and the webui continues to work as expected.

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

- [x] I have run Prettier to reformat any changed files
- [x] I have verified my changes work
