### PR TITLE
Fix Discord badge in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # The Peacock Project
 
-[![Discord](https://img.shields.io/discord/826809653181808651?label=Discord&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/peacock)
+[![Discord](https://img.shields.io/discord/826809653181808651?label=Discord&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/F8qQTfnajw)
 
 The Peacock Project is a HITMAN World of Assassination Trilogy server
 replacement.


### PR DESCRIPTION
Fixed broken Discord invite link in the README.

## Scope

I noticed that the vanity Discord invite link in the README.md badge has been broken for some time.  I copied the working Discord invite URL from thepeacockproject.org and corrected the link in the badge.

## Test Plan

I clicked the corrected badge and verified that the link took me to the correct Discord.

## Checklist


--------
#### General
- [x] I've run Prettier to format any changed files
- [x] I've verified that my changes work, and included a test plan