### PR TITLE
feat(options): add flag to disable challenge-unassociated items

### DIFF
--- a/components/flags.ts
+++ b/components/flags.ts
@@ -55,6 +55,12 @@ export const defaultFlags: Flags = {
                 desc: "When set to false, mastery progression will be disabled and all unlockables will be awarded at the beginning",
                 default: true,
             },
+            enableIsolatedUnlockables: {
+                category: "Gameplay",
+                title: "enableIsolatedUnlockables",
+                desc: "Decides if items are unlocked when there are no associated unlocking approaches. Requires enableMasteryProgression to be enabled.",
+                default: false,
+            },
             elusivesAreShown: {
                 category: "Gameplay",
                 title: "elusivesAreShown",

--- a/components/flags.ts
+++ b/components/flags.ts
@@ -58,7 +58,7 @@ export const defaultFlags: Flags = {
             enableIsolatedUnlockables: {
                 category: "Gameplay",
                 title: "enableIsolatedUnlockables",
-                desc: "Decides if items are unlocked when there are no associated unlocking approaches. Requires enableMasteryProgression to be enabled.",
+                desc: "Decides if items are unlocked when there are no associated unlocking approaches. Requires enableMasteryProgression to be true.",
                 default: false,
             },
             elusivesAreShown: {

--- a/components/inventory.ts
+++ b/components/inventory.ts
@@ -73,6 +73,7 @@ const DELUXE_DATA = [
     ...PENICILLIN_UNLOCKABLES,
     ...TOMORROWLAND_UNLOCKABLES,
     ...LAMBIC_UNLOCKABLES,
+    ...FRENCHMARTINI_UNLOCKABLES,
 ]
 
 /**
@@ -196,9 +197,9 @@ function filterUnlockedContent(
 
             if (isEvergreen || isDeluxe) {
                 acc[0].push(unlockable)
-            } else {
+            } else if (getFlag("enableIsolatedUnlockables")) {
                 /**
-                 *  List of untracked items (to award to user until they are tracked to corresponding challenges)
+                 *  List of untracked items when they are enabled (to award to user until they are tracked to corresponding challenges)
                  */
                 acc[1].push(unlockable)
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

Adds an option flag `enableIsolatedItems`, paired with `enableMasteryProgression` one. When both are set to `true`, the inventory will function as before. When this flag is `false`, the inventory will not handle items with no unlocking approaches, like the official server, which is also the default option. Disabling mastery progression makes this flag of no use. It can be one of default options of Peacock imo.

Meanwhile, takes Banker Pack into Peacock's consideration.

## Test Plan

Can "remove" newest items, and when flag's changed to `false` they come back again.

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

- [x] I have run Prettier to reformat any changed files
- [x] I have verified my changes work
