### PR TITLE
feat: update escalation level picker to handle multiple changes at once

### DIFF
--- a/static/EscalationCodenames.json
+++ b/static/EscalationCodenames.json
@@ -3,12 +3,14 @@
         {
             "codename": "Snowdrop",
             "name": "The Einarsson Inception",
-            "id": "aee6a16f-6525-4d63-a37f-225e293c6118"
+            "id": "aee6a16f-6525-4d63-a37f-225e293c6118",
+            "levels": 5
         },
         {
             "codename": "Wolfsbane",
             "name": "The Snorrason Ascension",
-            "id": "c469d91d-01fc-4314-b22c-71cb804e92c0"
+            "id": "c469d91d-01fc-4314-b22c-71cb804e92c0",
+            "levels": 5
         }
     ],
     "Paris": [
@@ -16,102 +18,122 @@
             "codename": "Southern Comfort",
             "name": "🦚 The Christmas Calamity",
             "id": "07bbf22b-d6ae-4883-bec2-122eeeb7b665",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Torenia",
             "name": "The Corky Commotion",
-            "id": "4f6ee6ec-b6d7-4958-9838-0352c10294a0"
+            "id": "4f6ee6ec-b6d7-4958-9838-0352c10294a0",
+            "levels": 3
         },
         {
             "codename": "Hawthorn",
             "name": "The Adrian Eclipse",
-            "id": "e6be23e8-8602-42c8-a014-17ffbfa053f5"
+            "id": "e6be23e8-8602-42c8-a014-17ffbfa053f5",
+            "levels": 5
         },
         {
             "codename": "Juniper",
             "name": "The Videl Cataclysm",
-            "id": "e01113e6-f27d-4ea1-a8ba-93062335bbf5"
+            "id": "e01113e6-f27d-4ea1-a8ba-93062335bbf5",
+            "levels": 5
         },
         {
             "codename": "Nightshade",
             "name": "The Seeger Beguilement",
-            "id": "0e5c23b1-4678-458b-ad98-8b55c268e90a"
+            "id": "0e5c23b1-4678-458b-ad98-8b55c268e90a",
+            "levels": 5
         },
         {
             "codename": "Nicotiana",
             "name": "The Adamoli Fascination",
-            "id": "c1db299f-3037-4726-b9fc-5cd951c45812"
+            "id": "c1db299f-3037-4726-b9fc-5cd951c45812",
+            "levels": 5
         },
         {
             "codename": "Goosefoot",
             "name": "The Teague Temptation",
-            "id": "bfb0d544-b4c9-4533-bed4-4562a43a3f40"
+            "id": "bfb0d544-b4c9-4533-bed4-4562a43a3f40",
+            "levels": 5
         },
         {
             "codename": "Larkspur",
             "name": "The Wetzel Determination",
-            "id": "51038604-c3f4-41e9-889b-25d9d5de93c6"
+            "id": "51038604-c3f4-41e9-889b-25d9d5de93c6",
+            "levels": 5
         },
         {
             "codename": "Bamboo",
             "name": "The Kotti Paradigm",
-            "id": "162e9039-cb05-418c-ba8f-792fc6cc5165"
+            "id": "162e9039-cb05-418c-ba8f-792fc6cc5165",
+            "levels": 3
         },
         {
             "codename": "Peony",
             "name": "The Kerner Disquiet",
-            "id": "e75663c8-afca-45a1-af18-25fe3e663848"
+            "id": "e75663c8-afca-45a1-af18-25fe3e663848",
+            "levels": 5
         },
         {
             "codename": "Foxglove",
             "name": "The Hexagon Protocol",
-            "id": "ebf8e5b5-3bf0-487e-8d1b-9473aee61291"
+            "id": "ebf8e5b5-3bf0-487e-8d1b-9473aee61291",
+            "levels": 5
         },
         {
             "codename": "Cyclamen",
             "name": "The Perkins Disarray",
-            "id": "39f03892-a841-4775-91ac-f8c91b485505"
+            "id": "39f03892-a841-4775-91ac-f8c91b485505",
+            "levels": 5
         },
         {
             "codename": "Wisteria",
             "name": "The Granville Curiosity",
-            "id": "54e6c794-2855-4ecf-acc2-d7710d5d96d1"
+            "id": "54e6c794-2855-4ecf-acc2-d7710d5d96d1",
+            "levels": 5
         },
         {
             "codename": "Tulip",
             "name": "The Ezekiel Paradox",
-            "id": "a1e7fdb4-88a4-4dbd-9ef2-d9bd1762cec2"
+            "id": "a1e7fdb4-88a4-4dbd-9ef2-d9bd1762cec2",
+            "levels": 5
         },
         {
             "codename": "Primrose",
             "name": "The Shapiro Omen",
-            "id": "2e365b7c-817d-4213-8fb1-496fa8067e7b"
+            "id": "2e365b7c-817d-4213-8fb1-496fa8067e7b",
+            "levels": 5
         },
         {
             "codename": "Clover",
             "name": "The Marsden Isotopy",
-            "id": "edeca4db-7394-4e93-9b6d-00581f16d6c1"
+            "id": "edeca4db-7394-4e93-9b6d-00581f16d6c1",
+            "levels": 5
         },
         {
             "codename": "Bluebell",
             "name": "The Osterman Mosaic",
-            "id": "5746f21e-efa1-4787-a9ca-99a5f233f507"
+            "id": "5746f21e-efa1-4787-a9ca-99a5f233f507",
+            "levels": 5
         },
         {
             "codename": "Anemone",
             "name": "The Gemini Fiasco",
-            "id": "77c7b56f-2410-4919-a4bc-64435c6cff55"
+            "id": "77c7b56f-2410-4919-a4bc-64435c6cff55",
+            "levels": 5
         },
         {
             "codename": "Blackthorn",
             "name": "The Holmwood Disturbance",
-            "id": "d6961637-effe-4c39-b99a-f2df4402657d"
+            "id": "d6961637-effe-4c39-b99a-f2df4402657d",
+            "levels": 5
         },
         {
             "codename": "Marigold",
             "name": "The Mandelbulb Requiem",
-            "id": "ced3ecb8-70ab-40b0-b033-6f6235c61900"
+            "id": "ced3ecb8-70ab-40b0-b033-6f6235c61900",
+            "levels": 5
         },
         {
             "codename": "Amaryllis",
@@ -125,131 +147,156 @@
             "codename": "Rocco",
             "name": "🦚 The McVeigh Ascension",
             "id": "9e0188e8-bdad-476c-b4ce-2faa5d2be56c",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Blueberry Bush",
             "name": "🦚 The PurpleKey Peril",
             "id": "74415eca-d01e-4070-9bc9-5ef9b4e8f7d2",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Satanta",
             "name": "🦚 The Jeffrey Consolation",
             "id": "0cceeecb-c8fe-42a4-aee4-d7b575f56a1b",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Sunflower",
             "name": "The Hamartia Compulsion",
-            "id": "4b6739eb-bcdb-48ad-8c45-a829794175e1"
+            "id": "4b6739eb-bcdb-48ad-8c45-a829794175e1",
+            "levels": 5
         },
         {
             "codename": "Bergamot",
             "name": "The Zunino Disintegration",
-            "id": "5a8bdb42-b11e-47d1-bc57-b4bf7efa9eda"
+            "id": "5a8bdb42-b11e-47d1-bc57-b4bf7efa9eda",
+            "levels": 5
         },
         {
             "codename": "Jasmine",
             "name": "The Lyndon Gyration",
-            "id": "641656f8-ab16-49c5-a09b-952738154b64"
+            "id": "641656f8-ab16-49c5-a09b-952738154b64",
+            "levels": 5
         },
         {
             "codename": "Hyacinth",
             "name": "The Andersen Animosity",
-            "id": "ee7e831b-f7ea-4803-8eba-80b42d020a7c"
+            "id": "ee7e831b-f7ea-4803-8eba-80b42d020a7c",
+            "levels": 5
         },
         {
             "codename": "Begonia",
             "name": "The Eccleston Illumination",
-            "id": "95bb86f8-fbbf-4eb0-b2fa-bd379c0a4878"
+            "id": "95bb86f8-fbbf-4eb0-b2fa-bd379c0a4878",
+            "levels": 5
         },
         {
             "codename": "Edelweiss",
             "name": "The Selmone Mimesis",
-            "id": "0c4c6ce2-09d5-4fff-a946-099ced0558ea"
+            "id": "0c4c6ce2-09d5-4fff-a946-099ced0558ea",
+            "levels": 5
         },
         {
             "codename": "Chrysantemum",
             "name": "The Gladwyn Simulacrum",
-            "id": "d43600cd-1128-4d59-bf87-075c73ae9776"
+            "id": "d43600cd-1128-4d59-bf87-075c73ae9776",
+            "levels": 5
         },
         {
             "codename": "Daffodil",
             "name": "The Scorpio Directive",
-            "id": "3d9dcf91-1708-4e22-88b3-41d184bcc8c3"
+            "id": "3d9dcf91-1708-4e22-88b3-41d184bcc8c3",
+            "levels": 5
         },
         {
             "codename": "Lavender",
             "name": "The Scarlatti Covenant",
-            "id": "525bd318-04e6-4672-9d01-6bba74362fc5"
+            "id": "525bd318-04e6-4672-9d01-6bba74362fc5",
+            "levels": 5
         },
         {
             "codename": "Artemisia",
             "name": "The Szilassi Darkness",
-            "id": "994540ee-3900-4a41-9544-17b2196a4b1a"
+            "id": "994540ee-3900-4a41-9544-17b2196a4b1a",
+            "levels": 5
         },
         {
             "codename": "Lilac",
             "name": "The Apeiron Sadness",
-            "id": "fab808f9-e88b-4775-aadb-a462c86bf2d9"
+            "id": "fab808f9-e88b-4775-aadb-a462c86bf2d9",
+            "levels": 5
         },
         {
             "codename": "Orchid",
             "name": "The Sigma Illusion",
-            "id": "f08934c0-73f3-460c-a612-231035131c96"
+            "id": "f08934c0-73f3-460c-a612-231035131c96",
+            "levels": 5
         },
         {
             "codename": "Rose",
             "name": "The Spaggiari Subversion",
-            "id": "8dec1e62-bbf9-438c-8495-24559c884466"
+            "id": "8dec1e62-bbf9-438c-8495-24559c884466",
+            "levels": 5
         },
         {
             "codename": "Moon Flower",
             "name": "The Agana Abyss",
-            "id": "74739eda-6ed5-4318-a501-2fa0bd53ef5a"
+            "id": "74739eda-6ed5-4318-a501-2fa0bd53ef5a",
+            "levels": 5
         }
     ],
     "Marrakesh": [
         {
             "codename": "Iris",
             "name": "The Bahadur Dexterity",
-            "id": "19660896-fc1f-49f9-b56b-2059137530e4"
+            "id": "19660896-fc1f-49f9-b56b-2059137530e4",
+            "levels": 5
         },
         {
             "codename": "Lupine",
             "name": "The Raskoph Satisfaction",
-            "id": "11c93649-6b00-46ac-bf2d-a3599a6ab3a9"
+            "id": "11c93649-6b00-46ac-bf2d-a3599a6ab3a9",
+            "levels": 5
         },
         {
             "codename": "Camellia",
             "name": "The Varvara Mystification",
-            "id": "ebf8ab97-6ff3-4063-9737-c6f237031de7"
+            "id": "ebf8ab97-6ff3-4063-9737-c6f237031de7",
+            "levels": 5
         },
         {
             "codename": "Honeysuckle",
             "name": "The Sokoloff Sophistication",
-            "id": "c67a1ead-7489-4d88-bbd2-c68d735e5df0"
+            "id": "c67a1ead-7489-4d88-bbd2-c68d735e5df0",
+            "levels": 5
         },
         {
             "codename": "Clematis",
             "name": "The Reziko Conundrum",
-            "id": "896233eb-e7c5-4915-bf2b-5867799d8bb4"
+            "id": "896233eb-e7c5-4915-bf2b-5867799d8bb4",
+            "levels": 5
         },
         {
             "codename": "Rhododendron",
             "name": "The Kilie Agitation",
-            "id": "45e6d255-f8e4-4170-ad7e-3416ab8a881d"
+            "id": "45e6d255-f8e4-4170-ad7e-3416ab8a881d",
+            "levels": 5
         },
         {
             "codename": "Amaranth",
             "name": "The Lupei Sensitivity",
-            "id": "c949817b-5212-42e8-9b06-9a2eb83de167"
+            "id": "c949817b-5212-42e8-9b06-9a2eb83de167",
+            "levels": 5
         },
         {
             "codename": "Salvia",
             "name": "The Ignatiev Integrity",
-            "id": "e359075e-a510-4b7c-a461-477b789ca7e4"
+            "id": "e359075e-a510-4b7c-a461-477b789ca7e4",
+            "levels": 5
         },
         {
             "codename": "Milfoil",
@@ -260,51 +307,60 @@
         {
             "codename": "Hellebore",
             "name": "The Cheveyo Calibration",
-            "id": "b49de2a1-fe8e-49c4-8331-17aaa9d65d32"
+            "id": "b49de2a1-fe8e-49c4-8331-17aaa9d65d32",
+            "levels": 3
         },
         {
             "codename": "Cereus",
             "name": "The Ataro Caliginosity",
-            "id": "c2e16fb7-d49f-49ef-9d76-46b8b31b3389"
+            "id": "c2e16fb7-d49f-49ef-9d76-46b8b31b3389",
+            "levels": 5
         }
     ],
     "Bangkok": [
         {
             "codename": "Delphinium",
             "name": "The Arthin Occultation",
-            "id": "f425e64f-99df-4ebf-9f7d-909a65a26aef"
+            "id": "f425e64f-99df-4ebf-9f7d-909a65a26aef",
+            "levels": 5
         },
         {
             "codename": "Hibiscus",
             "name": "The Caden Composition",
-            "id": "ccbde3e2-67e7-4534-95ec-e9bd7ef65273"
+            "id": "ccbde3e2-67e7-4534-95ec-e9bd7ef65273",
+            "levels": 5
         },
         {
             "codename": "Geranium",
             "name": "The Somsak Equation",
-            "id": "1f785def-03b7-4340-af7e-2f5831e77eb5"
+            "id": "1f785def-03b7-4340-af7e-2f5831e77eb5",
+            "levels": 5
         },
         {
             "codename": "Blood Lily",
             "name": "The Asya Attunement",
-            "id": "45c831c4-b455-4d21-90f3-6f09b28ee01b"
+            "id": "45c831c4-b455-4d21-90f3-6f09b28ee01b",
+            "levels": 5
         }
     ],
     "Colorado": [
         {
             "codename": "Scullcap",
             "name": "The Otaktay Obliteration",
-            "id": "e6f4d3a4-9a33-4bd9-b761-da297069cf8c"
+            "id": "e6f4d3a4-9a33-4bd9-b761-da297069cf8c",
+            "levels": 5
         },
         {
             "codename": "Daisy",
             "name": "The Farley Crescendo",
-            "id": "c5d88e8c-437b-476b-afe2-d94aa4293502"
+            "id": "c5d88e8c-437b-476b-afe2-d94aa4293502",
+            "levels": 5
         },
         {
             "codename": "Thistle",
             "name": "The Mallory Misfortune",
-            "id": "4186dd23-1cfc-4ba0-9863-9f19f7cba249"
+            "id": "4186dd23-1cfc-4ba0-9863-9f19f7cba249",
+            "levels": 5
         }
     ],
     "Hokkaido": [
@@ -312,27 +368,32 @@
             "codename": "CurryMaker Chaos",
             "name": "🦚 The CurryMaker Chaos",
             "id": "115425b1-e797-47bf-b517-410dc7507397",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Tumbleweed",
             "name": "The Dexter Discordance",
-            "id": "e96fb040-a13f-466c-9d96-c8f3b2b8a09a"
+            "id": "e96fb040-a13f-466c-9d96-c8f3b2b8a09a",
+            "levels": 3
         },
         {
             "codename": "Asagao",
             "name": "The Yuuma Tenacity",
-            "id": "a1e5f4f4-ea9c-4a42-b826-50a212026d50"
+            "id": "a1e5f4f4-ea9c-4a42-b826-50a212026d50",
+            "levels": 5
         },
         {
             "codename": "Sakura",
             "name": "The Susumu Obsession",
-            "id": "85a2b618-2e3c-444f-931c-b89d566e45f7"
+            "id": "85a2b618-2e3c-444f-931c-b89d566e45f7",
+            "levels": 5
         },
         {
             "codename": "Kosumosu",
             "name": "The Meiko Incarnation",
-            "id": "88451dd9-4b57-441e-9eab-e20b9879bafa"
+            "id": "88451dd9-4b57-441e-9eab-e20b9879bafa",
+            "levels": 5
         }
     ],
     "Hawkes Bay": [
@@ -340,12 +401,14 @@
             "codename": "Yulania",
             "name": "🦚 The Selena Snarl",
             "id": "e1e86206-d3f0-a819-e477-3d80e55e8a40",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Opuntia",
             "name": "The Mills Reverie",
-            "id": "3efc73f9-33f0-4af6-9508-7208e6851394"
+            "id": "3efc73f9-33f0-4af6-9508-7208e6851394",
+            "levels": 3
         },
         {
             "codename": "Dodder",
@@ -360,74 +423,88 @@
         {
             "codename": "Crinum",
             "name": "The Riviera Restoration",
-            "id": "719ee044-4b05-4bd9-b2bb-75029f6d2a35"
+            "id": "719ee044-4b05-4bd9-b2bb-75029f6d2a35",
+            "levels": 3
         },
         {
             "codename": "Lamium",
             "name": "The Simmons Concussion",
-            "id": "5284cb9f-9bdd-4b00-99c3-0b5939b01818"
+            "id": "5284cb9f-9bdd-4b00-99c3-0b5939b01818",
+            "levels": 3
         },
         {
             "codename": "Plumbago",
             "name": "The Aquatic Retribution",
-            "id": "d0f44e71-6eab-4af4-9484-78d61dbe376a"
+            "id": "d0f44e71-6eab-4af4-9484-78d61dbe376a",
+            "levels": 3
         },
         {
             "codename": "Cardinal",
             "name": "The Unpalatable Termination",
-            "id": "fca539ff-1b1a-4c04-93e0-03b9b902f86c"
+            "id": "fca539ff-1b1a-4c04-93e0-03b9b902f86c",
+            "levels": 3
         },
         {
             "codename": "Pentas",
             "name": "The Sweeney Scrupulousness",
-            "id": "782a2849-14a2-4cd4-99fc-ddacaeaba2dd"
+            "id": "782a2849-14a2-4cd4-99fc-ddacaeaba2dd",
+            "levels": 3
         },
         {
             "codename": "Bakerian",
             "name": "The Treasonous Mimicry",
-            "id": "be3ea01f-ec56-4fcb-95ec-164a1d9980f3"
+            "id": "be3ea01f-ec56-4fcb-95ec-164a1d9980f3",
+            "levels": 3
         },
         {
             "codename": "Catchfly",
             "name": "The BigMooney Flamboyancy",
-            "id": "066ce378-0418-452a-b02e-a5e4ee711096"
+            "id": "066ce378-0418-452a-b02e-a5e4ee711096",
+            "levels": 3
         }
     ],
     "Santa Fortuna": [
         {
             "codename": "Holly",
             "name": "The Truman Contravention",
-            "id": "390ba7b6-de27-464a-b8af-6d0ff54c2aec"
+            "id": "390ba7b6-de27-464a-b8af-6d0ff54c2aec",
+            "levels": 3
         },
         {
             "codename": "Snapdragon",
             "name": "The Montague Audacity",
-            "id": "70150cd2-ef76-4ba8-80cc-b1e63871b030"
+            "id": "70150cd2-ef76-4ba8-80cc-b1e63871b030",
+            "levels": 3
         },
         {
             "codename": "Titanumarum",
             "name": "The Merle Revelation",
-            "id": "be567ad3-23f4-4d0b-9d2e-b261ea845ef0"
+            "id": "be567ad3-23f4-4d0b-9d2e-b261ea845ef0",
+            "levels": 3
         },
         {
             "codename": "Zinnia",
             "name": "The Calvino Cacophony",
-            "id": "a5e81878-0eae-4bcf-af9b-9a7e7833f85d"
+            "id": "a5e81878-0eae-4bcf-af9b-9a7e7833f85d",
+            "levels": 3
         },
         {
             "codename": "Rafflesia",
             "name": "The Delgado Larceny",
-            "id": "757fd132-0300-45ec-b5bd-bdd48c543b5c"
+            "id": "757fd132-0300-45ec-b5bd-bdd48c543b5c",
+            "levels": 3
         },
         {
             "codename": "Arrayan",
             "name": "The Turms Infatuation",
-            "id": "41ecf8ce-dfd4-4c08-8f44-52dedc3f089a"
+            "id": "41ecf8ce-dfd4-4c08-8f44-52dedc3f089a",
+            "levels": 3
         },
         {
             "codename": "Calluna",
             "name": "The MacMillan Surreptition",
-            "id": "d336d894-024a-4cd4-9867-dee7de70ee79"
+            "id": "d336d894-024a-4cd4-9867-dee7de70ee79",
+            "levels": 3
         },
         {
             "codename": "Poppy",
@@ -443,37 +520,44 @@
             "codename": "Khakiasp Documentation",
             "name": "🦚 The Khakiasp Documentation",
             "id": "667f48a3-7f6b-486e-8f6b-2f782a5c4857",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Gloriosa",
             "name": "The Han Encasement",
-            "id": "9badee3e-0014-46b1-9ef6-edf8858ba038"
+            "id": "9badee3e-0014-46b1-9ef6-edf8858ba038",
+            "levels": 3
         },
         {
             "codename": "Anthogonium",
             "name": "The Raaz Algorithm",
-            "id": "b6a6330a-301a-4e8e-a26f-0f3e0ea809b5"
+            "id": "b6a6330a-301a-4e8e-a26f-0f3e0ea809b5",
+            "levels": 3
         },
         {
             "codename": "Monkshood",
             "name": "The Divine Descendance",
-            "id": "4a62b328-dfe7-4956-ac0f-a3a8990fce26"
+            "id": "4a62b328-dfe7-4956-ac0f-a3a8990fce26",
+            "levels": 3
         },
         {
             "codename": "Protea",
             "name": "The Dubious Cohabitation",
-            "id": "a10472e4-0eb3-451d-814d-38837dd0f407"
+            "id": "a10472e4-0eb3-451d-814d-38837dd0f407",
+            "levels": 3
         },
         {
             "codename": "Ashoka",
             "name": "The Chameleon Anonymity",
-            "id": "ae0bd6cd-7062-4336-8cb0-5fafad3d0f4f"
+            "id": "ae0bd6cd-7062-4336-8cb0-5fafad3d0f4f",
+            "levels": 3
         },
         {
             "codename": "Nutmeg",
             "name": "The Hirani Evacuation",
-            "id": "b47f34cb-6537-421c-8fc8-720a4a118540"
+            "id": "b47f34cb-6537-421c-8fc8-720a4a118540",
+            "levels": 3
         }
     ],
     "Whittleton Creek": [
@@ -481,64 +565,76 @@
             "codename": "Thornbush",
             "name": "🦚 The Dammchicu Disaster",
             "id": "218302a3-f682-46f9-9ffd-bb3e82487b7c",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Baneberry",
             "name": "The McCallister Ransack",
-            "id": "d1b9250b-33f6-4712-831b-f33fa11ee4d8"
+            "id": "d1b9250b-33f6-4712-831b-f33fa11ee4d8",
+            "levels": 3
         },
         {
             "codename": "Milkweed",
             "name": "The Covert Dispersal",
-            "id": "1d5dcf3e-9682-4e32-ac11-ad6586daa456"
+            "id": "1d5dcf3e-9682-4e32-ac11-ad6586daa456",
+            "levels": 3
         },
         {
             "codename": "Myrtle",
             "name": "The Batty Tranquility",
-            "id": "74e6b561-ff1a-4742-9a7b-890b7818c796"
+            "id": "74e6b561-ff1a-4742-9a7b-890b7818c796",
+            "levels": 3
         },
         {
             "codename": "Claytonia",
             "name": "The O'Leary Conflagration",
-            "id": "15b7ad4e-565a-4fdb-b669-c9a68176e665"
+            "id": "15b7ad4e-565a-4fdb-b669-c9a68176e665",
+            "levels": 3
         },
         {
             "codename": "Gorse",
             "name": "The Nolan Disinfection",
-            "id": "fe088a10-5dbf-460f-bbe2-6b55e7a66253"
+            "id": "fe088a10-5dbf-460f-bbe2-6b55e7a66253",
+            "levels": 3
         }
     ],
     "Isle of Sgàil": [
         {
             "codename": "Heather",
             "name": "The Rafael Misadventure",
-            "id": "e63eeb62-29ef-428d-b003-ea043b1f11f9"
+            "id": "e63eeb62-29ef-428d-b003-ea043b1f11f9",
+            "levels": 3
         },
         {
             "codename": "Lotus",
             "name": "The Quimby Quandary",
-            "id": "b66f151d-47a7-4681-a403-c48a46916224"
+            "id": "b66f151d-47a7-4681-a403-c48a46916224",
+            "levels": 3
         },
         {
             "codename": "Galium",
             "name": "The Scarlett Deceit",
-            "id": "dbb0e22d-084b-4b57-8616-42290982fd90"
+            "id": "dbb0e22d-084b-4b57-8616-42290982fd90",
+            "levels": 3
         },
         {
             "codename": "Dahlia",
             "name": "The Babayeva Dissonance",
-            "id": "4fbfae2e-a5e7-4b79-b008-94f6cbcb13cb"
+            "id": "4fbfae2e-a5e7-4b79-b008-94f6cbcb13cb",
+            "levels": 3
         },
         {
             "codename": "Hogweed",
             "name": "The Marinello Motivation",
-            "id": "3721e543-b5e6-4af8-a4fc-c92e9a4453bd"
+            "id": "3721e543-b5e6-4af8-a4fc-c92e9a4453bd",
+            "levels": 3
         },
         {
             "codename": "Pansy",
             "name": "The Aelwin Augment",
-            "id": "8c6daf5e-5974-4438-af20-71ff570c7ff3"
+            "id": "8c6daf5e-5974-4438-af20-71ff570c7ff3",
+            "levels": 3
         },
         {
             "codename": "Venus Flytrap",
@@ -554,12 +650,14 @@
             "codename": "Hedgebush",
             "name": "🦚 The Tedious Thievery",
             "id": "9a461f89-86c5-44e4-998e-f2f66b496aa7",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Dandelion",
             "name": "The Dalton Dissection",
-            "id": "55063d85-e84a-4c76-8bf7-e70fe2cab651"
+            "id": "55063d85-e84a-4c76-8bf7-e70fe2cab651",
+            "levels": 3
         }
     ],
     "Haven Island": [
@@ -567,45 +665,53 @@
             "codename": "Pirates Problem",
             "name": "🦚 The Pirates Problem",
             "id": "f19f7ac8-39ec-498b-aa23-44c8e75d8693",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Longbush",
             "name": "🦚 The sleazeball Situation",
             "id": "35f1f534-ae2d-42be-8472-dd55e96625ea",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Arctic Thyme",
             "name": "The Bartholomew Hornswoggle",
-            "id": "83d4e87e-2f47-4c81-b831-30bd13a29b05"
+            "id": "83d4e87e-2f47-4c81-b831-30bd13a29b05",
+            "levels": 3
         }
     ],
     "Dubai": [
         {
             "codename": "Angelica",
             "name": "The Sebastian Principle",
-            "id": "8885eeda-ad64-44fa-a944-1438b36c670c"
+            "id": "8885eeda-ad64-44fa-a944-1438b36c670c",
+            "levels": 3
         },
         {
             "codename": "Lunaria",
             "name": "The Greed Enumeration",
-            "id": "ae04c7a0-4028-4524-b27f-6a62f020fdca"
+            "id": "ae04c7a0-4028-4524-b27f-6a62f020fdca",
+            "levels": 3
         },
         {
             "codename": "Sheep's Sorrel",
             "name": "The Sinbad Stringent",
-            "id": "9448d91d-f7df-4b5a-8ea3-91f1233f644a"
+            "id": "9448d91d-f7df-4b5a-8ea3-91f1233f644a",
+            "levels": 3
         },
         {
             "codename": "Desert Rose",
             "name": "The Asmodeus Waltz",
-            "id": "89305766-199e-43eb-9fcb-29e6f2b6e9ab"
+            "id": "89305766-199e-43eb-9fcb-29e6f2b6e9ab",
+            "levels": 3
         },
         {
             "codename": "Vine",
             "name": "The Phoenix Ascension",
-            "id": "a9dc4bf9-d277-4115-8dac-6c665cd68168"
+            "id": "a9dc4bf9-d277-4115-8dac-6c665cd68168",
+            "levels": 3
         },
         {
             "codename": "SINS PACK testing",
@@ -617,32 +723,38 @@
             "codename": "Rose Bush",
             "name": "🦚 The dez Dichotomy",
             "id": "78628e05-93ce-4f87-8a17-b910d32df51f",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Hollyhock",
             "name": "The Wrath Termination",
-            "id": "8e95dcd0-704f-4121-8be6-088a3812f838"
+            "id": "8e95dcd0-704f-4121-8be6-088a3812f838",
+            "levels": 3
         },
         {
             "codename": "Harebell",
             "name": "The Sloth Depletion",
-            "id": "a838c4b0-7db5-4ac7-8d52-e8c5b82aa376"
+            "id": "a838c4b0-7db5-4ac7-8d52-e8c5b82aa376",
+            "levels": 3
         },
         {
             "codename": "Snake's Head",
             "name": "The Baskerville Barney",
-            "id": "b12d08ea-c842-498a-82ea-889653588592"
+            "id": "b12d08ea-c842-498a-82ea-889653588592",
+            "levels": 3
         },
         {
             "codename": "Fern",
             "name": "The Percival Passage",
-            "id": "4689ef5e-0ddd-44b3-adca-aebf3293d9e1"
+            "id": "4689ef5e-0ddd-44b3-adca-aebf3293d9e1",
+            "levels": 3
         },
         {
             "codename": "Smooth snake",
             "name": "Dartmoor Garden Show",
-            "id": "5680108a-19dc-4448-9344-3d0290217162"
+            "id": "5680108a-19dc-4448-9344-3d0290217162",
+            "levels": 3
         }
     ],
     "Berlin": [
@@ -650,38 +762,45 @@
             "codename": "Casper",
             "name": "🦚 The Aberratious Stravaig",
             "id": "5bc6a2a3-d80a-4cb3-9ebc-a93d9238950d",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Shangrila",
             "name": "🦚 The mendietinha Madness",
             "id": "ccdc7043-62af-44e8-a5fc-38b008c2044e",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Grass snake",
             "name": "Berlin Egg Hunt",
-            "id": "9d88605f-6871-46a8-bd46-9804ea04fca9"
+            "id": "9d88605f-6871-46a8-bd46-9804ea04fca9",
+            "levels": 3
         },
         {
             "codename": "Smilax",
             "name": "The Halliwell Fable",
-            "id": "12d83cb0-a2d6-4c01-b9d8-675ac635ee61"
+            "id": "12d83cb0-a2d6-4c01-b9d8-675ac635ee61",
+            "levels": 3
         },
         {
             "codename": "Ambrosia",
             "name": "The Lust Assignation",
-            "id": "e3b65e65-636b-4dfd-bb42-65a18c5dce4a"
+            "id": "e3b65e65-636b-4dfd-bb42-65a18c5dce4a",
+            "levels": 1
         },
         {
             "codename": "Cornflower",
             "name": "The Satu Mare Delirium",
-            "id": "079876de-ddd7-47aa-8719-abe97d82fc12"
+            "id": "079876de-ddd7-47aa-8719-abe97d82fc12",
+            "levels": 3
         },
         {
             "codename": "Night Phlox",
             "name": "The Lesley Celebration",
-            "id": "5bb29a6b-7384-4641-944c-3540fa5cd8aa"
+            "id": "5bb29a6b-7384-4641-944c-3540fa5cd8aa",
+            "levels": 3
         }
     ],
     "Chongqing": [
@@ -689,27 +808,32 @@
             "codename": "KOats Conspiracy",
             "name": "🦚 The KOats Conspiracy",
             "id": "07ffa72a-bbac-45ca-8c9f-b9c1b526153a",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Azalea",
             "name": "The Gluttony Gobble",
-            "id": "5121acde-313d-4517-ae70-6a54ca5d775a"
+            "id": "5121acde-313d-4517-ae70-6a54ca5d775a",
+            "levels": 3
         },
         {
             "codename": "Makoyana",
             "name": "The Pride Profusion",
-            "id": "494d97a6-9e31-45e0-9dae-f3793c731336"
+            "id": "494d97a6-9e31-45e0-9dae-f3793c731336",
+            "levels": 3
         },
         {
             "codename": "Magnolia",
             "name": "The Jinzhen Incident",
-            "id": "542108f2-f82f-4a04-bfec-efa92785fec1"
+            "id": "542108f2-f82f-4a04-bfec-efa92785fec1",
+            "levels": 3
         },
         {
             "codename": "Ginseng",
             "name": "The Lee Hong Derivation",
-            "id": "84bf03cc-3055-4fd4-a691-d8b0ac61a51f"
+            "id": "84bf03cc-3055-4fd4-a691-d8b0ac61a51f",
+            "levels": 3
         }
     ],
     "Mendoza": [
@@ -717,35 +841,41 @@
             "codename": "Yannini Yearning",
             "name": "🦚 The Yannini Yearning",
             "id": "1e4423b7-d4ff-448f-a8a8-4bb600cab7e3",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Grape Bush",
             "name": "🦚 The Argentine Acrimony",
             "id": "edbacf4b-e402-4548-b723-cd4351571537",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Frangipani",
             "name": "The Envy Contention",
-            "id": "8c8ed496-948f-4672-879b-4d9575406577"
+            "id": "8c8ed496-948f-4672-879b-4d9575406577",
+            "levels": 3
         },
         {
             "codename": "Jacaranda",
             "name": "The Pasquel Consortium",
-            "id": "14a21819-f81f-453d-8734-a3aab528fa62"
+            "id": "14a21819-f81f-453d-8734-a3aab528fa62",
+            "levels": 3
         },
         {
             "codename": "White Dryas",
             "name": "The Gauchito Antiquity",
-            "id": "72aaaa7b-4386-4ee7-9e9e-73fb8ff8e416"
+            "id": "72aaaa7b-4386-4ee7-9e9e-73fb8ff8e416",
+            "levels": 3
         }
     ],
     "Carpathian Mountains": [
         {
             "codename": "Bellflower",
             "name": "The Proloff Parable",
-            "id": "078a50d1-6427-4fc3-9099-e46390e637a0"
+            "id": "078a50d1-6427-4fc3-9099-e46390e637a0",
+            "levels": 3
         }
     ],
     "Ambrose Island": [
@@ -753,6 +883,7 @@
             "codename": "Pontus",
             "name": "🦚 The Kukri Convention",
             "id": "50fa5e99-0b51-45d4-9062-cd46dd928461",
+            "levels": 3,
             "isPeacock": true
         }
     ],
@@ -761,202 +892,242 @@
             "codename": "Kasturi",
             "name": "🦚 The Personages",
             "id": "797e204a-ef3d-463b-a386-57df0fe29b8f",
+            "levels": 3,
             "isPeacock": true
         },
         {
             "codename": "Tamarillo",
             "name": "The Antithesis",
-            "id": "6678cf8a-f614-4536-9584-e649351f40c2"
+            "id": "6678cf8a-f614-4536-9584-e649351f40c2",
+            "levels": 2
         },
         {
             "codename": "Pitaya",
             "name": "The Dragon",
-            "id": "3fa83d8d-eb75-4973-926a-6052ee5b2aa4"
+            "id": "3fa83d8d-eb75-4973-926a-6052ee5b2aa4",
+            "levels": 2
         },
         {
             "codename": "Blackcurrant",
             "name": "The Monarchique",
-            "id": "80582fdb-c77e-4d6a-b33f-1f14f34b72c4"
+            "id": "80582fdb-c77e-4d6a-b33f-1f14f34b72c4",
+            "levels": 2
         },
         {
             "codename": "Kiwi",
             "name": "The Replication",
-            "id": "e9168f42-882e-4c7e-8353-33d2bd8bb864"
+            "id": "e9168f42-882e-4c7e-8353-33d2bd8bb864",
+            "levels": 2
         },
         {
             "codename": "Coconut",
             "name": "The Base",
-            "id": "f1e3dcdc-2247-4da8-bf8e-856f5fd23888"
+            "id": "f1e3dcdc-2247-4da8-bf8e-856f5fd23888",
+            "levels": 2
         },
         {
             "codename": "CoffeeFruit",
             "name": "The Ostentatious",
-            "id": "b1fb40d7-c013-4c9f-bb8a-8782e980b11a"
+            "id": "b1fb40d7-c013-4c9f-bb8a-8782e980b11a",
+            "levels": 2
         },
         {
             "codename": "AniseStar",
             "name": "The Ouroboros",
-            "id": "de9788cc-b9c4-47fc-b5df-86451cd82c43"
+            "id": "de9788cc-b9c4-47fc-b5df-86451cd82c43",
+            "levels": 3
         },
         {
             "codename": "Honeydew",
             "name": "The Authoritarians",
-            "id": "ff5b4e53-49ea-4d85-b94e-d3c8b3fc7ab3"
+            "id": "ff5b4e53-49ea-4d85-b94e-d3c8b3fc7ab3",
+            "levels": 3
         },
         {
             "codename": "Fig",
             "name": "The Aesthetes",
-            "id": "80cf04de-8e0b-4f38-b094-600753e2ac24"
+            "id": "80cf04de-8e0b-4f38-b094-600753e2ac24",
+            "levels": 3
         },
         {
             "codename": "Jackfruit",
             "name": "The Epicures",
-            "id": "85a67f31-75ce-40f5-a281-7765791f58ca"
+            "id": "85a67f31-75ce-40f5-a281-7765791f58ca",
+            "levels": 3
         },
         {
             "codename": "Lychee",
             "name": "The Baneful",
-            "id": "a79640cb-331a-41af-abaf-58e629fe0a04"
+            "id": "a79640cb-331a-41af-abaf-58e629fe0a04",
+            "levels": 3
         },
         {
             "codename": "Raspberry",
             "name": "The Phantoms",
-            "id": "cab4293f-e359-419d-aa6f-83d91a158cf5"
+            "id": "cab4293f-e359-419d-aa6f-83d91a158cf5",
+            "levels": 3
         },
         {
             "codename": "Strawberry",
             "name": "The Malefactors",
-            "id": "dd68d30f-3900-415f-bb17-84681a2cd4fc"
+            "id": "dd68d30f-3900-415f-bb17-84681a2cd4fc",
+            "levels": 3
         },
         {
             "codename": "Blueberry",
             "name": "The Thespians",
-            "id": "07bc9bbf-7cba-4cdf-92bb-3ab57f09b1cc"
+            "id": "07bc9bbf-7cba-4cdf-92bb-3ab57f09b1cc",
+            "levels": 3
         },
         {
             "codename": "Orange",
             "name": "The Tregetours",
-            "id": "223aa1f3-64a1-43c0-b3c8-36aebd7998e4"
+            "id": "223aa1f3-64a1-43c0-b3c8-36aebd7998e4",
+            "levels": 3
         },
         {
             "codename": "Tangelo",
             "name": "The Bombastic",
-            "id": "9cbdb972-95df-4e0a-be77-7937ec6f2fb0"
+            "id": "9cbdb972-95df-4e0a-be77-7937ec6f2fb0",
+            "levels": 3
         },
         {
             "codename": "Soursop",
             "name": "The Blusterous",
-            "id": "afb4ce18-bf9d-443d-85a8-207df9011792"
+            "id": "afb4ce18-bf9d-443d-85a8-207df9011792",
+            "levels": 3
         },
         {
             "codename": "Salak",
             "name": "The Illusory",
-            "id": "09ea9b32-dc85-4633-9f6a-c5c4bfded5ac"
+            "id": "09ea9b32-dc85-4633-9f6a-c5c4bfded5ac",
+            "levels": 3
         },
         {
             "codename": "Pomelo",
             "name": "The Infiltrators",
-            "id": "479ec396-b96f-4e01-94d9-aedaa0582ed9"
+            "id": "479ec396-b96f-4e01-94d9-aedaa0582ed9",
+            "levels": 3
         },
         {
             "codename": "Plantain",
             "name": "The Diabolicals",
-            "id": "5081776a-86b6-4935-a83e-631a65ba8ee8"
+            "id": "5081776a-86b6-4935-a83e-631a65ba8ee8",
+            "levels": 3
         },
         {
             "codename": "Nectarine",
             "name": "The Dyads",
-            "id": "8db8fa33-cb41-4a0d-a2de-e30d884afb95"
+            "id": "8db8fa33-cb41-4a0d-a2de-e30d884afb95",
+            "levels": 3
         },
         {
             "codename": "Grapefruit",
             "name": "The Connoisseurs",
-            "id": "be787ec9-e7b9-4984-bb39-fda4c71705ec"
+            "id": "be787ec9-e7b9-4984-bb39-fda4c71705ec",
+            "levels": 3
         },
         {
             "codename": "Mandarin",
             "name": "The Detours",
-            "id": "74278853-5990-4058-8972-1f10ad12b6d8"
+            "id": "74278853-5990-4058-8972-1f10ad12b6d8",
+            "levels": 3
         },
         {
             "codename": "Lime",
             "name": "The Cartes Blanches",
-            "id": "6516174c-abe0-4cd7-acdb-7cda4c9b5016"
+            "id": "6516174c-abe0-4cd7-acdb-7cda4c9b5016",
+            "levels": 3
         },
         {
             "codename": "Blackberry",
             "name": "The Faux Pas",
-            "id": "d21e2e91-602c-49d2-9d42-e8bcfb810e9a"
+            "id": "d21e2e91-602c-49d2-9d42-e8bcfb810e9a",
+            "levels": 3
         },
         {
             "codename": "Avocado",
             "name": "The Entrepreneurs",
-            "id": "6de90688-ad4c-457e-ae25-c4bbc8f55196"
+            "id": "6de90688-ad4c-457e-ae25-c4bbc8f55196",
+            "levels": 3
         },
         {
             "codename": "Cherry",
             "name": "The Clichés",
-            "id": "06f99231-9b1e-483f-8a72-f91efcc2fd2b"
+            "id": "06f99231-9b1e-483f-8a72-f91efcc2fd2b",
+            "levels": 3
         },
         {
             "codename": "Cherimoya",
             "name": "The Déjà Vus",
-            "id": "17027c6f-7010-43b8-bb42-1a6846fc0b7b"
+            "id": "17027c6f-7010-43b8-bb42-1a6846fc0b7b",
+            "levels": 3
         },
         {
             "codename": "Carambola",
             "name": "The Liaisons",
-            "id": "09a40d33-4820-454b-89af-a10e0b8d3e08"
+            "id": "09a40d33-4820-454b-89af-a10e0b8d3e08",
+            "levels": 3
         },
         {
             "codename": "Cantaloupe",
             "name": "The Provocateurs",
-            "id": "7886bed7-3805-46c6-a792-4a0d55758934"
+            "id": "7886bed7-3805-46c6-a792-4a0d55758934",
+            "levels": 3
         },
         {
             "codename": "Melon",
             "name": "The Quanta",
-            "id": "2c2afdfe-d396-451a-a6a3-52aca4ea4f1f"
+            "id": "2c2afdfe-d396-451a-a6a3-52aca4ea4f1f",
+            "levels": 3
         },
         {
             "codename": "Peach",
             "name": "The Indices",
-            "id": "39cc0603-4348-4dbf-9bd3-733cadf2913c"
+            "id": "39cc0603-4348-4dbf-9bd3-733cadf2913c",
+            "levels": 3
         },
         {
             "codename": "Pear",
             "name": "The Clutches",
-            "id": "b4d555eb-e2c9-40c2-b155-328a7019fd28"
+            "id": "b4d555eb-e2c9-40c2-b155-328a7019fd28",
+            "levels": 5
         },
         {
             "codename": "Lemon",
             "name": "The Vitae",
-            "id": "e4b29c19-13b4-471b-b188-cd9c0a788cd0"
+            "id": "e4b29c19-13b4-471b-b188-cd9c0a788cd0",
+            "levels": 3
         },
         {
             "codename": "Apricot",
             "name": "The Genera",
-            "id": "90121ee0-0431-4a97-9bc8-8a7e2ca30d65"
+            "id": "90121ee0-0431-4a97-9bc8-8a7e2ca30d65",
+            "levels": 3
         },
         {
             "codename": "Papaya",
             "name": "The Nebulae",
-            "id": "7569d5e4-5270-4b69-96c8-e47b99876390"
+            "id": "7569d5e4-5270-4b69-96c8-e47b99876390",
+            "levels": 5
         },
         {
             "codename": "Banana",
             "name": "The Ellipses",
-            "id": "bfb56fe6-06db-440a-aafe-42eeeb223fa1"
+            "id": "bfb56fe6-06db-440a-aafe-42eeeb223fa1",
+            "levels": 3
         },
         {
             "codename": "Apple",
             "name": "The Codices",
-            "id": "b9f55fc3-c53f-4661-a4b6-9956303422aa"
+            "id": "b9f55fc3-c53f-4661-a4b6-9956303422aa",
+            "levels": 3
         },
         {
             "codename": "Plum",
             "name": "The Deceits",
-            "id": "9e469023-e0c4-42bf-8527-f9fcaf624421"
+            "id": "9e469023-e0c4-42bf-8527-f9fcaf624421",
+            "levels": 5
         }
     ],
     "Unknown": [

--- a/webui/src/App.css
+++ b/webui/src/App.css
@@ -115,6 +115,13 @@ body {
     content: "" !important;
 }
 
+/* Fixed indicator for escalation level picker */
+.save-indicator {
+    position: fixed;
+    right: 2rem;
+    top: 50%;
+}
+
 /* RADIX DIALOG */
 .AlertDialogOverlay {
     position: fixed;

--- a/webui/src/pages/EscalationLevelPage.tsx
+++ b/webui/src/pages/EscalationLevelPage.tsx
@@ -34,6 +34,7 @@ export type CodenameMeta = {
         readonly id?: string
         readonly isPeacock?: boolean
         readonly hidden?: boolean
+        readonly levels?: number
     }[]
 }
 

--- a/webui/src/utils.ts
+++ b/webui/src/utils.ts
@@ -35,6 +35,24 @@ export const fetcher: SWRConfiguration = {
         axios[method](url).then((res) => res.data),
 }
 
+export const debounce = <T extends unknown[]>(
+    callback: (...args: T) => void,
+    delay = 0,
+): ((...args: T) => void) => {
+    let timeoutTimer: number | null = null
+
+    return (...args: T) => {
+        if (timeoutTimer !== null) {
+            window.clearTimeout(timeoutTimer)
+        }
+
+        timeoutTimer = window.setTimeout(() => {
+            callback(...args)
+            timeoutTimer = null
+        }, delay)
+    }
+}
+
 /**
  * Shared type with @peacockproject/core.
  */


### PR DESCRIPTION
## Scope

- The escalation level picker did not always save changes correctly when doing multiple changes. I believe the reason was the way dirty profiles are automatically saved by a background thread, so I changed the escalation changing logic to pass data less frequently.
- Added a debounce method so the escalation picker only calls the server 3 seconds after the last change (3s as that's how frequently the background thread runs)
- Changed the data format so instead of passing escalation id and level, pass all updated escalations and their levels at once
- Added info on how many levels each escalation has so the WebUI can display it and prevent trying to set the level too high
- Added a small info message to inform the user of the changes being saved

## Test Plan

1. Check escalation levels in game
2. Update several escalations in the picker, wait for the changes to be saved
3. Reload escalation list in game, confirm the levels match what was set in the picker

## Checklist

<!--
Once you create the PR, the checklist will be added below this comment automatically (based on what files you've changed).
It's just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
When you have completed the checklist, press the "Ready for review" button.
-->


--------
#### General
- [x] I've run Prettier to format any changed files
- [x] I've verified that my changes work, and included a test plan

--------
#### Testing
- [x] I have added or considered adding unit/integration tests that cover any code changes