### PR TITLE
fix: H2016 pro mode using 6000 XP per level

### DIFF
--- a/components/candle/masteryService.ts
+++ b/components/candle/masteryService.ts
@@ -299,7 +299,7 @@ export class MasteryService {
                       ? xpRequiredForEvergreenLevel
                       : xpRequiredForLevel,
                 subPackageId,
-                masteryPkg.XpPerLevel,
+                subPackage?.XpPerLevel ?? masteryPkg.XpPerLevel,
             ),
             Id: isSniper ? subPackageId! : masteryPkg.LocationId,
             SubLocationId: isSniper ? "" : subLocationId,

--- a/components/candle/progressionService.ts
+++ b/components/candle/progressionService.ts
@@ -185,15 +185,29 @@ export class ProgressionService {
                 parentLocationId,
                 contractSession.gameVersion,
             )
+            const subPackageId =
+                contractSession.gameVersion === "h1"
+                    ? (contract.Metadata.Difficulty ?? "normal")
+                    : (sniperUnlockable ?? undefined)
             const locationData = this.getMasteryProgressionForLocation(
                 userProfile,
                 parentLocationId,
-                contractSession.gameVersion === "h1"
-                    ? (contract.Metadata.Difficulty ?? "normal")
-                    : (sniperUnlockable ?? undefined),
+                subPackageId,
             )
 
-            const maxLevel = masteryData?.MaxLevel || DEFAULT_MASTERY_MAXLEVEL
+            // subpackages (e.g. H2016 professional mode) may override the max
+            // level and the amount of XP required per level.
+            const subPackage = subPackageId
+                ? masteryData?.SubPackages?.find(
+                      (pkg) => pkg.Id === subPackageId,
+                  )
+                : undefined
+
+            const maxLevel =
+                subPackage?.MaxLevel ||
+                masteryData?.MaxLevel ||
+                DEFAULT_MASTERY_MAXLEVEL
+            const xpPerLevel = subPackage?.XpPerLevel ?? masteryData?.XpPerLevel
             const isEvergreenContract = contract.Metadata.Type === "evergreen"
 
             if (masteryData) {
@@ -207,10 +221,7 @@ export class ProgressionService {
                         ? xpRequiredForEvergreenLevel(maxLevel)
                         : sniperUnlockable
                           ? xpRequiredForSniperLevel(maxLevel)
-                          : xpRequiredForLevel(
-                                maxLevel,
-                                masteryData.XpPerLevel,
-                            ),
+                          : xpRequiredForLevel(maxLevel, xpPerLevel),
                 )
 
                 locationData.Level = clampValue(
@@ -218,7 +229,7 @@ export class ProgressionService {
                         ? evergreenLevelForXp(locationData.Xp)
                         : sniperUnlockable
                           ? sniperLevelForXp(locationData.Xp)
-                          : levelForXp(locationData.Xp, masteryData.XpPerLevel),
+                          : levelForXp(locationData.Xp, xpPerLevel),
                     1,
                     maxLevel,
                 )

--- a/components/scoreHandler.ts
+++ b/components/scoreHandler.ts
@@ -859,14 +859,23 @@ export async function getMissionEndData(
         gameVersion,
     )
 
+    // some locations (e.g. H2016 professional mode) use a different amount of
+    // XP per level per subpackage, so prefer the subpackage value when present.
+    const masteryXpPerLevel =
+        (query.masteryUnlockableId
+            ? masteryData?.SubPackages?.find(
+                  (subPkg) => subPkg.Id === query.masteryUnlockableId,
+              )?.XpPerLevel
+            : undefined) ?? masteryData?.XpPerLevel
+
     // Calculate the old location progression based on the current one and process it
     const oldLocationXp = completionData.PreviouslySeenXp
         ? completionData.PreviouslySeenXp
         : completionData.XP - totalXpGain
-    let oldLocationLevel = levelForXp(oldLocationXp, masteryData?.XpPerLevel)
+    let oldLocationLevel = levelForXp(oldLocationXp, masteryXpPerLevel)
 
     const newLocationXp = completionData.XP
-    let newLocationLevel = levelForXp(newLocationXp, masteryData?.XpPerLevel)
+    let newLocationLevel = levelForXp(newLocationXp, masteryXpPerLevel)
     const userProgressionLocations = userData.Extensions.progression.Locations
 
     if (!query.masteryUnlockableId) {
@@ -893,7 +902,7 @@ export async function getMissionEndData(
                 : masteryData.MaxLevel) || DEFAULT_MASTERY_MAXLEVEL
 
         locationLevelInfo = Array.from({ length: maxLevel }, (_, i) => {
-            return xpRequiredForLevel(i + 1, masteryData.XpPerLevel)
+            return xpRequiredForLevel(i + 1, masteryXpPerLevel)
         })
     }
 

--- a/components/types/mastery.ts
+++ b/components/types/mastery.ts
@@ -31,6 +31,7 @@ export type MasteryPackageDrop = {
 export type MasterySubPackage = {
     Id: string
     MaxLevel?: number
+    XpPerLevel?: number
     Drops: MasteryPackageDrop[]
 }
 

--- a/contractdata/BANGKOK/_LEGACY_BANGKOK_MASTERY.json
+++ b/contractdata/BANGKOK/_LEGACY_BANGKOK_MASTERY.json
@@ -98,6 +98,7 @@
         {
             "Id": "pro1",
             "MaxLevel": 10,
+            "XpPerLevel": 10000,
             "Drops": [
                 {
                     "Id": "PRO1_STARTING_LOCATION_BANGKOK_SECURITY_HUT",

--- a/contractdata/COLORADO/_LEGACY_COLORADO_MASTERY.json
+++ b/contractdata/COLORADO/_LEGACY_COLORADO_MASTERY.json
@@ -98,6 +98,7 @@
         {
             "Id": "pro1",
             "MaxLevel": 10,
+            "XpPerLevel": 10000,
             "Drops": [
                 {
                     "Id": "PRO1_AGENCYPICKUP_COLORADO_WATERTOWER",

--- a/contractdata/HOKKAIDO/_LEGACY_HOKKAIDO_MASTERY.json
+++ b/contractdata/HOKKAIDO/_LEGACY_HOKKAIDO_MASTERY.json
@@ -102,6 +102,7 @@
         {
             "Id": "pro1",
             "MaxLevel": 10,
+            "XpPerLevel": 10000,
             "Drops": [
                 {
                     "Id": "PRO1_AGENCYPICKUP_HOKKAIDO_SNOWCRANE_SLEEPINGQUARTERS",

--- a/contractdata/MARRAKESH/_LEGACY_MARRAKESH_MASTERY.json
+++ b/contractdata/MARRAKESH/_LEGACY_MARRAKESH_MASTERY.json
@@ -98,6 +98,7 @@
         {
             "Id": "pro1",
             "MaxLevel": 10,
+            "XpPerLevel": 10000,
             "Drops": [
                 {
                     "Id": "PRO1_AGENCYPICKUP_MARRAKESH_SPIDER_CONSULATE_BASEMENT",

--- a/contractdata/PARIS/_LEGACY_PARIS_MASTERY.json
+++ b/contractdata/PARIS/_LEGACY_PARIS_MASTERY.json
@@ -94,6 +94,7 @@
         {
             "Id": "pro1",
             "MaxLevel": 10,
+            "XpPerLevel": 10000,
             "Drops": [
                 {
                     "Id": "PRO1_STARTING_LOCATION_PARIS_PEACOCK_BASEMENT_KITCHEN",

--- a/contractdata/SAPIENZA/_LEGACY_SAPIENZA_MASTERY.json
+++ b/contractdata/SAPIENZA/_LEGACY_SAPIENZA_MASTERY.json
@@ -98,6 +98,7 @@
         {
             "Id": "pro1",
             "MaxLevel": 10,
+            "XpPerLevel": 10000,
             "Drops": [
                 {
                     "Id": "PRO1_STARTING_LOCATION_SAPIENZA_APARTMENT",


### PR DESCRIPTION
## Scope

Fixes #686. Subpackages can now override the mastery packages' XP per level.

## Test Plan

- Confirm it in game

## Checklist


--------
#### General
- [x] I've run Prettier to format any changed files
- [x] I've verified that my changes work, and included a test plan

--------
#### Escalations
- [x] Any new escalations added follow the [escalation guidelines](https://github.com/thepeacockproject/Peacock/blob/master/docs/ESCALATION_GUIDELINES.md)

--------
#### Testing
- [x] I have added or considered adding unit/integration tests that cover any code changes