### PR TITLE
Deprecate modIsInstalled in favour of new SMFv3-style shims

### DIFF
--- a/components/controller.ts
+++ b/components/controller.ts
@@ -476,14 +476,15 @@ export class Controller {
      *
      * @param modId The mod's ID.
      * @returns If the mod is unavailable. You should probably abort initialization if true is returned. Also returns true if the `overrideFrameworkChecks` flag is set.
-     * @deprecated since v5.5.0, use `!controller.smf.modIsInstalled`
+     * @deprecated since v5.5.0, use `!controller.smf.modEnabledForUser` or `!controller.smf.modEnabledForGame`
      */
     public addClientSideModDependency(modId: string): boolean {
-        log(
-            LogLevel.WARN,
-            "controller.addClientSideModDependency is deprecated, use !controller.smf.modIsInstalled instead!",
-            "plugins",
+        deprecated(
+            "controller.addClientSideModDependency",
+            "controller.smf.modEnabledForUser or controller.smf.modEnabledForGame",
+            "v9",
         )
+
         return (
             getFlag("overrideFrameworkChecks") === true ||
             !this.smf.modIsInstalled(modId)
@@ -497,14 +498,15 @@ export class Controller {
      *
      * @param modId The mod's ID.
      * @returns If the mod is available (or the `overrideFrameworkChecks` flag is set). You should probably abort initialisation if false is returned.
-     * @deprecated since v7.0.0, use `controller.smf.modIsInstalled`
+     * @deprecated since v7.0.0, use `controller.smf.modEnabledForUser` or `controller.smf.modEnabledForGame`
      */
     public modIsInstalled(modId: string): boolean {
-        log(
-            LogLevel.WARN,
-            "controller.modIsInstalled is deprecated, use controller.smf.modIsInstalled instead!",
-            "plugins",
+        deprecated(
+            "controller.modIsInstalled",
+            "controller.smf.modEnabledForUser or controller.smf.modEnabledForGame",
+            "v9",
         )
+
         return this.smf.modIsInstalled(modId)
     }
 

--- a/components/smfSupport.ts
+++ b/components/smfSupport.ts
@@ -30,6 +30,7 @@ import path, { basename, join } from "path"
 import { readFile } from "fs/promises"
 import { menuSystemDatabase } from "./menus/menuSystem"
 import { parse } from "json5"
+import { deprecated } from "./utils"
 
 type LastServerSideData = SMFLastDeploy["lastServerSideStates"]
 
@@ -224,6 +225,12 @@ export class SMFSupport {
      * @deprecated since v8.9.0, use `controller.smf.modEnabledForUser` or `controller.smf.modEnabledForGame`
      */
     public modIsInstalled(modId: string): boolean {
+        deprecated(
+            "controller.smf.modIsInstalled",
+            "controller.smf.modEnabledForUser or controller.smf.modEnabledForGame",
+            "v9",
+        )
+
         return (
             this.lastDeploy?.loadOrder.includes(modId) ||
             getFlag("overrideFrameworkChecks") === true

--- a/components/smfSupport.ts
+++ b/components/smfSupport.ts
@@ -20,7 +20,12 @@ import { Controller } from "./controller"
 import { existsSync, readFileSync } from "fs"
 import { getFlag } from "./flags"
 import { log, LogLevel } from "./loggingInterop"
-import { MissionManifest, SMFLastDeploy } from "./types/types"
+import {
+    GameVersion,
+    JwtData,
+    MissionManifest,
+    SMFLastDeploy,
+} from "./types/types"
 import path, { basename, join } from "path"
 import { readFile } from "fs/promises"
 import { menuSystemDatabase } from "./menus/menuSystem"
@@ -216,8 +221,51 @@ export class SMFSupport {
      *
      * @param modId The mod's ID.
      * @returns If the mod is available (or the `overrideFrameworkChecks` flag is set). You should probably abort initialisation if false is returned.
+     * @deprecated since v8.9.0, use `controller.smf.modEnabledForUser` or `controller.smf.modEnabledForGame`
      */
     public modIsInstalled(modId: string): boolean {
+        return (
+            this.lastDeploy?.loadOrder.includes(modId) ||
+            getFlag("overrideFrameworkChecks") === true
+        )
+    }
+
+    /**
+     * Returns whether a mod is enabled for the given user, by checking the deployments from Simple Mod Framework.
+     * Note that if the user has not yet logged in, this function will return null.
+     *
+     * @param userId The user ID to check against.
+     * @param modRef The mod ID and SemVer version range, in the form `id@version`.
+     * @returns If the mod is enabled (or the `overrideFrameworkChecks` flag is set).
+     */
+    public modEnabledForUser(userId: string, modRef: string): boolean | null {
+        const modId = modRef.split("@")[0]
+
+        // Until SMFv3, we don't have the necessary information to
+        // actually check more than whether the mod is installed.
+        return (
+            this.lastDeploy?.loadOrder.includes(modId) ||
+            getFlag("overrideFrameworkChecks") === true
+        )
+    }
+
+    /**
+     * Returns whether a mod is enabled for the given game version and platform, by checking the deployments from Simple Mod Framework.
+     *
+     * @param gameVersion The game version to check against.
+     * @param platform The platform to check against.
+     * @param modRef The mod ID and SemVer version range, in the form `id@version`.
+     * @returns If the mod is enabled (or the `overrideFrameworkChecks` flag is set).
+     */
+    public modEnabledForGame(
+        gameVersion: GameVersion,
+        platform: JwtData["platform"],
+        modRef: string,
+    ): boolean {
+        const modId = modRef.split("@")[0]
+
+        // Until SMFv3, we don't have the necessary information to
+        // actually check more than whether the mod is installed.
         return (
             this.lastDeploy?.loadOrder.includes(modId) ||
             getFlag("overrideFrameworkChecks") === true


### PR DESCRIPTION
Introduces `modEnabledForUser` and `modEnabledForGame` from #710 and deprecates the existing `modIsInstalled` in favour of the new functions. SMFv2 does not actually provide the necessary data to check the mod version, or information for a specific game, so these functions currently have the exact same behaviour as `modIsInstalled`. Nonetheless, they have the same signature as the ones in #710, so will help get developers in the habit of specifying the correct information.

--------
#### General
- [x] I've run Prettier to format any changed files
- [x] I've verified that my changes work, and included a test plan

--------
#### Testing
- [x] I have added or considered adding unit/integration tests that cover any code changes