### PR TITLE
Fix crash that can happen while loading into missions from the menu

### DIFF
--- a/static/peacock-menu/index.json
+++ b/static/peacock-menu/index.json
@@ -2,11 +2,11 @@
     "$datacontext": {
         "in": "$.",
         "datavalues": {
-            "@global.CacheBuster": "0"
+            "CacheBuster": "$.@global.CacheBuster"
         },
         "do": {
             "$include": {
-                "$path": "$formatstring menusystem/pages/peacock-menu/options.json@{$.@global.CacheBuster}"
+                "$path": "$formatstring menusystem/pages/peacock-menu/options.json@{$.CacheBuster}"
             }
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Peacock! Here's a bit of a template to help make sure everything relevant is covered. -->

## Scope

This change will fix crash that can happen while loading into missions from the menu. Relevant issue:
https://github.com/thepeacockproject/Peacock/issues/596


## Test Plan
After countless hours of trial and error, i narrowed the source of the crash to the lines 4-6 in static/peacock-menu/index.json:
        "datavalues": {
            "@global.CacheBuster": "0"
        },
Removing this, the game no longer seems to crash during loading. Verified by loading into missions over and over (100+ at least). Without this fix, the game crashes something like 1 out of 15 times or so when loading a mission. Maybe i just got unbeliavably lucky though, so i would appreciate others trying this fix.
I also verified that the peacock menu in settings still work, so not sure what this CacheBuster is used for, other than making the game crash.
## Checklist

<!--
Once you create the PR, the checklist will be added below this comment automatically (based on what files you've changed).
It's just a few reminders to make sure everything is perfect. You can place an "X" in the boxes to tick them off.
When you have completed the checklist, press the "Ready for review" button.
-->
