### PR TITLE
feat: add auto-update system

### DIFF
--- a/components/autoUpdate.ts
+++ b/components/autoUpdate.ts
@@ -35,6 +35,7 @@ import * as readline from "readline"
 
 const PEACOCK_REPO = "thepeacockproject/Peacock"
 const STAGING_DIR = ".peacock_update_staging"
+const ASSET_NAME_PATTERN = /^Peacock-v\d+\.\d+\.\d+(-(linux|macos))?\.zip$/
 
 interface GitHubAsset {
     name: string
@@ -199,6 +200,15 @@ export async function performAutoUpdate(): Promise<void> {
             ? release.tag_name.slice(1)
             : release.tag_name
 
+        if (!/^\d+\.\d+\.\d+$/.test(latestVersion)) {
+            log(
+                LogLevel.ERROR,
+                `Invalid version format from API: "${release.tag_name}".`,
+                "auto-update",
+            )
+            return
+        }
+
         const comparison = compare(PEACOCKVERSTRING, latestVersion)
 
         if (comparison === 0) {
@@ -249,6 +259,15 @@ export async function performAutoUpdate(): Promise<void> {
                 log(LogLevel.INFO, `  ${a.name}`, "auto-update")
             }
 
+            return
+        }
+
+        if (!ASSET_NAME_PATTERN.test(assetName)) {
+            log(
+                LogLevel.ERROR,
+                `Asset name "${assetName}" has an unexpected format.`,
+                "auto-update",
+            )
             return
         }
 

--- a/components/autoUpdate.ts
+++ b/components/autoUpdate.ts
@@ -19,7 +19,15 @@
 import { log, LogLevel } from "./loggingInterop"
 import { PEACOCKVERSTRING, compare } from "./utils"
 import { getFlag } from "./flags"
-import { createWriteStream, existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "fs"
+import {
+    createWriteStream,
+    existsSync,
+    mkdirSync,
+    readdirSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "fs"
 import { join } from "path"
 import { execSync } from "child_process"
 import picocolors from "picocolors"
@@ -103,7 +111,7 @@ function writeApplyScripts(sourcePath: string, targetPath: string): void {
             "Get-ChildItem -Path $source | ForEach-Object {",
             "    if ($preserve -notcontains $_.Name) {",
             "        $dest = Join-Path $target $_.Name",
-            '        Copy-Item -Path $_.FullName -Destination $dest -Recurse -Force',
+            "        Copy-Item -Path $_.FullName -Destination $dest -Recurse -Force",
             "    }",
             "}",
             "",
@@ -155,7 +163,9 @@ function writeApplyScripts(sourcePath: string, targetPath: string): void {
         ].join("\n")
 
         writeFileSync(join(targetPath, "apply-update.sh"), sh)
-        execSync(`chmod +x "${join(targetPath, "apply-update.sh")}"`, { stdio: "ignore" })
+        execSync(`chmod +x "${join(targetPath, "apply-update.sh")}"`, {
+            stdio: "ignore",
+        })
     }
 }
 
@@ -179,7 +189,9 @@ export async function performAutoUpdate(): Promise<void> {
         )
 
         if (!res.ok) {
-            throw new Error(`GitHub API responded with ${res.status} ${res.statusText}`)
+            throw new Error(
+                `GitHub API responded with ${res.status} ${res.statusText}`,
+            )
         }
 
         const release = (await res.json()) as GitHubRelease
@@ -190,7 +202,11 @@ export async function performAutoUpdate(): Promise<void> {
         const comparison = compare(PEACOCKVERSTRING, latestVersion)
 
         if (comparison === 0) {
-            log(LogLevel.DEBUG, `Peacock v${PEACOCKVERSTRING} is up to date.`, "auto-update")
+            log(
+                LogLevel.DEBUG,
+                `Peacock v${PEACOCKVERSTRING} is up to date.`,
+                "auto-update",
+            )
             return
         }
 
@@ -212,14 +228,22 @@ export async function performAutoUpdate(): Promise<void> {
         const assetName = getPlatformAssetName(latestVersion)
 
         if (!assetName) {
-            log(LogLevel.ERROR, `Unsupported platform: ${process.platform}.`, "auto-update")
+            log(
+                LogLevel.ERROR,
+                `Unsupported platform: ${process.platform}.`,
+                "auto-update",
+            )
             return
         }
 
         const asset = release.assets.find((a) => a.name === assetName)
 
         if (!asset) {
-            log(LogLevel.ERROR, `Asset "${assetName}" not found for v${latestVersion}.`, "auto-update")
+            log(
+                LogLevel.ERROR,
+                `Asset "${assetName}" not found for v${latestVersion}.`,
+                "auto-update",
+            )
 
             for (const a of release.assets) {
                 log(LogLevel.INFO, `  ${a.name}`, "auto-update")
@@ -285,7 +309,9 @@ export async function performAutoUpdate(): Promise<void> {
             if (done) break
             downloaded += value.length
             const pct = Math.round((downloaded / total) * 100)
-            process.stdout.write(`\rDownloading... ${pct}% (${(downloaded / 1024 / 1024).toFixed(1)} MB)`)
+            process.stdout.write(
+                `\rDownloading... ${pct}% (${(downloaded / 1024 / 1024).toFixed(1)} MB)`,
+            )
             writer.write(value)
         }
 
@@ -316,7 +342,10 @@ export async function performAutoUpdate(): Promise<void> {
         const sourcePath = getExtractedSource(stagingPath)
         writeApplyScripts(sourcePath, process.cwd())
 
-        const scriptName = process.platform === "win32" ? "apply-update.bat" : "apply-update.sh"
+        const scriptName =
+            process.platform === "win32"
+                ? "apply-update.bat"
+                : "apply-update.sh"
         log(
             LogLevel.WARN,
             `Update v${latestVersion} staged! Close this window and run "${scriptName}" to apply.`,

--- a/components/autoUpdate.ts
+++ b/components/autoUpdate.ts
@@ -35,7 +35,8 @@ import * as readline from "readline"
 
 const PEACOCK_REPO = "thepeacockproject/Peacock"
 const STAGING_DIR = ".peacock_update_staging"
-const ASSET_NAME_PATTERN = /^Peacock-v\d+\.\d+\.\d+(-(linux|macos))?\.zip$/
+export const ASSET_NAME_PATTERN =
+    /^Peacock-v\d+\.\d+\.\d+(-(linux|macos))?\.zip$/
 
 interface GitHubAsset {
     name: string
@@ -48,7 +49,7 @@ interface GitHubRelease {
     assets: GitHubAsset[]
 }
 
-function getPlatformAssetName(version: string): string | null {
+export function getPlatformAssetName(version: string): string | null {
     const platform = process.platform
     if (platform === "win32") return `Peacock-v${version}.zip`
     if (platform === "linux") return `Peacock-v${version}-linux.zip`

--- a/components/autoUpdate.ts
+++ b/components/autoUpdate.ts
@@ -1,0 +1,332 @@
+/*
+ *     The Peacock Project - a HITMAN server replacement.
+ *     Copyright (C) 2021-2026 The Peacock Project Team
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { log, LogLevel } from "./loggingInterop"
+import { PEACOCKVERSTRING, compare } from "./utils"
+import { getFlag } from "./flags"
+import { createWriteStream, existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "fs"
+import { join } from "path"
+import { execSync } from "child_process"
+import picocolors from "picocolors"
+import * as readline from "readline"
+
+const PEACOCK_REPO = "thepeacockproject/Peacock"
+const STAGING_DIR = ".peacock_update_staging"
+
+interface GitHubAsset {
+    name: string
+    browser_download_url: string
+    size: number
+}
+
+interface GitHubRelease {
+    tag_name: string
+    assets: GitHubAsset[]
+}
+
+function getPlatformAssetName(version: string): string | null {
+    const platform = process.platform
+    if (platform === "win32") return `Peacock-v${version}.zip`
+    if (platform === "linux") return `Peacock-v${version}-linux.zip`
+    if (platform === "darwin") return `Peacock-v${version}-macos.zip`
+    return null
+}
+
+function formatTimestamp(): string {
+    const now = new Date()
+    const hh = String(now.getHours()).padStart(2, "0")
+    const mm = String(now.getMinutes()).padStart(2, "0")
+    const ss = String(now.getSeconds()).padStart(2, "0")
+    const ms = String(now.getMilliseconds()).padStart(3, "0")
+    return `[${hh}:${mm}:${ss}:${ms}]`
+}
+
+function formatUpdatePrompt(message: string): string {
+    return `${picocolors.gray(formatTimestamp())} [${picocolors.green("Update")}] ${message}`
+}
+
+function getExtractedSource(stagingPath: string): string {
+    const entries = readdirSync(stagingPath).filter((e) =>
+        statSync(join(stagingPath, e)).isDirectory(),
+    )
+
+    if (entries.length === 1 && /^Peacock-v\d/.test(entries[0])) {
+        return join(stagingPath, entries[0])
+    }
+
+    return stagingPath
+}
+
+function writeApplyScripts(sourcePath: string, targetPath: string): void {
+    const isWin = process.platform === "win32"
+    const preserveItems = [
+        "userdata",
+        "plugins",
+        "logs",
+        "contractSessions",
+        "contracts",
+        "images",
+        "options.ini",
+    ]
+
+    if (isWin) {
+        const ps1 = [
+            "$ErrorActionPreference = 'Stop'",
+            "Start-Sleep -Seconds 3",
+            `$source = "${sourcePath.replace(/\\/g, "\\\\")}"`,
+            `$target = "${targetPath.replace(/\\/g, "\\\\")}"`,
+            `$preserve = @(${preserveItems.map((p) => `"${p}"`).join(", ")})`,
+            "",
+            'Write-Host "Applying Peacock update..." -ForegroundColor Cyan',
+            "",
+            "Get-ChildItem -Path $target | ForEach-Object {",
+            "    if ($preserve -notcontains $_.Name) {",
+            "        Remove-Item -Path $_.FullName -Recurse -Force",
+            "    }",
+            "}",
+            "",
+            "Get-ChildItem -Path $source | ForEach-Object {",
+            "    if ($preserve -notcontains $_.Name) {",
+            "        $dest = Join-Path $target $_.Name",
+            '        Copy-Item -Path $_.FullName -Destination $dest -Recurse -Force',
+            "    }",
+            "}",
+            "",
+            `Remove-Item -Path "${sourcePath.replace(/\\/g, "\\\\")}" -Recurse -Force`,
+            'Write-Host "Update applied!" -ForegroundColor Green',
+            "pause",
+        ].join("\n")
+
+        writeFileSync(join(targetPath, "apply-update.ps1"), ps1)
+
+        const bat = [
+            "@echo off",
+            'powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0apply-update.ps1"',
+            "pause",
+        ].join("\r\n")
+
+        writeFileSync(join(targetPath, "apply-update.bat"), bat)
+    } else {
+        const sh = [
+            "#!/bin/bash",
+            `SOURCE="${sourcePath}"`,
+            `TARGET="${targetPath}"`,
+            "",
+            `PRESERVE="${preserveItems.join(" ")}"`,
+            "",
+            'echo "Applying Peacock update..."',
+            "sleep 3",
+            "",
+            'for item in "$TARGET"/*; do',
+            '    name=$(basename "$item")',
+            "    skip=0",
+            "    for p in $PRESERVE; do",
+            '        if [ "$name" = "$p" ]; then skip=1; break; fi',
+            "    done",
+            '    if [ "$skip" = "0" ]; then rm -rf "$item"; fi',
+            "done",
+            "",
+            'for item in "$SOURCE"/*; do',
+            '    name=$(basename "$item")',
+            "    skip=0",
+            "    for p in $PRESERVE; do",
+            '        if [ "$name" = "$p" ]; then skip=1; break; fi',
+            "    done",
+            '    if [ "$skip" = "0" ]; then cp -r "$item" "$TARGET/"; fi',
+            "done",
+            "",
+            'rm -rf "$SOURCE"',
+            'echo "Update applied!"',
+        ].join("\n")
+
+        writeFileSync(join(targetPath, "apply-update.sh"), sh)
+        execSync(`chmod +x "${join(targetPath, "apply-update.sh")}"`, { stdio: "ignore" })
+    }
+}
+
+export async function performAutoUpdate(): Promise<void> {
+    if (getFlag("updateChecking") === false) {
+        log(LogLevel.DEBUG, "Update checking is disabled.", "auto-update")
+        return
+    }
+
+    try {
+        log(LogLevel.INFO, "Checking for updates...", "auto-update")
+
+        const res = await fetch(
+            `https://api.github.com/repos/${PEACOCK_REPO}/releases/latest`,
+            {
+                headers: {
+                    Accept: "application/vnd.github.v3+json",
+                    "User-Agent": `Peacock/${PEACOCKVERSTRING}`,
+                },
+            },
+        )
+
+        if (!res.ok) {
+            throw new Error(`GitHub API responded with ${res.status} ${res.statusText}`)
+        }
+
+        const release = (await res.json()) as GitHubRelease
+        const latestVersion = release.tag_name.startsWith("v")
+            ? release.tag_name.slice(1)
+            : release.tag_name
+
+        const comparison = compare(PEACOCKVERSTRING, latestVersion)
+
+        if (comparison === 0) {
+            log(LogLevel.DEBUG, `Peacock v${PEACOCKVERSTRING} is up to date.`, "auto-update")
+            return
+        }
+
+        if (comparison === 1) {
+            log(
+                LogLevel.INFO,
+                `You're ahead of the latest release! v${latestVersion} is older than v${PEACOCKVERSTRING}.`,
+                "auto-update",
+            )
+            return
+        }
+
+        log(
+            LogLevel.WARN,
+            `New version available: v${latestVersion} (you have v${PEACOCKVERSTRING})`,
+            "auto-update",
+        )
+
+        const assetName = getPlatformAssetName(latestVersion)
+
+        if (!assetName) {
+            log(LogLevel.ERROR, `Unsupported platform: ${process.platform}.`, "auto-update")
+            return
+        }
+
+        const asset = release.assets.find((a) => a.name === assetName)
+
+        if (!asset) {
+            log(LogLevel.ERROR, `Asset "${assetName}" not found for v${latestVersion}.`, "auto-update")
+
+            for (const a of release.assets) {
+                log(LogLevel.INFO, `  ${a.name}`, "auto-update")
+            }
+
+            return
+        }
+
+        if (!process.stdout.isTTY) {
+            log(
+                LogLevel.INFO,
+                `Run "apply-update.bat" after downloading v${latestVersion} from the GitHub releases page.`,
+                "auto-update",
+            )
+            return
+        }
+
+        process.stdout.write("\n")
+        const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+        })
+
+        const answer = await new Promise<string>((resolve) => {
+            rl.question(
+                `${formatUpdatePrompt(`Download and stage Peacock v${latestVersion} update? (y/N): `)} `,
+                (a) => {
+                    rl.close()
+                    resolve(a.trim())
+                },
+            )
+        })
+
+        if (answer.toLowerCase() !== "y" && answer.toLowerCase() !== "yes") {
+            log(LogLevel.INFO, "Update skipped by user.", "auto-update")
+            return
+        }
+
+        const stagingPath = join(process.cwd(), STAGING_DIR)
+        const downloadPath = join(stagingPath, assetName)
+
+        if (existsSync(stagingPath)) {
+            rmSync(stagingPath, { recursive: true, force: true })
+        }
+
+        mkdirSync(stagingPath, { recursive: true })
+
+        log(LogLevel.INFO, `Downloading ${assetName}...`, "auto-update")
+
+        const downloadRes = await fetch(asset.browser_download_url)
+
+        if (!downloadRes.ok || !downloadRes.body) {
+            throw new Error(`Download failed with status ${downloadRes.status}`)
+        }
+
+        const writer = createWriteStream(downloadPath)
+        const reader = downloadRes.body.getReader()
+        let downloaded = 0
+        const total = asset.size
+
+        while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            downloaded += value.length
+            const pct = Math.round((downloaded / total) * 100)
+            process.stdout.write(`\rDownloading... ${pct}% (${(downloaded / 1024 / 1024).toFixed(1)} MB)`)
+            writer.write(value)
+        }
+
+        writer.end()
+        process.stdout.write("\n")
+
+        await new Promise<void>((resolve, reject) => {
+            writer.on("finish", resolve)
+            writer.on("error", reject)
+        })
+
+        log(LogLevel.INFO, "Extracting update...", "auto-update")
+
+        if (process.platform === "win32") {
+            execSync(
+                `powershell -NoProfile -ExecutionPolicy Bypass -Command "& { Expand-Archive -Path '${downloadPath}' -DestinationPath '${stagingPath}' -Force }"`,
+                { stdio: "inherit", timeout: 120000 },
+            )
+        } else {
+            execSync(`unzip -o "${downloadPath}" -d "${stagingPath}"`, {
+                stdio: "inherit",
+                timeout: 120000,
+            })
+        }
+
+        rmSync(downloadPath)
+
+        const sourcePath = getExtractedSource(stagingPath)
+        writeApplyScripts(sourcePath, process.cwd())
+
+        const scriptName = process.platform === "win32" ? "apply-update.bat" : "apply-update.sh"
+        log(
+            LogLevel.WARN,
+            `Update v${latestVersion} staged! Close this window and run "${scriptName}" to apply.`,
+            "auto-update",
+        )
+    } catch (e) {
+        log(
+            LogLevel.ERROR,
+            `Auto-update failed: ${(e as Error).message}`,
+            "auto-update",
+        )
+    }
+}

--- a/components/generatedPeacockRequireTable.ts
+++ b/components/generatedPeacockRequireTable.ts
@@ -16,6 +16,7 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import * as autoUpdate from "./autoUpdate"
 import * as commandService from "./commandService"
 import * as configSwizzleManager from "./configSwizzleManager"
 import * as controller from "./controller"
@@ -39,6 +40,7 @@ import * as playStyles from "./playStyles"
 import * as profileHandler from "./profileHandler"
 import * as scoreHandler from "./scoreHandler"
 import * as smfSupport from "./smfSupport"
+import * as socketActivation from "./socketActivation"
 import * as utils from "./utils"
 import * as webFeatures from "./webFeatures"
 import * as legacyContractHandler from "./2016/legacyContractHandler"
@@ -82,6 +84,7 @@ import * as contractCreation from "./statemachines/contractCreation"
 import * as escalationService from "./contracts/escalations/escalationService"
 
 export default {
+    "@peacockproject/core/autoUpdate": autoUpdate,
     "@peacockproject/core/commandService": commandService,
     "@peacockproject/core/configSwizzleManager": configSwizzleManager,
     "@peacockproject/core/controller": controller,
@@ -105,6 +108,7 @@ export default {
     "@peacockproject/core/profileHandler": profileHandler,
     "@peacockproject/core/scoreHandler": scoreHandler,
     "@peacockproject/core/smfSupport": smfSupport,
+    "@peacockproject/core/socketActivation": socketActivation,
     "@peacockproject/core/utils": utils,
     "@peacockproject/core/webFeatures": webFeatures,
     "@peacockproject/core/2016/legacyContractHandler": legacyContractHandler,

--- a/components/index.ts
+++ b/components/index.ts
@@ -19,7 +19,6 @@
 import express, { NextFunction, Request, Response, Router } from "express"
 import http from "http"
 import {
-    checkForUpdates,
     extractServerVersion,
     extractToken,
     handleAxiosError,
@@ -28,6 +27,7 @@ import {
     PEACOCKVERSTRING,
     ServerVer,
 } from "./utils"
+import { performAutoUpdate } from "./autoUpdate"
 import { getConfig } from "./configSwizzleManager"
 import {
     error400,
@@ -520,7 +520,7 @@ export async function startServer(options: {
     hmr: boolean
     pluginDevHost: boolean
 }): Promise<void> {
-    void checkForUpdates()
+    void performAutoUpdate()
 
     if (!IS_LAUNCHER) {
         console.log(

--- a/tests/src/autoUpdate.test.ts
+++ b/tests/src/autoUpdate.test.ts
@@ -1,0 +1,80 @@
+/*
+ *     The Peacock Project - a HITMAN server replacement.
+ *     Copyright (C) 2021-2026 The Peacock Project Team
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from "vitest"
+import { ASSET_NAME_PATTERN, getPlatformAssetName } from "../../components/autoUpdate"
+
+describe("getPlatformAssetName", () => {
+    const originalPlatform = process.platform
+
+    afterAll(() => {
+        Object.defineProperty(process, "platform", {
+            value: originalPlatform,
+        })
+    })
+
+    function mockPlatform(platform: NodeJS.Platform) {
+        Object.defineProperty(process, "platform", {
+            value: platform,
+            configurable: true,
+        })
+    }
+
+    it("returns the Windows asset name", () => {
+        mockPlatform("win32")
+        expect(getPlatformAssetName("8.8.1")).toBe("Peacock-v8.8.1.zip")
+    })
+
+    it("returns the Linux asset name", () => {
+        mockPlatform("linux")
+        expect(getPlatformAssetName("8.8.1")).toBe("Peacock-v8.8.1-linux.zip")
+    })
+
+    it("returns the macOS asset name", () => {
+        mockPlatform("darwin")
+        expect(getPlatformAssetName("8.8.1")).toBe("Peacock-v8.8.1-macos.zip")
+    })
+
+    it("returns null for unsupported platforms", () => {
+        mockPlatform("aix" as NodeJS.Platform)
+        expect(getPlatformAssetName("8.8.1")).toBeNull()
+    })
+})
+
+describe("ASSET_NAME_PATTERN", () => {
+    it("matches Windows asset names", () => {
+        expect(ASSET_NAME_PATTERN.test("Peacock-v8.8.1.zip")).toBe(true)
+        expect(ASSET_NAME_PATTERN.test("Peacock-v10.0.0.zip")).toBe(true)
+    })
+
+    it("matches Linux asset names", () => {
+        expect(ASSET_NAME_PATTERN.test("Peacock-v8.8.1-linux.zip")).toBe(true)
+    })
+
+    it("matches macOS asset names", () => {
+        expect(ASSET_NAME_PATTERN.test("Peacock-v8.8.1-macos.zip")).toBe(true)
+    })
+
+    it("rejects invalid asset names", () => {
+        expect(ASSET_NAME_PATTERN.test("Peacock-v8.8.1.2.zip")).toBe(false)
+        expect(ASSET_NAME_PATTERN.test("Peacock-v8.8.zip")).toBe(false)
+        expect(ASSET_NAME_PATTERN.test("Peacock-v8.8.1.exe")).toBe(false)
+        expect(ASSET_NAME_PATTERN.test("; rm -rf /")).toBe(false)
+        expect(ASSET_NAME_PATTERN.test("")).toBe(false)
+    })
+})

--- a/tests/src/autoUpdate.test.ts
+++ b/tests/src/autoUpdate.test.ts
@@ -16,8 +16,11 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { describe, expect, it } from "vitest"
-import { ASSET_NAME_PATTERN, getPlatformAssetName } from "../../components/autoUpdate"
+import { afterAll, describe, expect, it } from "vitest"
+import {
+    ASSET_NAME_PATTERN,
+    getPlatformAssetName,
+} from "../../components/autoUpdate"
 
 describe("getPlatformAssetName", () => {
     const originalPlatform = process.platform


### PR DESCRIPTION
Replaces the fire-and-forget checkForUpdates() warning with a full
auto-update flow that checks GitHub releases, prompts the user, and
stages the download for manual application.

- Creates components/autoUpdate.ts with the core logic
- Respects the existing updateChecking flag
- Supports Windows (PowerShell + bat), Linux, and macOS
- Preserves userdata, plugins, logs, and other user files

--------
#### General
- [x] I've run Prettier to format any changed files
- [x] I've verified that my changes work, and included a test plan

--------
#### Testing
- [x] I have added or considered adding unit/integration tests that cover any code changes