### PR TITLE
fix: Loadouts being empty on brand-new profiles

### DIFF
--- a/components/loadouts.ts
+++ b/components/loadouts.ts
@@ -201,13 +201,14 @@ export class Loadouts {
                 userProfile.Extensions.defaultloadout?.[sublocation?.Id] ??
                 defaultLoadout
         } else {
-            let dl = loadouts.getLoadoutFor(gameVersion)
+            let gameVersionedLoadout = loadouts.getLoadoutFor(gameVersion)
 
-            if (!dl) {
-                dl = loadouts.createDefault(gameVersion)
+            if (!gameVersionedLoadout) {
+                gameVersionedLoadout = loadouts.createDefault(gameVersion)
             }
 
-            loadout = dl.data[sublocation?.Id] ?? {}
+            loadout =
+                gameVersionedLoadout.data[sublocation?.Id] ?? defaultLoadout
         }
 
         // SILLY HACK FOR OLD (< 8.6.0) SAVES: For LOCATION_NEWZEALAND, if the saved suit is TOKEN_OUTFIT_WET_SUIT, replace


### PR DESCRIPTION

<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

<!-- List any relevant changes you have made here. Be sure to link any issues fixed, or that are relevant to these changes. -->

In 11b437320e4f0e7a266ecef634aa36df6ce62356 we did some refactoring, but because of how it ended up, this code path never gets hit when using loadout profiles.

Fixes an issue reported on Discord where new profiles would start with empty loadouts.


## Test Plan

<!-- List how you have verified these changes work as intended. -->

After the fix, create a new profile and ensure the items are properly selected:

<img width="2541" height="1362" alt="Screenshot 2025-12-28 134438" src="https://github.com/user-attachments/assets/748336fa-8967-478f-ba25-982d05b70a3b" />

## Checklist

<!--
Once you create the PR, the checklist will be added below this comment automatically (based on what files you've changed).
It's just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
When you have completed the checklist, press the "Ready for review" button.
-->


--------
#### General
- [x] I've run Prettier to format any changed files
- [x] I've verified that my changes work, and included a test plan

--------
#### Testing
- [x] I have added or considered adding unit/integration tests that cover any code changes