### PR TITLE
Fix freelancer mastery inventory items unlock

### DIFF
--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -128,7 +128,9 @@ function filterUnlockedContent(
 
         // Handles unlockables that belong to a package or unlocked gear from evergreen
         if (packagedUnlocks.has(unlockable.Id)) {
-            packagedUnlocks.get(unlockable.Id) && acc[0].push(unlockable)
+            if (packagedUnlocks.get(unlockable.Id)) {
+                acc[0].push(unlockable)
+            }
         }
 
         // Handles packages


### PR DESCRIPTION
## Scope

This reverts change in a85f1d2.
It makes freelancer mastery inventory items locked if the necessary mastery level is not reached.
Currently all freelancer mastery inventory items are unlocked even if mastery level is not reached.

## Test Plan

Checked inventory after the change, only the items are there now that i have unlocked in freelancer mastery.

## Checklist

- [X] I have run Prettier to reformat any changed files
- [X] I have verified my changes work
