### PR TITLE
fix: Remove obsolete scoring exclusion

### DIFF
--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -150,8 +150,6 @@ export function calculateScore(
             bonusId: "AllObjectivesCompletedBonus",
             condition:
                 gameVersion === "h1" ||
-                contractData.Metadata.Id ===
-                    "2d1bada4-aa46-4954-8cf5-684989f1668a" ||
                 isTrueForEveryElement(
                     contractSession.objectives.values(),
                     (obj: MissionManifestObjective) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->

We did this to fix a bug in barbegue escalation level 2, which is no longer in peacock.

Ref: https://github.com/RDIL/PeacockProject/commit/8512befb1b06bfbaa9b956ab4750e453a78bd8e1

## Test Plan

<!-- List how you have verified these changes work as intended. -->
N/A

## Checklist

<!--
Just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
If you have not completed one of the steps below, you can create the pull request as a draft, and then check off the items as you go.
When you have completed the checklist, press the "Ready for review" button.
-->

- [x] I have run Prettier to reformat any changed files
- [x] I have verified my changes work
