### PR TITLE
fix: translate windows plugin paths on linux

### DIFF
--- a/components/smfSupport.ts
+++ b/components/smfSupport.ts
@@ -21,7 +21,7 @@ import { existsSync, readFileSync } from "fs"
 import { getFlag } from "./flags"
 import { log, LogLevel } from "./loggingInterop"
 import { MissionManifest, SMFLastDeploy } from "./types/types"
-import { basename, join } from "path"
+import path, { basename, join } from "path"
 import { readFile } from "fs/promises"
 import { menuSystemDatabase } from "./menus/menuSystem"
 import { parse } from "json5"
@@ -92,6 +92,14 @@ export class SMFSupport {
     }
 
     private async executePlugin(plugin: string) {
+        // Check if we are running on linux and got a wine path
+        if (
+            process.platform === "linux" &&
+            plugin.startsWith(`${process.env.WINE_DRIVE_PREFIX ?? "Z"}:\\`)
+        ) {
+            plugin = plugin.substring(2).replace(/\\/g, path.sep)
+        }
+
         if (!existsSync(plugin)) return
 
         await this.controller.executePlugin(


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->
Translates windows wine paths from SMF's lastDeploy.json to linux paths if running natively on linux.
This makes loading peacock plugins from SMF work on Linux.

## Test Plan

<!-- List how you have verified these changes work as intended. -->
Tested the following mods with peacock plugins successfully on Linux:
- [Passenger Train](https://www.nexusmods.com/hitman3/mods/791)
- [Sandbox Hantu Port](https://www.nexusmods.com/hitman3/mods/588)

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

- [x] I have run Prettier to reformat any changed files
- [x] I have verified my changes work
