### PR TITLE
fix: Handle unsafe pointer access which breaks Welcome to Cuba, or any custom location

### DIFF
--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -43,7 +43,6 @@ import type {
     JwtData,
     MissionManifest,
     MissionManifestObjective,
-    ProgressionData,
     Seconds,
     UserProfile,
 } from "./types/types"

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -886,17 +886,12 @@ export async function getMissionEndData(
     const userProgressionLocations = userData.Extensions.progression.Locations
 
     if (!query.masteryUnlockableId) {
-        if (userProgressionLocations[locationParentId]) {
-            userProgressionLocations[locationParentId].PreviouslySeenXp = newLocationXp
-        } else {
-            log(LogLevel.WARN, `Location progression missing for ${locationParentId}, adding default progression.`)
-            const defaultProgression: ProgressionData = {
-                Xp: 0,
-                Level: 1,
-                PreviouslySeenXp: newLocationXp
-            }
-            userProgressionLocations[locationParentId] = defaultProgression
+        userProgressionLocations[locationParentId] ??= {
+            Xp: 0,
+            Level: 1,
+            PreviouslySeenXp: newLocationXp
         }
+        userProgressionLocations[locationParentId].PreviouslySeenXp = newLocationXp
     }
 
     if (!isDryRun) writeUserData(jwt.unique_name, gameVersion)

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -888,7 +888,7 @@ export async function getMissionEndData(
         userProgressionLocations[locationParentId] ??= {
             Xp: 0,
             Level: 1,
-            PreviouslySeenXp: newLocationXp
+            PreviouslySeenXp: newLocationXp,
         }
         userProgressionLocations[locationParentId].PreviouslySeenXp = newLocationXp
     }

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -43,6 +43,7 @@ import type {
     JwtData,
     MissionManifest,
     MissionManifestObjective,
+    ProgressionData,
     Seconds,
     UserProfile,
 } from "./types/types"
@@ -882,11 +883,20 @@ export async function getMissionEndData(
 
     const newLocationXp = completionData.XP
     let newLocationLevel = levelForXp(newLocationXp, masteryData?.XpPerLevel)
+    const userProgressionLocations = userData.Extensions.progression.Locations
 
     if (!query.masteryUnlockableId) {
-        userData.Extensions.progression.Locations[
-            locationParentId
-        ].PreviouslySeenXp = newLocationXp
+        if (userProgressionLocations[locationParentId]) {
+            userProgressionLocations[locationParentId].PreviouslySeenXp = newLocationXp
+        } else {
+            log(LogLevel.WARN, `Location progression missing for ${locationParentId}, adding default progression.`)
+            const defaultProgression: ProgressionData = {
+                Xp: 0,
+                Level: 1,
+                PreviouslySeenXp: newLocationXp
+            }
+            userProgressionLocations[locationParentId] = defaultProgression
+        }
     }
 
     if (!isDryRun) writeUserData(jwt.unique_name, gameVersion)


### PR DESCRIPTION
Existing user progression data not having a newly added location (like Welcome to Cuba) can cause the game to hang up on mission end due to an invalid pointer access trying to set PreviouslySeenXP of null. Added error check to catch this and fill in default progression data in this case, so custom locations like Cuba can be completed without locking up the game.

## Scope

Just added error handling in scoreHandler.ts to catch invalid pointer access and fill in default progression data if it's missing from a custom location

## Test Plan

Tested with both new and existing Peacock userdata, on Cuba and normal missions, everything works as it should now.

## Checklist
- [x ] I have run Prettier to reformat any changed files
- [x ] I have verified my changes work
